### PR TITLE
#160: Implement real API for KPI Analytics Lambda

### DIFF
--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -25,7 +25,12 @@ def lambda_handler(event, context):
         cursor = conn.cursor()
         print("Successfully connected to the database")
 
-        response_body = {}
+        status_distribution, total_requests = get_request_status_distribution(cursor)
+
+        response_body = {
+            "request_status_distribution": status_distribution,
+            "total_requests": total_requests
+        }
 
         return {
             "statusCode": 200,
@@ -45,3 +50,34 @@ def lambda_handler(event, context):
         if conn:
             conn.close()
         print("Database connection closed")
+
+
+def get_request_status_distribution(cursor):
+    """
+    Counts requests grouped by their status label (e.g. CREATED, IN_PROGRESS, RESOLVED).
+    Joins request -> request_status to resolve the status name from the FK.
+    Returns (distribution_list, total_count).
+    """
+    try:
+        query = f"""
+            SELECT rs.req_status, COUNT(r.req_id) AS count
+            FROM {REAL_TABLE_REQUEST} r
+            JOIN {REAL_TABLE_REQUEST_STATUS} rs
+                ON r.req_status_id = rs.req_status_id
+            GROUP BY rs.req_status
+            ORDER BY count DESC
+        """
+        cursor.execute(query)
+        rows = cursor.fetchall()
+
+        distribution = [
+            {"status": row[0], "count": int(row[1])}
+            for row in rows
+        ]
+        total = sum(item["count"] for item in distribution)
+
+        return distribution, total
+
+    except Exception as e:
+        print("Error in get_request_status_distribution:", str(e))
+        return [], 0

--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -1,0 +1,47 @@
+import json
+import psycopg2
+import os
+
+# Virginia RDS table references
+REAL_TABLE_REQUEST = "virginia_dev_saayam_rdbms.request"
+REAL_TABLE_REQUEST_STATUS = "virginia_dev_saayam_rdbms.request_status"
+REAL_TABLE_HELP_CATEGORIES = "virginia_dev_saayam_rdbms.help_categories"
+
+
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+
+    DB_CONFIG = {
+        "host": os.environ['host'],
+        "port": os.environ['port'],
+        "dbname": os.environ['dbname'],
+        "user": os.environ['user'],
+        "password": os.environ['password']
+    }
+
+    try:
+        conn = psycopg2.connect(**DB_CONFIG)
+        cursor = conn.cursor()
+        print("Successfully connected to the database")
+
+        response_body = {}
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps(response_body)
+        }
+
+    except Exception as e:
+        print("ERROR:", str(e))
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": "Could not connect to database"})
+        }
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+        print("Database connection closed")

--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -31,15 +31,15 @@ def lambda_handler(event, context):
         }
     }
 
-    DB_CONFIG = {
-        "host": os.environ['host'],
-        "port": os.environ['port'],
-        "dbname": os.environ['dbname'],
-        "user": os.environ['user'],
-        "password": os.environ['password']
-    }
-
     try:
+        DB_CONFIG = {
+            "host": os.environ['host'],
+            "port": os.environ['port'],
+            "dbname": os.environ['dbname'],
+            "user": os.environ['user'],
+            "password": os.environ['password']
+        }
+
         conn = psycopg2.connect(**DB_CONFIG)
         cursor = conn.cursor()
         print("Successfully connected to the database")
@@ -146,6 +146,7 @@ def get_average_resolution_time_by_category(cursor):
     except Exception as e:
         print("Error in get_average_resolution_time_by_category:", str(e))
         return []
-    
+
+
 if __name__ == "__main__":
     print(lambda_handler({}, None))

--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -146,3 +146,6 @@ def get_average_resolution_time_by_category(cursor):
     except Exception as e:
         print("Error in get_average_resolution_time_by_category:", str(e))
         return []
+    
+if __name__ == "__main__":
+    print(lambda_handler({}, None))

--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -18,6 +18,19 @@ def lambda_handler(event, context):
     conn = None
     cursor = None
 
