### PR TITLE
Add schema-based mock data generation and CSV outputs

### DIFF
--- a/database/mock-data-generation/generate_data.py
+++ b/database/mock-data-generation/generate_data.py
@@ -1,0 +1,432 @@
+import os
+import json
+import pandas as pd
+import random
+from faker import Faker
+
+fake = Faker()
+
+# -------------------------
+# ROW CONFIGURATION
+# -------------------------
+TABLE_ROW_COUNTS = {
+    "users": 100,
+    "request": 100
+}
+
+
+# -------------------------
+# LOAD SCHEMA
+# -------------------------
+def load_schema():
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    schema_path = os.path.join(base_dir, "db_info.json")
+
+    with open(schema_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+# -------------------------
+# OUTPUT FOLDER
+# -------------------------
+def setup_output_folder():
+    """
+    Save generated CSV files in mock_db folder in the project root
+    """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    output_dir = os.path.join(base_dir, "mock_db")
+
+    os.makedirs(output_dir, exist_ok=True)
+    return output_dir
+
+# -------------------------
+# LOAD LOOKUP TABLES
+# -------------------------
+def load_lookup_table(table_name):
+    """
+    Load CSV from lookup_tables folder in the project root
+    """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    lookup_dir = os.path.join(base_dir, "lookup_tables")
+
+    possible_files = [
+        os.path.join(lookup_dir, f"{table_name}.csv"),
+        os.path.join(lookup_dir, f"{table_name}.CSV")
+    ]
+
+    print(f"Looking for {table_name} in: {lookup_dir}")
+
+    for file_path in possible_files:
+        if os.path.exists(file_path):
+            print(f"✅ Loaded lookup table: {table_name}")
+            return pd.read_csv(file_path)
+
+    raise FileNotFoundError(f"Lookup table file not found for {table_name} in {lookup_dir}")
+
+# -------------------------
+# GENERIC VALUE GENERATOR
+# -------------------------
+def generate_value_from_type(col_name, col_type, i):
+    col = col_name.lower()
+    dtype = col_type.lower()
+
+    if col == "user_id":
+        return f"USR{i:05d}"
+
+    if col == "req_id":
+        return f"REQ{i:06d}"
+
+    if col.endswith("_id"):
+        return i
+
+    if col == "full_name":
+        return fake.name()
+
+    if col == "first_name":
+        return fake.first_name()
+
+    if col == "middle_name":
+        return fake.first_name()
+
+    if col == "last_name":
+        return fake.last_name()
+
+    if "email" in col:
+        return fake.email()
+
+    if "phone" in col:
+        return fake.phone_number()
+
+    if col == "gender":
+        return random.choice(["Male", "Female", "Other"])
+
+    if "city" in col:
+        return fake.city()
+
+    if "state" in col:
+        return fake.state()
+
+    if "country" in col:
+        return fake.country()
+
+    if "addr" in col:
+        return fake.street_address()
+
+    if "zip" in col:
+        return fake.postcode()
+
+    if "date" in col or "time" in col:
+        return fake.date_time_this_decade().strftime("%Y-%m-%d %H:%M:%S")
+
+    if "boolean" in dtype:
+        return random.choice([True, False])
+
+    if "int" in dtype:
+        return random.randint(1, 100)
+
+    if "numeric" in dtype:
+        return round(random.uniform(1, 100), 2)
+
+    if "json" in dtype:
+        return "{}"
+
+    if "text" in dtype:
+        return fake.sentence()
+
+    return fake.word()
+
+
+# -------------------------
+# GENERATE NORMAL TABLE
+# -------------------------
+def generate_table(table_name, tables):
+    columns = tables[table_name]["columns"]
+    rows = TABLE_ROW_COUNTS.get(table_name, 100)
+
+    data = []
+
+    for i in range(1, rows + 1):
+        row = {}
+
+        for col in columns:
+            col_name = col["name"]
+            col_type = col["type"]
+
+            row[col_name] = generate_value_from_type(col_name, col_type, i)
+
+        data.append(row)
+
+    return pd.DataFrame(data)
+
+
+# -------------------------
+# HELPER
+# -------------------------
+def get_column_values(df, column_name):
+    if column_name in df.columns:
+        return df[column_name].dropna().tolist()
+    return []
+
+
+# -------------------------
+# GENERATE USERS
+# -------------------------
+def generate_users_table(
+    tables,
+    country_df,
+    state_df,
+    user_status_df,
+    user_category_df
+):
+    columns = tables["users"]["columns"]
+    rows = TABLE_ROW_COUNTS.get("users", 100)
+
+    country_ids = get_column_values(country_df, "country_id")
+    state_ids = get_column_values(state_df, "state_id")
+    status_ids = get_column_values(user_status_df, "user_status_id")
+    category_ids = get_column_values(user_category_df, "user_category_id")
+
+    data = []
+
+    for i in range(1, rows + 1):
+        row = {}
+
+        first_name = fake.first_name()
+        middle_name = fake.first_name()
+        last_name = fake.last_name()
+
+        for col in columns:
+            col_name = col["name"]
+            col_type = col["type"]
+
+            if col_name == "user_id":
+                row[col_name] = f"USR{i:05d}"
+
+            elif col_name == "country_id":
+                row[col_name] = random.choice(country_ids)
+
+            elif col_name == "state_id":
+                row[col_name] = random.choice(state_ids)
+
+            elif col_name == "user_status_id":
+                row[col_name] = random.choice(status_ids)
+
+            elif col_name == "user_category_id":
+                row[col_name] = random.choice(category_ids)
+
+            elif col_name == "first_name":
+                row[col_name] = first_name
+
+            elif col_name == "middle_name":
+                row[col_name] = middle_name
+
+            elif col_name == "last_name":
+                row[col_name] = last_name
+
+            elif col_name == "full_name":
+                row[col_name] = f"{first_name} {middle_name} {last_name}"
+
+            else:
+                row[col_name] = generate_value_from_type(col_name, col_type, i)
+
+        data.append(row)
+
+    return pd.DataFrame(data)
+
+
+# -------------------------
+# GENERATE REQUEST
+# -------------------------
+def generate_request_table(
+    tables,
+    users_df,
+    request_for_df,
+    request_isleadvol_df,
+    help_categories_df,
+    request_type_df,
+    request_priority_df,
+    request_status_df
+):
+    columns = tables["request"]["columns"]
+    rows = TABLE_ROW_COUNTS.get("request", 100)
+
+    user_ids = get_column_values(users_df, "user_id")
+    req_for_ids = get_column_values(request_for_df, "req_for_id")
+    lead_ids = get_column_values(request_isleadvol_df, "req_islead_id")
+    cat_ids = get_column_values(help_categories_df, "cat_id")
+    type_ids = get_column_values(request_type_df, "req_type_id")
+    priority_ids = get_column_values(request_priority_df, "req_priority_id")
+    status_ids = get_column_values(request_status_df, "req_status_id")
+
+    data = []
+
+    for i in range(1, rows + 1):
+        row = {}
+
+        for col in columns:
+            col_name = col["name"]
+            col_type = col["type"]
+
+            if col_name == "req_id":
+                row[col_name] = f"REQ{i:06d}"
+
+            elif col_name == "req_user_id":
+                row[col_name] = random.choice(user_ids)
+
+            elif col_name == "req_for_id":
+                row[col_name] = random.choice(req_for_ids)
+
+            elif col_name == "req_islead_id":
+                row[col_name] = random.choice(lead_ids)
+
+            elif col_name == "req_cat_id":
+                row[col_name] = random.choice(cat_ids)
+
+            elif col_name == "req_type_id":
+                row[col_name] = random.choice(type_ids)
+
+            elif col_name == "req_priority_id":
+                row[col_name] = random.choice(priority_ids)
+
+            elif col_name == "req_status_id":
+                row[col_name] = random.choice(status_ids)
+
+            else:
+                row[col_name] = generate_value_from_type(col_name, col_type, i)
+
+        data.append(row)
+
+    return pd.DataFrame(data)
+
+
+# -------------------------
+# VALIDATION
+# -------------------------
+def validate_fk(child_df, child_col, parent_df, parent_col):
+    invalid = child_df[~child_df[child_col].isin(parent_df[parent_col])]
+
+    if len(invalid) == 0:
+        print(f"✅ FK OK: {child_col} -> {parent_col}")
+    else:
+        print(f"❌ FK FAIL: {child_col} -> {parent_col} ({len(invalid)} invalid rows)")
+
+
+def run_validations(generated_tables):
+    print("\n🔍 Running Foreign Key Validations...\n")
+
+    validate_fk(
+        generated_tables["users"],
+        "country_id",
+        generated_tables["country"],
+        "country_id"
+    )
+
+    validate_fk(
+        generated_tables["users"],
+        "state_id",
+        generated_tables["state"],
+        "state_id"
+    )
+
+    validate_fk(
+        generated_tables["request"],
+        "req_user_id",
+        generated_tables["users"],
+        "user_id"
+    )
+
+
+# -------------------------
+# MAIN
+# -------------------------
+def main():
+    print("🚀 ENGINE STARTED")
+
+    schema = load_schema()
+    tables = schema["tables"]
+
+    output_dir = setup_output_folder()
+
+    generated_tables = {}
+
+    # -------------------------
+    # LOOKUP TABLES
+    # -------------------------
+    lookup_first = [
+        "country",
+        "state",
+        "user_status",
+        "user_category",
+        "request_for",
+        "request_isleadvol",
+        "request_priority",
+        "request_status",
+        "request_type",
+        "help_categories"
+    ]
+
+    for table_name in lookup_first:
+        if table_name in tables:
+            df = load_lookup_table(table_name)
+            generated_tables[table_name] = df
+
+    # -------------------------
+    # USERS
+    # -------------------------
+    users_df = generate_users_table(
+        tables,
+        generated_tables["country"],
+        generated_tables["state"],
+        generated_tables["user_status"],
+        generated_tables["user_category"]
+    )
+
+    generated_tables["users"] = users_df
+    print("✅ users created")
+
+    # -------------------------
+    # REQUEST
+    # -------------------------
+    request_df = generate_request_table(
+        tables,
+        generated_tables["users"],
+        generated_tables["request_for"],
+        generated_tables["request_isleadvol"],
+        generated_tables["help_categories"],
+        generated_tables["request_type"],
+        generated_tables["request_priority"],
+        generated_tables["request_status"]
+    )
+
+    generated_tables["request"] = request_df
+    print("✅ request created")
+
+    # -------------------------
+    # OTHER TABLES
+    # -------------------------
+    already_done = set(generated_tables.keys())
+
+    for table_name in tables:
+        if table_name not in already_done:
+            df = generate_table(table_name, tables)
+            generated_tables[table_name] = df
+            print(f"✅ {table_name} created")
+
+    # -------------------------
+    # VALIDATE
+    # -------------------------
+    run_validations(generated_tables)
+
+    # -------------------------
+    # SAVE CSV
+    # -------------------------
+    for table_name, df in generated_tables.items():
+        output_file = os.path.join(output_dir, f"{table_name}.csv")
+        df.to_csv(output_file, index=False)
+        print(f"💾 Saved: {table_name}.csv")
+
+    print("\n🎉 ALL TABLES GENERATED SUCCESSFULLY")
+
+
+if __name__ == "__main__":
+    main()

--- a/database/mock_db/request.csv
+++ b/database/mock_db/request.csv
@@ -1,0 +1,101 @@
+req_id,req_user_id,req_for_id,req_islead_id,req_cat_id,req_type_id,req_priority_id,req_status_id,req_loc,iscalamity,req_subj,req_desc,req_doc_link,audio_req_desc,submission_date,serviced_date,last_update_date,to_public
+REQ000001,USR00015,4,2,2,3,4,1,during,False,property,go,Author allow sometimes customer office fine.,laugh,2024-02-14 09:01:11,2023-08-30 06:23:13,2024-07-19 16:32:34,True
+REQ000002,USR00027,3,1,4,4,3,2,individual,True,second,activity,Several media method along less.,safe,2020-05-17 09:49:46,2023-09-24 01:33:54,2024-03-31 07:19:31,False
+REQ000003,USR00078,4,2,1,4,3,3,music,True,throw,sign,Agent end parent go create wait always.,report,2024-12-04 19:33:00,2023-05-22 18:00:57,2023-10-29 07:16:09,True
+REQ000004,USR00093,3,1,3,4,4,1,determine,False,international,job,Exist show blood theory.,before,2021-10-08 01:06:37,2023-02-28 21:29:52,2021-10-27 07:34:01,True
+REQ000005,USR00016,4,2,4,1,4,4,apply,True,success,southern,Girl conference section find room.,experience,2020-05-06 15:46:54,2024-02-27 15:10:08,2022-09-23 05:37:22,True
+REQ000006,USR00016,2,2,2,4,1,3,Democrat,True,lose,sort,Life let leader yard.,letter,2024-09-26 00:10:23,2020-01-13 14:50:27,2025-08-18 11:49:50,False
+REQ000007,USR00028,3,2,3,4,1,2,so,False,possible,system,Later level say physical once husband gun.,as,2023-02-11 03:29:00,2021-06-01 15:13:57,2020-01-20 13:04:35,False
+REQ000008,USR00079,4,2,3,1,3,2,care,True,song,thus,Tell none enter go bed.,similar,2024-08-19 13:54:01,2022-09-14 14:41:11,2025-12-19 16:00:03,False
+REQ000009,USR00024,1,1,3,1,3,3,cold,False,truth,difficult,Later thank they full go recently seven add.,bit,2020-12-22 21:41:30,2020-09-21 16:29:56,2023-08-30 20:07:52,False
+REQ000010,USR00015,3,2,2,2,3,1,trip,False,bring,whole,Page economy today.,seat,2024-05-31 13:27:04,2024-08-04 00:36:25,2025-11-14 11:50:30,False
+REQ000011,USR00006,2,2,1,3,3,3,sure,True,adult,others,Brother design news only how argue.,blood,2023-08-18 16:21:41,2023-11-06 16:44:19,2025-05-10 15:11:21,False
+REQ000012,USR00015,2,1,1,2,1,3,newspaper,False,than,security,Talk eye most whom result open.,audience,2022-01-13 16:29:44,2022-03-15 05:31:59,2021-03-17 17:11:48,True
+REQ000013,USR00046,2,1,3,3,4,2,what,True,media,TV,Sound camera night.,pressure,2020-03-22 06:31:11,2023-04-20 23:59:06,2023-03-26 22:21:29,True
+REQ000014,USR00057,3,1,3,2,2,4,avoid,False,make,that,Simply general event identify light support.,them,2024-08-18 03:28:52,2021-12-19 06:35:22,2024-11-02 05:57:37,True
+REQ000015,USR00028,3,1,3,4,2,4,kid,True,thing,radio,South audience thing what heart.,near,2023-12-09 07:17:14,2021-04-14 03:23:27,2021-10-13 23:26:06,True
+REQ000016,USR00004,4,1,1,2,2,3,hard,False,left,help,Kid black value cover keep act foot.,worker,2023-02-17 00:21:20,2020-05-08 01:31:32,2025-07-31 13:19:17,False
+REQ000017,USR00014,4,1,4,4,1,2,foot,True,these,might,Blue certainly man half kitchen.,hair,2021-01-03 00:35:29,2025-02-10 04:46:06,2021-05-06 14:04:38,True
+REQ000018,USR00030,3,2,4,2,2,2,building,True,media,score,Game for firm participant front trial military.,cut,2023-07-04 22:55:16,2022-08-29 10:49:24,2022-08-31 22:45:58,False
+REQ000019,USR00063,3,2,3,3,2,4,simple,False,see,too,Door power hard exist.,audience,2020-12-09 22:50:06,2020-11-03 17:17:34,2023-05-15 01:12:44,False
+REQ000020,USR00044,2,2,4,3,4,2,scientist,True,condition,him,Size difficult project choose pressure set artist.,put,2026-02-17 02:00:11,2025-06-12 22:20:41,2024-06-13 09:12:10,False
+REQ000021,USR00011,3,2,4,2,2,4,usually,False,computer,grow,Against page do number hair.,two,2021-10-26 09:59:02,2025-05-16 11:20:01,2023-03-11 23:06:31,True
+REQ000022,USR00001,3,1,1,4,1,3,generation,False,step,security,Option series mouth base.,above,2022-08-30 09:29:27,2020-11-17 08:39:11,2022-03-31 21:22:54,True
+REQ000023,USR00067,1,1,1,4,1,1,entire,True,budget,determine,Good individual full less list then health.,money,2022-12-22 16:41:13,2023-01-26 20:01:09,2025-06-18 19:22:40,True
+REQ000024,USR00025,3,2,4,1,2,4,fast,True,month,top,Small need prevent close staff message be.,college,2024-07-19 17:11:19,2022-02-16 11:55:49,2022-05-17 08:21:36,True
+REQ000025,USR00007,3,2,1,1,2,2,everyone,True,conference,staff,Character heavy who office term enter.,morning,2026-03-10 13:01:07,2023-07-20 15:40:27,2020-05-01 16:46:02,True
+REQ000026,USR00052,3,1,2,2,2,4,list,False,message,sport,Music carry now fall black by management.,cut,2020-10-31 16:38:46,2022-05-25 03:46:13,2024-05-04 23:14:29,True
+REQ000027,USR00074,4,2,2,4,1,1,age,False,run,here,Manager strategy letter available final would.,animal,2024-08-07 23:42:50,2022-11-22 06:27:54,2024-08-24 09:26:32,True
+REQ000028,USR00066,2,1,1,1,2,4,early,True,walk,west,Enjoy stuff should check.,forward,2021-08-02 17:35:51,2020-07-01 10:59:47,2025-03-22 11:06:18,False
+REQ000029,USR00097,4,2,3,1,4,2,admit,False,too,fact,Bar past foreign service process.,audience,2025-03-06 14:28:32,2025-09-16 05:12:35,2021-12-06 07:52:34,False
+REQ000030,USR00095,1,2,2,2,3,1,soldier,False,measure,hit,Reach live allow material.,sort,2023-11-06 23:11:26,2021-01-17 12:28:41,2025-09-02 22:34:06,False
+REQ000031,USR00007,4,1,4,1,3,4,least,True,product,concern,Leg instead major enjoy.,garden,2020-04-10 05:04:06,2021-01-24 11:23:12,2021-03-02 16:26:47,False
+REQ000032,USR00055,3,1,4,2,1,4,author,True,free,enter,Natural who news building.,whether,2025-07-16 06:27:41,2025-03-18 23:27:50,2023-03-26 08:17:54,True
+REQ000033,USR00087,1,1,2,3,4,2,ok,True,discussion,stay,Politics seem behavior success.,commercial,2024-10-27 17:43:53,2025-08-15 12:17:33,2023-07-26 18:07:48,True
+REQ000034,USR00038,1,1,4,4,1,2,move,False,pass,imagine,Present practice war magazine admit performance.,these,2021-05-11 13:58:57,2021-10-08 02:57:58,2024-10-29 08:59:03,True
+REQ000035,USR00065,4,1,4,3,3,3,study,True,time,operation,Media natural property.,firm,2025-09-10 04:37:26,2023-06-11 20:39:27,2020-04-07 21:53:20,True
+REQ000036,USR00052,3,2,1,1,1,2,realize,True,group,control,Sing work movie around computer.,pattern,2025-08-31 07:52:22,2024-02-12 10:22:25,2020-06-03 07:13:40,False
+REQ000037,USR00100,3,2,3,4,3,1,culture,True,son,learn,Event it evening section age agency.,police,2026-01-08 13:55:34,2025-03-05 19:12:07,2021-04-21 15:44:25,False
+REQ000038,USR00001,1,1,1,4,1,4,available,False,travel,future,With available evening outside great toward.,season,2023-09-09 23:23:39,2022-02-04 22:13:17,2022-07-19 06:15:49,True
+REQ000039,USR00073,4,1,3,1,1,2,meet,True,current,condition,Structure allow mean truth treat each.,see,2020-10-02 17:37:37,2021-01-20 13:59:24,2024-05-12 15:02:11,True
+REQ000040,USR00032,2,2,4,4,1,4,throughout,False,station,floor,Cup sell travel our.,music,2023-12-19 19:26:22,2026-04-06 12:27:30,2021-08-11 01:53:23,False
+REQ000041,USR00052,2,1,3,4,1,1,street,False,still,dog,Series office image upon moment.,never,2020-02-27 07:20:52,2022-08-13 12:29:58,2025-07-11 21:25:12,False
+REQ000042,USR00038,4,1,3,1,3,2,allow,True,throughout,kind,Participant onto born himself option reach.,often,2022-08-16 07:09:52,2021-06-18 05:07:51,2020-05-14 05:29:59,False
+REQ000043,USR00025,2,2,2,2,2,4,record,True,issue,race,Can fight someone around approach.,religious,2021-05-30 19:52:27,2025-10-04 02:14:53,2024-06-13 10:19:56,True
+REQ000044,USR00075,4,1,2,2,2,2,he,False,class,bill,Daughter fast low child fast organization first else.,dinner,2025-10-26 15:41:59,2020-05-16 01:06:45,2024-05-28 21:46:39,True
+REQ000045,USR00095,3,1,3,2,2,2,ball,True,purpose,democratic,Matter first within could learn rather sound study.,us,2023-03-02 06:44:28,2025-04-29 02:12:08,2025-10-05 00:47:34,False
+REQ000046,USR00063,3,2,4,2,3,3,easy,False,near,environment,Shake experience west good.,some,2025-12-05 10:07:35,2020-02-14 16:31:25,2025-09-07 00:17:40,False
+REQ000047,USR00037,2,1,1,1,1,2,for,False,perform,evidence,Do wide ready within poor candidate.,company,2020-08-01 00:07:46,2020-08-02 17:43:02,2021-08-19 06:24:13,True
+REQ000048,USR00002,1,1,4,1,3,3,charge,True,rich,government,Everyone ball once it main skin moment.,night,2020-03-10 05:57:19,2020-06-15 06:16:49,2020-07-26 18:37:17,True
+REQ000049,USR00088,3,1,1,1,4,3,vote,False,admit,off,Gas part food my citizen.,young,2020-11-14 02:38:38,2020-03-17 00:54:24,2020-11-01 00:59:13,False
+REQ000050,USR00070,1,2,1,4,1,3,available,False,smile,Republican,Professional various source big great teach.,nation,2022-05-19 19:10:55,2020-03-24 05:07:51,2023-11-26 16:21:55,True
+REQ000051,USR00003,2,1,2,2,2,3,car,True,sister,address,Show well organization political teacher suggest goal.,raise,2021-08-16 02:53:52,2020-09-26 02:01:38,2021-12-19 20:10:00,False
+REQ000052,USR00022,1,1,3,2,4,3,owner,False,value,too,Clearly start party good model lot responsibility final.,door,2024-01-25 08:40:22,2025-12-03 10:32:07,2021-04-10 07:13:20,False
+REQ000053,USR00051,2,2,2,3,2,4,space,False,several,kid,Participant film class there they visit special.,address,2023-12-04 02:14:58,2023-01-13 02:05:17,2020-05-07 10:13:24,False
+REQ000054,USR00079,4,2,1,2,3,2,anyone,True,these,protect,Policy think former although tend national.,minute,2022-08-13 17:21:03,2021-11-10 19:22:51,2020-01-16 09:03:01,True
+REQ000055,USR00008,4,2,1,3,3,3,first,True,enter,painting,Join discussion activity.,against,2020-12-06 14:12:55,2020-05-14 06:16:05,2024-06-01 10:14:51,False
+REQ000056,USR00024,1,2,1,3,2,3,mother,True,onto,analysis,Statement power current radio.,lawyer,2024-09-14 14:28:30,2021-06-21 14:41:38,2023-07-31 05:33:18,False
+REQ000057,USR00089,4,1,2,4,4,2,score,True,out,foot,Dinner central support author toward film generation represent.,home,2024-06-06 11:43:12,2022-09-12 14:36:45,2023-02-16 01:51:39,True
+REQ000058,USR00059,2,2,4,2,3,2,purpose,True,floor,only,Can church remember.,song,2022-08-11 17:13:39,2024-06-19 22:57:14,2022-07-25 15:42:17,True
+REQ000059,USR00093,3,2,4,2,1,2,resource,False,pattern,society,Apply yard theory stock town now their cell.,too,2025-04-18 00:17:48,2020-12-24 05:27:24,2025-08-11 23:41:39,True
+REQ000060,USR00098,4,1,1,2,1,1,section,True,operation,resource,Since teach small reach stuff difficult.,manage,2026-04-03 23:50:02,2021-08-28 07:48:33,2020-06-30 17:37:31,True
+REQ000061,USR00072,4,2,3,2,4,1,improve,False,party,nation,College interview her somebody not whether choice.,hard,2022-02-18 23:37:03,2023-12-11 16:48:19,2024-10-09 10:04:37,False
+REQ000062,USR00025,4,1,1,1,2,4,shoulder,True,memory,position,Less surface green stay.,tell,2023-06-16 12:00:46,2024-12-05 22:33:37,2025-05-23 14:16:34,False
+REQ000063,USR00042,3,2,1,4,1,3,soon,False,them,create,Anyone for year sea run low lawyer.,short,2025-06-29 17:11:53,2023-03-23 10:25:48,2021-04-16 05:07:28,False
+REQ000064,USR00093,3,2,4,1,4,3,career,False,catch,necessary,Information sing safe radio become share.,party,2020-01-17 04:04:12,2025-07-13 00:01:10,2022-01-08 06:45:37,False
+REQ000065,USR00036,1,2,1,4,3,4,without,True,bar,family,Structure scientist Congress national guess head.,improve,2020-04-27 15:37:08,2023-11-23 08:46:09,2024-08-06 04:55:50,False
+REQ000066,USR00078,1,1,3,3,3,4,off,True,any,eye,Would ten reason use training development hour next.,question,2025-10-28 04:03:26,2022-11-03 15:31:40,2025-05-26 14:11:49,True
+REQ000067,USR00087,3,2,1,1,4,3,everybody,False,machine,approach,Tend we though degree me.,practice,2021-04-29 11:53:51,2025-09-17 05:15:49,2020-04-25 22:25:33,True
+REQ000068,USR00005,1,2,2,4,4,3,should,False,human,budget,Interview keep move herself sit.,idea,2026-01-29 07:20:03,2024-08-27 13:19:12,2025-03-28 15:50:04,True
+REQ000069,USR00095,3,2,3,1,2,1,doctor,False,music,foot,Visit evidence event physical respond watch Democrat.,seat,2021-10-13 03:01:56,2025-01-05 11:19:09,2020-03-22 20:45:13,True
+REQ000070,USR00090,3,2,4,2,3,2,skill,True,bar,win,Central billion enough increase clear capital organization.,always,2023-12-12 17:27:23,2024-11-03 21:34:40,2024-01-23 08:59:04,False
+REQ000071,USR00022,2,1,4,2,3,1,story,True,hit,plant,Talk occur young stop.,poor,2021-07-22 11:26:32,2020-05-19 07:20:26,2022-12-12 10:56:35,False
+REQ000072,USR00035,4,2,1,2,3,3,under,False,knowledge,course,Hot investment memory adult lead individual.,company,2021-12-18 04:08:19,2024-03-08 18:23:39,2026-01-28 10:44:26,False
+REQ000073,USR00047,2,2,1,4,3,4,sister,True,accept,coach,Work place wife unit yeah.,leg,2023-04-14 05:41:53,2024-07-12 07:39:28,2023-02-26 18:22:36,True
+REQ000074,USR00040,2,2,4,4,2,3,writer,False,still,source,Decade half social box enough.,customer,2025-12-08 18:49:00,2025-12-18 05:05:27,2025-02-20 04:34:51,True
+REQ000075,USR00022,2,1,1,3,1,1,protect,False,step,identify,Another more itself together again else.,reach,2024-07-20 20:23:16,2021-11-29 05:17:24,2024-04-03 17:17:55,True
+REQ000076,USR00043,2,1,3,2,1,3,collection,True,onto,once,Since fact value lay.,father,2022-12-04 17:18:57,2021-04-27 14:17:35,2025-06-04 11:29:29,True
+REQ000077,USR00024,2,2,1,4,4,2,discover,False,over,onto,Data service note recognize certain also market affect.,school,2020-03-26 00:26:47,2020-08-11 03:00:15,2023-02-20 13:43:24,True
+REQ000078,USR00077,3,1,3,2,3,3,usually,False,even,every,Represent minute size ground sell color.,focus,2022-06-10 01:06:46,2024-10-10 07:29:02,2023-08-16 20:08:33,True
+REQ000079,USR00083,2,2,1,2,2,2,newspaper,False,reason,without,Low population professional whatever continue need.,popular,2020-10-30 00:32:03,2022-04-23 16:31:16,2023-05-22 18:52:30,False
+REQ000080,USR00007,1,2,2,3,1,3,far,True,politics,billion,Budget bank Mr own nice head both.,American,2025-10-31 02:50:40,2020-07-30 03:01:37,2020-10-09 18:37:19,True
+REQ000081,USR00040,3,1,2,2,1,2,reach,False,lead,training,Position nothing sense side say responsibility toward.,nation,2023-10-28 00:48:35,2022-01-15 03:50:03,2021-05-23 18:01:22,True
+REQ000082,USR00053,2,1,2,1,3,3,buy,False,future,employee,Yeah source when almost executive.,bag,2020-03-18 15:55:48,2025-10-15 04:59:14,2020-10-09 12:31:47,False
+REQ000083,USR00059,1,1,1,1,4,1,health,False,the,herself,Democratic even since above save sense.,success,2025-07-12 14:20:58,2025-05-03 11:31:40,2023-10-07 02:19:06,False
+REQ000084,USR00098,4,2,2,1,1,4,note,True,hundred,Congress,Pull with similar among music easy return establish.,leg,2024-07-22 02:24:31,2025-05-04 23:34:53,2021-05-10 16:36:57,False
+REQ000085,USR00012,4,1,3,4,1,4,purpose,True,sell,give,Tough population southern forget month environment listen trade.,likely,2024-06-06 21:05:26,2022-02-02 21:08:16,2024-09-20 17:12:03,True
+REQ000086,USR00064,1,2,1,3,4,1,military,False,nice,party,Knowledge ask beat.,discussion,2022-10-10 11:32:17,2022-05-23 17:50:42,2025-01-25 19:32:38,False
+REQ000087,USR00047,3,2,3,1,4,3,accept,True,social,machine,Week senior key perform stop college phone.,training,2022-09-18 22:49:48,2020-05-13 08:02:05,2024-08-12 20:07:37,True
+REQ000088,USR00010,4,1,2,1,3,2,arrive,False,society,term,List director whether million line.,national,2024-12-17 06:15:34,2023-10-22 00:21:32,2024-04-29 07:49:32,False
+REQ000089,USR00099,1,1,3,4,4,4,sport,False,maintain,always,Simply modern quality executive who develop.,mother,2021-11-04 14:05:08,2024-02-25 19:01:22,2021-12-25 20:44:20,True
+REQ000090,USR00027,1,1,3,3,1,1,community,True,piece,serve,Raise try floor officer.,service,2023-02-12 13:09:58,2020-03-29 11:36:13,2021-06-03 01:35:30,False
+REQ000091,USR00082,3,2,3,1,2,3,run,False,event,up,Research artist election however out radio.,age,2020-04-23 23:16:46,2022-08-13 02:28:58,2025-07-21 23:00:26,True
+REQ000092,USR00001,3,1,1,3,4,3,remain,True,determine,want,Audience election science chance interesting catch.,poor,2026-02-21 15:26:52,2023-05-18 15:07:31,2026-03-05 10:12:58,False
+REQ000093,USR00003,3,2,1,2,4,4,become,False,same,scene,Official month stand past message house.,stock,2024-03-30 19:22:16,2026-02-03 20:48:32,2024-02-01 07:50:54,False
+REQ000094,USR00029,1,2,3,1,4,2,attack,True,vote,Republican,Order by mind send reality office whatever create.,time,2024-04-09 11:59:23,2025-03-07 13:22:44,2024-01-18 02:27:53,True
+REQ000095,USR00025,3,2,3,1,3,2,can,False,Mr,travel,Such turn other well.,member,2026-04-08 05:35:39,2021-02-19 19:53:37,2021-02-11 16:17:40,True
+REQ000096,USR00040,1,1,3,3,1,3,activity,False,phone,rest,Our anyone themselves win expert.,military,2024-05-31 15:13:54,2026-03-22 14:18:41,2024-08-05 21:47:50,False
+REQ000097,USR00090,1,2,2,3,4,2,decide,True,no,girl,Decide above especially report close forget.,peace,2022-04-01 23:33:58,2023-12-26 05:46:48,2022-07-08 04:23:23,False
+REQ000098,USR00001,3,2,1,2,2,1,responsibility,True,five,southern,Lay experience participant provide out year.,item,2025-02-26 05:22:06,2025-05-30 21:34:07,2022-08-11 23:07:54,True
+REQ000099,USR00087,2,1,2,4,3,1,later,False,after,drop,Former arrive respond official clearly no enjoy.,fear,2021-09-22 17:06:18,2022-02-04 12:11:27,2025-01-08 05:27:31,False
+REQ000100,USR00035,1,2,3,4,1,3,development,False,message,bag,Bad bit artist.,rather,2025-03-10 13:51:53,2024-03-18 04:12:00,2020-05-06 06:30:10,False


### PR DESCRIPTION
This PR adds a schema-driven Python script to generate synthetic/mock CSV data for testing and development.

Changes:
- Added generate_data.py for automated mock data generation
- Added users.csv and request.csv output files
- Ensures foreign key relationships using lookup tables
- Organized files under database and mock_db folders