### PR TITLE
Revert "Revert "feat: add date filters support to KPI analytics lambda function #181""

### DIFF
--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -3,6 +3,8 @@ import os
 import boto3 
 import psycopg2
 from psycopg2.extras import RealDictCursor
+from aws_lambda_powertools.utilities import parameters
+import os
 
 
 SCHEMA_NAME = "virginia_dev_saayam_rdbms"
@@ -53,6 +55,36 @@ def get_db_connection():
         sslmode="require"
     )
 
+def build_date_filter(time_range, start_date=None, end_date=None):
+    """
+    Builds the dynamic WHERE clause fragment and SQL parameters based on the selected time_range.
+    """
+    sql_fragment = ""
+    params = []
+
+    if time_range == "7D":
+        sql_fragment = "r.submission_date >= CURRENT_DATE - INTERVAL '7 days'"
+    elif time_range == "30D":
+        sql_fragment = "r.submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+    elif time_range == "1Y":
+        sql_fragment = "r.submission_date >= CURRENT_DATE - INTERVAL '1 year'"
+    elif time_range == "Custom":
+        if start_date and end_date:
+            sql_fragment = "r.submission_date BETWEEN %s AND %s"
+            params = [start_date, end_date]
+        else:
+            # Fallback if custom dates are missing or invalid
+            sql_fragment = ""
+    
+    return sql_fragment, params
+
+def fetch_request_status_distribution(cursor, time_range, start_date=None, end_date=None):
+    # Call our helper function
+    date_clause, params = build_date_filter(time_range, start_date, end_date)
+    
+    # If a filter exists, add a WHERE block right before the GROUP BY
+    where_clause = f"WHERE {date_clause}" if date_clause else ""
+
 
 
 def fetch_request_status_distribution(cursor):
@@ -63,11 +95,13 @@ def fetch_request_status_distribution(cursor):
         FROM {SCHEMA_NAME}.request r
         JOIN {SCHEMA_NAME}.request_status rs
             ON r.req_status_id = rs.req_status_id
+        {where_clause}
         GROUP BY rs.req_status
         ORDER BY rs.req_status;
     """
 
-    cursor.execute(query)
+    # Pass the params securely along with the query execution
+    cursor.execute(query, params)
     rows = cursor.fetchall()
 
     return [
@@ -78,19 +112,30 @@ def fetch_request_status_distribution(cursor):
         for row in rows
     ]
 
+
+def fetch_total_requests(cursor, time_range, start_date=None, end_date=None):
+    date_clause, params = build_date_filter(time_range, start_date, end_date)
+    where_clause = f"WHERE {date_clause}" if date_clause else ""
+
 def fetch_total_requests(cursor):
     query = f"""
-        SELECT COUNT(req_id) AS total_requests
-        FROM {SCHEMA_NAME}.request;
+        SELECT COUNT(r.req_id) AS total_requests
+        FROM {SCHEMA_NAME}.request r
+        {where_clause};
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     row = cursor.fetchone()
 
     return int(row["total_requests"]) if row and row["total_requests"] is not None else 0
 
 
-def fetch_average_resolution_time_by_category(cursor):
+def fetch_average_resolution_time_by_category(cursor, time_range, start_date=None, end_date=None):
+    date_clause, params = build_date_filter(time_range, start_date, end_date)
+    
+    # Append to existing conditions if the filter is active
+    additional_filter = f"AND {date_clause}" if date_clause else ""
+
     query = f"""
         SELECT
             hc.cat_name AS category,
@@ -109,11 +154,12 @@ def fetch_average_resolution_time_by_category(cursor):
           AND r.serviced_date IS NOT NULL
           AND r.serviced_date >= r.submission_date
           AND UPPER(rs.req_status) IN ('COMPLETED', 'RESOLVED')
+          {additional_filter}
         GROUP BY hc.cat_name
         ORDER BY avg_hours DESC;
     """
 
-    cursor.execute(query)
+    cursor.execute(query, params)
     rows = cursor.fetchall()
 
     return [
@@ -129,24 +175,35 @@ def lambda_handler(event, context):
     cursor = None
     response_body = get_default_response()
 
+    # Extract time filter arguments from the event dictionary with fallback defaults
+    time_range = event.get("time_range", "All")
+    start_date = event.get("start_date")
+    end_date = event.get("end_date")
+
     try:
         conn = get_db_connection()
         cursor = conn.cursor(cursor_factory=RealDictCursor)
 
         try:
-            response_body["request_status_distribution"] = fetch_request_status_distribution(cursor)
+            response_body["request_status_distribution"] = fetch_request_status_distribution(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Status distribution query failed: {error}")
             response_body["request_status_distribution"] = []
 
         try:
-            response_body["total_requests"] = fetch_total_requests(cursor)
+            response_body["total_requests"] = fetch_total_requests(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Total request count query failed: {error}")
             response_body["total_requests"] = 0
 
         try:
-            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(cursor)
+            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Average resolution time query failed: {error}")
             response_body["average_resolution_time_by_category"] = []
@@ -165,4 +222,16 @@ def lambda_handler(event, context):
 
 
 if __name__ == "__main__":
+    # Test Payload Examples
+    test_event = {"time_range": "30D"}
+    # test_event = {"time_range": "Custom", "start_date": "2026-05-01", "end_date": "2026-05-31"}
+    
+    print(f"Testing local analytics endpoint execution with event scope: {test_event}")
+    
+    # Note: To run this successfully locally, you will want to comment out the 
+    # 'parameters.get_parameter' function lines inside your get_db_connection() function 
+    # and temporarily replace them with your local .env database connection values.
+    
+    result = lambda_handler(test_event, None)
+    print(json.dumps(result, indent=2))  
     result = lambda_handler({}, None)


### PR DESCRIPTION
Closes #181

Summary
Adds the `kpi_api_analytics` Lambda handler, which exposes KPI metrics 
for the request-tracking system via API Gateway:
1. Request status distribution (counts per status)
2.Total request count
 3.Average resolution time by category (in hours)
4.Fixed SLA thresholds (target: 10 days / 240 hrs, warning: 8.33 days / 200 hrs)

Supports filtering by time range: 7D, 30D, 1Y, Custom(start/end date), 
or All (no filter).

 How it works
1.Pulls DB credentials securely from AWS SSM Parameter Store
2.Connects to PostgreSQL and runs three independent queries
 3.Each query is wrapped in its own try/except so a single query failure 
  doesn't break the full response — it just falls back to an empty/default value
4. Returns a standard API Gateway-style JSON response with CORS headers

Testing
Added `test_kpi_api_analytics.py` — a pytest suite (19 tests) that mocks 
boto3 and psycopg2 so it runs without real AWS/DB access. Covers:
1.Response shape/contract
2. All time-range filters (All, 7D, 30D, 1Y, Custom)
3. Status distribution counts and ordering
4. Average resolution time calculation (excludes still-open requests)
5.Partial query failure handling (200 + fallback) and full DB failure (500)

Run with: