### PR TITLE
#181: Add date filter support to KPI analytics Lambda

### DIFF
--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -55,7 +55,34 @@ def get_db_connection():
 
 
 
-def fetch_request_status_distribution(cursor):
+def build_date_filter(time_range, start_date=None, end_date=None):
+    """Build a SQL WHERE-clause snippet for filtering by r.submission_date.
+
+    Supported time_range values: "7D", "30D", "1Y", "All", "Custom".
+    Unknown / missing values are treated as "All" (no filter applied).
+
+    Returns:
+        (sql_snippet, params): The snippet is prefixed with "AND " and is
+        intended to be appended into an existing WHERE clause. params is a
+        list of values for psycopg2 to substitute (empty for the relative
+        ranges, two values for "Custom").
+    """
+    time_range = (time_range or "All").strip()
+
+    if time_range == "7D":
+        return ("AND r.submission_date > CURRENT_TIMESTAMP - INTERVAL '7 days'", [])
+    if time_range == "30D":
+        return ("AND r.submission_date > CURRENT_TIMESTAMP - INTERVAL '30 days'", [])
+    if time_range == "1Y":
+        return ("AND r.submission_date > CURRENT_TIMESTAMP - INTERVAL '1 year'", [])
+    if time_range == "Custom" and start_date and end_date:
+        return ("AND r.submission_date BETWEEN %s AND %s", [start_date, end_date])
+    # "All" or anything else → no filter
+    return ("", [])
+
+
+def fetch_request_status_distribution(cursor, time_range="All", start_date=None, end_date=None):
+    date_filter, params = build_date_filter(time_range, start_date, end_date)
     query = f"""
         SELECT
             rs.req_status AS status,
@@ -63,11 +90,13 @@ def fetch_request_status_distribution(cursor):
         FROM {SCHEMA_NAME}.request r
         JOIN {SCHEMA_NAME}.request_status rs
             ON r.req_status_id = rs.req_status_id
+        WHERE 1=1
+          {date_filter}
         GROUP BY rs.req_status
         ORDER BY rs.req_status;
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     rows = cursor.fetchall()
 
     return [
@@ -78,19 +107,23 @@ def fetch_request_status_distribution(cursor):
         for row in rows
     ]
 
-def fetch_total_requests(cursor):
+def fetch_total_requests(cursor, time_range="All", start_date=None, end_date=None):
+    date_filter, params = build_date_filter(time_range, start_date, end_date)
     query = f"""
-        SELECT COUNT(req_id) AS total_requests
-        FROM {SCHEMA_NAME}.request;
+        SELECT COUNT(r.req_id) AS total_requests
+        FROM {SCHEMA_NAME}.request r
+        WHERE 1=1
+          {date_filter};
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     row = cursor.fetchone()
 
     return int(row["total_requests"]) if row and row["total_requests"] is not None else 0
 
 
-def fetch_average_resolution_time_by_category(cursor):
+def fetch_average_resolution_time_by_category(cursor, time_range="All", start_date=None, end_date=None):
+    date_filter, params = build_date_filter(time_range, start_date, end_date)
     query = f"""
         SELECT
             hc.cat_name AS category,
@@ -109,11 +142,12 @@ def fetch_average_resolution_time_by_category(cursor):
           AND r.serviced_date IS NOT NULL
           AND r.serviced_date >= r.submission_date
           AND UPPER(rs.req_status) IN ('COMPLETED', 'RESOLVED')
+          {date_filter}
         GROUP BY hc.cat_name
         ORDER BY avg_hours DESC;
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     rows = cursor.fetchall()
 
     return [
@@ -129,24 +163,36 @@ def lambda_handler(event, context):
     cursor = None
     response_body = get_default_response()
 
+    # Parse optional date filter parameters from event
+    event = event or {}
+    time_range = event.get("time_range", "All")
+    start_date = event.get("start_date")
+    end_date = event.get("end_date")
+
     try:
         conn = get_db_connection()
         cursor = conn.cursor(cursor_factory=RealDictCursor)
 
         try:
-            response_body["request_status_distribution"] = fetch_request_status_distribution(cursor)
+            response_body["request_status_distribution"] = fetch_request_status_distribution(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Status distribution query failed: {error}")
             response_body["request_status_distribution"] = []
 
         try:
-            response_body["total_requests"] = fetch_total_requests(cursor)
+            response_body["total_requests"] = fetch_total_requests(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Total request count query failed: {error}")
             response_body["total_requests"] = 0
 
         try:
-            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(cursor)
+            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Average resolution time query failed: {error}")
             response_body["average_resolution_time_by_category"] = []


### PR DESCRIPTION
## Summary
Adds `time_range` filtering to `kpi_api_analytics.py` for the Super Admin dashboard. Supports `7D` / `30D` / `1Y` / `All` / `Custom` ranges on `r.submission_date`.

Closes #181.

## Changes (single file: `data-analytics/lambda_functions/kpi_api_analytics.py`)

**New helper**
- `build_date_filter(time_range, start_date=None, end_date=None)` → returns `(sql_snippet, params)`. Unknown / missing values fall back to `All` (no filter). `Custom` falls back to `All` if either date is missing.

**Modified**
- `fetch_request_status_distribution(cursor, time_range, start_date, end_date)` — appends the filter to a `WHERE 1=1` base clause.
- `fetch_total_requests(cursor, time_range, start_date, end_date)` — same pattern, query now uses the `r` alias so the date filter references `r.submission_date` consistently.
- `fetch_average_resolution_time_by_category(cursor, time_range, start_date, end_date)` — appends the date filter to the existing WHERE; non-null / completed-or-resolved logic preserved.
- `lambda_handler(event, context)` — reads `time_range`, `start_date`, `end_date` from the event payload and passes them through to all three fetch functions.

## Unchanged
- Response shape (4 keys: `request_status_distribution`, `total_requests`, `average_resolution_time_by_category`, `sla`)
- SLA metadata
- Safe defaults (`[]` for lists, `0` for counts)
- Per-query `try/except` + connection/cursor cleanup in `finally`
- Credentials still loaded via Parameter Store; nothing hardcoded
- Virginia DB only

## Phase 4 — local verification

Ran each of the 6 listed payloads against a mocked DB connection. All returned `statusCode: 200` with the full response structure and the correct SQL injected for each time range.

| Payload | Filter applied | Params |
|---|---|---|
| `{}` (default) | none → All | `[]` |
| `{"time_range":"7D"}` | `INTERVAL '7 days'` | `[]` |
| `{"time_range":"30D"}` | `INTERVAL '30 days'` | `[]` |
| `{"time_range":"1Y"}` | `INTERVAL '1 year'` | `[]` |
| `{"time_range":"All"}` | none | `[]` |
| `{"time_range":"Custom","start_date":"2026-05-01","end_date":"2026-05-31"}` | `BETWEEN %s AND %s` | `['2026-05-01','2026-05-31']` |