### PR TITLE
feat: add date filter support to KPI analytics API (#181)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+venv/
+env/
+.venv/
+
+# Secrets / environment
+.env
+*.env
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Notebooks
+.ipynb_checkpoints/
+
+# Build / packaging
+dist/
+build/
+*.egg-info/
+
+# Coverage
+htmlcov/
+.coverage

--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -4,6 +4,7 @@ import psycopg2
 from psycopg2.extras import RealDictCursor
 from aws_lambda_powertools.utilities import parameters
 
+
 SCHEMA_NAME = "virginia_dev_saayam_rdbms"
 
 
@@ -34,6 +35,22 @@ def build_response(status_code, body):
         "body": json.dumps(body, default=str)
     }
 
+def build_date_filter(time_range, start_date=None, end_date=None):
+    sql_date_condition = ""
+    sql_params = ()
+
+    if time_range == "Custom" and start_date and end_date:
+        sql_date_condition = f"r.submission_date BETWEEN %s AND %s"
+        sql_params = (start_date, end_date)
+    elif time_range == "7D":
+        sql_date_condition = "r.submission_date >= CURRENT_DATE - INTERVAL '7 days'"
+    elif time_range == "30D":
+        sql_date_condition = "r.submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+    elif time_range == "1Y":
+        sql_date_condition = "r.submission_date >= CURRENT_DATE - INTERVAL '1 year'"
+    
+    return sql_date_condition, sql_params
+
 
 def get_db_connection():
     creds = json.loads(parameters.get_parameter(
@@ -50,10 +67,13 @@ def get_db_connection():
         user=creds["USERNAME"],
         password=creds["PASSWORD"],
         port=creds["PORT"],
-        sslmode="require"
+        sslmode="require"     
     )
 
-def fetch_request_status_distribution(cursor):
+def fetch_request_status_distribution(cursor, time_range="All", start_date=None, end_date=None):
+    date_filter, params = build_date_filter(time_range, start_date, end_date)
+    date_filter_clause = f"WHERE {date_filter}" if date_filter else ""
+    
     query = f"""
         SELECT
             rs.req_status AS status,
@@ -61,11 +81,12 @@ def fetch_request_status_distribution(cursor):
         FROM {SCHEMA_NAME}.request r
         JOIN {SCHEMA_NAME}.request_status rs
             ON r.req_status_id = rs.req_status_id
+        {date_filter_clause}
         GROUP BY rs.req_status
         ORDER BY rs.req_status;
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     rows = cursor.fetchall()
 
     return [
@@ -77,19 +98,26 @@ def fetch_request_status_distribution(cursor):
     ]
 
 
-def fetch_total_requests(cursor):
+def fetch_total_requests(cursor, time_range="All", start_date=None, end_date=None):
+    date_filter, params = build_date_filter(time_range, start_date, end_date)
+    date_filter_clause = f"WHERE {date_filter}" if date_filter else ""
+
     query = f"""
-        SELECT COUNT(req_id) AS total_requests
-        FROM {SCHEMA_NAME}.request;
+        SELECT COUNT(r.req_id) AS total_requests
+        FROM {SCHEMA_NAME}.request r
+        {date_filter_clause};
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     row = cursor.fetchone()
 
     return int(row["total_requests"]) if row and row["total_requests"] is not None else 0
 
 
-def fetch_average_resolution_time_by_category(cursor):
+def fetch_average_resolution_time_by_category(cursor, time_range="All", start_date=None, end_date=None):
+    date_filter, params = build_date_filter(time_range, start_date, end_date)
+    date_filter_clause = f"AND {date_filter}" if date_filter else ""
+
     query = f"""
         SELECT
             hc.cat_name AS category,
@@ -108,11 +136,12 @@ def fetch_average_resolution_time_by_category(cursor):
           AND r.serviced_date IS NOT NULL
           AND r.serviced_date >= r.submission_date
           AND UPPER(rs.req_status) IN ('COMPLETED', 'RESOLVED')
+          {date_filter_clause}
         GROUP BY hc.cat_name
         ORDER BY avg_hours DESC;
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     rows = cursor.fetchall()
 
     return [
@@ -129,24 +158,28 @@ def lambda_handler(event, context):
     cursor = None
     response_body = get_default_response()
 
+    time_range = event.get("time_range", "All")
+    start_date = event.get("start_date")
+    end_date = event.get("end_date")
+
     try:
         conn = get_db_connection()
         cursor = conn.cursor(cursor_factory=RealDictCursor)
 
         try:
-            response_body["request_status_distribution"] = fetch_request_status_distribution(cursor)
+            response_body["request_status_distribution"] = fetch_request_status_distribution(cursor, time_range, start_date, end_date)
         except Exception as error:
             print(f"Status distribution query failed: {error}")
             response_body["request_status_distribution"] = []
 
         try:
-            response_body["total_requests"] = fetch_total_requests(cursor)
+            response_body["total_requests"] = fetch_total_requests(cursor, time_range, start_date, end_date)
         except Exception as error:
             print(f"Total request count query failed: {error}")
             response_body["total_requests"] = 0
 
         try:
-            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(cursor)
+            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(cursor, time_range, start_date, end_date)
         except Exception as error:
             print(f"Average resolution time query failed: {error}")
             response_body["average_resolution_time_by_category"] = []
@@ -165,5 +198,40 @@ def lambda_handler(event, context):
 
 
 if __name__ == "__main__":
-    result = lambda_handler({}, None)
-    print(json.dumps(result, indent=2))
+    result_default = lambda_handler({}, None)
+    
+    result_7d = lambda_handler({
+                                        "time_range": "7D"
+                                    }, None)
+    
+    result_30d = lambda_handler({
+                                        "time_range": "30D"
+                                    }, None)
+    
+    result_1y = lambda_handler({
+                                        "time_range": "1Y"
+                                    }, None)
+    
+    result_all = lambda_handler({
+                                        "time_range": "All"
+                                    }, None)
+    
+    result_cust = lambda_handler({
+                                        "time_range": "Custom",
+                                        "start_date": "2026-05-01",
+                                        "end_date": "2026-05-31"
+                                    }, None)
+
+
+    print("-------------Default Time Range (All):-------------")
+    print(json.dumps(result_default, indent=2))
+    print("-------------7 Days Time Range-------------")
+    print(json.dumps(result_7d, indent=2))
+    print("-------------30 Days Time Range-------------")
+    print(json.dumps(result_30d, indent=2))
+    print("-------------1 Year Time Range-------------")
+    print(json.dumps(result_1y, indent=2))
+    print("-------------All Time Range-------------")
+    print(json.dumps(result_all, indent=2))
+    print("-------------Custom Time Range-------------")
+    print(json.dumps(result_cust, indent=2))


### PR DESCRIPTION
## What this does
Adds date filter support (7D, 30D, 1Y, All, Custom) to the KPI analytics API.

### Acceptance Criteria

* [x] Existing `kpi_api_analytics.py` is updated.
* [x] No new API file is created.
* [x] No frontend/UI changes are made.
* [x] No dropdown, tab, or chart-view logic is added.
* [x] `build_date_filter()` is implemented.
* [x] `lambda_handler()` reads `time_range`, `start_date`, and `end_date` from event payload.
* [x] `fetch_request_status_distribution()` supports `7D`, `30D`, `1Y`, `All`, and `Custom`.
* [x] `fetch_total_requests()` supports `7D`, `30D`, `1Y`, `All`, and `Custom`.
* [x] `fetch_average_resolution_time_by_category()` supports `7D`, `30D`, `1Y`, `All`, and `Custom`.
* [x] `total_requests` respects the selected date filter.
* [x] Existing response structure remains unchanged.
* [x] `sla` is always present.
* [x] Safe empty-data responses are returned.
* [x] Code works for Virginia database.
* [x] Production credentials are not hardcoded.


## How it was tested
Tested locally against a PostgreSQL copy of the Virginia tables for all
five time ranges, plus verified average resolution time with seeded
resolved requests.

Closes #181