+    # Safe default response returned on any unrecoverable error
+    safe_response = {
+        "request_status_distribution": [],
+        "total_requests": 0,
+        "average_resolution_time_by_category": [],
+        "sla": {
+            "target_days": SLA_TARGET_DAYS,
+            "target_hours": SLA_TARGET_HOURS,
+            "warning_days": SLA_WARNING_DAYS,
+            "warning_hours": SLA_WARNING_HOURS
+        }
+    }
+
     DB_CONFIG = {
         "host": os.environ['host'],
         "port": os.environ['port'],
@@ -55,7 +68,7 @@ def lambda_handler(event, context):
         print("ERROR:", str(e))
         return {
             "statusCode": 500,
-            "body": json.dumps({"error": "Could not connect to database"})
+            "body": json.dumps(safe_response)
         }
 
     finally:

--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -7,6 +7,12 @@ REAL_TABLE_REQUEST = "virginia_dev_saayam_rdbms.request"
 REAL_TABLE_REQUEST_STATUS = "virginia_dev_saayam_rdbms.request_status"
 REAL_TABLE_HELP_CATEGORIES = "virginia_dev_saayam_rdbms.help_categories"
 
+# SLA constants (dashboard-defined thresholds)
+SLA_TARGET_DAYS = 10
+SLA_TARGET_HOURS = 240
+SLA_WARNING_DAYS = 8.33
+SLA_WARNING_HOURS = 200
+
 
 def lambda_handler(event, context):
     conn = None
@@ -26,10 +32,18 @@ def lambda_handler(event, context):
         print("Successfully connected to the database")
 
         status_distribution, total_requests = get_request_status_distribution(cursor)
+        avg_resolution = get_average_resolution_time_by_category(cursor)
 
         response_body = {
             "request_status_distribution": status_distribution,
-            "total_requests": total_requests
+            "total_requests": total_requests,
+            "average_resolution_time_by_category": avg_resolution,
+            "sla": {
+                "target_days": SLA_TARGET_DAYS,
+                "target_hours": SLA_TARGET_HOURS,
+                "warning_days": SLA_WARNING_DAYS,
+                "warning_hours": SLA_WARNING_HOURS
+            }
         }
 
         return {
@@ -81,3 +95,41 @@ def get_request_status_distribution(cursor):
     except Exception as e:
         print("Error in get_request_status_distribution:", str(e))
         return [], 0
+
+
+def get_average_resolution_time_by_category(cursor):
+    """
+    Calculates average resolution time (in hours) per help category.
+    Uses submission_date and serviced_date from the request table.
+    Only includes requests where both dates are present.
+    Joins request -> help_categories to get the category name.
+    """
+    try:
+        query = f"""
+            SELECT
+                hc.cat_name AS category,
+                ROUND(
+                    AVG(
+                        EXTRACT(EPOCH FROM (r.serviced_date - r.submission_date)) / 3600
+                    )::numeric,
+                    2
+                ) AS avg_hours
+            FROM {REAL_TABLE_REQUEST} r
+            JOIN {REAL_TABLE_HELP_CATEGORIES} hc
+                ON r.req_cat_id = hc.cat_id
+            WHERE r.submission_date IS NOT NULL
+              AND r.serviced_date IS NOT NULL
+            GROUP BY hc.cat_name
+            ORDER BY avg_hours DESC
+        """
+        cursor.execute(query)
+        rows = cursor.fetchall()
+
+        return [
+            {"category": row[0], "avg_hours": float(row[1])}
+            for row in rows
+        ]
+
+    except Exception as e:
+        print("Error in get_average_resolution_time_by_category:", str(e))
+        return []


### PR DESCRIPTION
## Summary
Implements `kpi_api_analytics.py` — a new AWS Lambda that connects to the Virginia RDS PostgreSQL database and returns chart-ready JSON for two KPI dashboard widgets.

Closes #160

## What's Implemented

### Part 1 — Request Status Distribution
- Counts requests grouped by status (CREATED, IN_PROGRESS, RESOLVED)
- Returns `request_status_distribution` array and `total_requests` count
- Returns `[]` and `0` when no data exists

### Part 2 — Average Resolution Time by Category
- Calculates avg resolution time (hours) per help category
- Uses `submission_date` and `serviced_date`, only includes fully resolved requests
- Returns SLA metadata (target: 10 days/240 hours, warning: 8.33 days/200 hours)
- Returns `[]` when no resolved requests exist, SLA always present

### Error Handling
- DB connection and queries wrapped in try/except
- Returns statusCode 500 with safe defaults on failure
- finally block closes cursor and connection

### Local Testing
- `__main__` block for local execution
- Verified: safe response on missing env vars, no crashes, all keys present

## Schema Corrections from Issue
The issue referenced table/column names that differ from the actual Virginia DB:
| Issue assumed | Actual DB | Used in code |
|---|---|---|
| `request.request_id` | `request.req_id` | `req_id` |
| `request.request_status` | `request.req_status_id` (FK) | Joined to `request_status` table |
| `request.category_id` | `request.req_cat_id` | `req_cat_id` |
| `request_category` table | `help_categories` table | `help_categories` |
| `request.resolved_date` | `request.serviced_date` | `serviced_date` |

## Reference
- Follows patterns from `beneficiariesTrendAnalysis.py` and `volunteer_application_analytics.py`
- Table/column names confirmed from `Saayam_Table.column.names_data.xlsx`