### PR TITLE
Ktb2110 203 additional request fields

### DIFF
--- a/data-analytics/lambda_functions/additional_request_details.py
+++ b/data-analytics/lambda_functions/additional_request_details.py
@@ -3,6 +3,8 @@ import os
 import boto3 
 import psycopg2
 from psycopg2.extras import RealDictCursor
+import re
+
 
 
 SCHEMA_NAME = "virginia_dev_saayam_rdbms"
@@ -32,6 +34,7 @@ def get_db_connection():
     )
 
     creds = json.loads(response["Parameter"]["Value"])
+
     db_name = creds["DATABASE NAME"]
     return psycopg2.connect(
         host=creds["HOST"],
@@ -41,6 +44,11 @@ def get_db_connection():
         port=creds["PORT"],
         sslmode="require"
     )
+
+def check_if_datetime(value: str) -> bool:
+    # Simple regex for basic datetime format (you can adjust this as needed)
+    datetime_pattern = re.compile(r'^\d{4}-\d{2}-\d{2}T')
+    return bool(datetime_pattern.match(value))
 
 def fetch_additional_request_info(cursor, request_id):
 
@@ -58,20 +66,67 @@ def fetch_additional_request_info(cursor, request_id):
 
     for row in rows:
         if row['field_id'] in response:
+            # field_id already exists — append or extend the existing entry
             if row['item_id'] and not row['field_value']:
+                # Radio/checkbox: another selection for the same field, append to list
                 response[row['field_id']].append(row['item_id'])
             elif row['item_id'] and row['field_value']:
-                response[row['field_id']][row['item_id']] = row['field_value']
+                if check_if_datetime(row['field_value']):
+                    # Date&time with item_id: add _date and _time keys to existing dict
+                    date = row['field_value'].split('T')[0]
+                    time = row['field_value'].split('T')[1]
+                    date_key = f"{row['item_id']}_date"
+                    time_key = f"{row['item_id']}_time"
+                    response[row['field_id']][date_key] = date
+                    response[row['field_id']][time_key] = time
+                else:
+                    # Non-datetime with item_id: add item_id → field_value to existing dict
+                    response[row['field_id']][row['item_id']] = row['field_value']
             elif not row['item_id'] and row['field_value']:
-                response[row['field_id']] = row['field_value']
+                if check_if_datetime(row['field_value']):
+                    # Date&time with no item_id: use field_id as key prefix
+                    date = row['field_value'].split('T')[0]
+                    time = row['field_value'].split('T')[1]
+
+                    date_key = f"{row['field_id']}_date"
+                    time_key = f"{row['field_id']}_time"
+
+                    response[row['field_id']][date_key] = date
+                    response[row['field_id']][time_key] = time
+                else:
+                    # Textbox: overwrite with new value (same field_id, no item_id — shouldn't repeat but just in case)
+                    response[row['field_id']] = row['field_value']
         else:
+            # field_id not yet in response — create the entry
             if row['item_id'] and not row['field_value']:
+                # Radio/checkbox: start a new list with this item_id
                 response[row['field_id']] = [row['item_id']]
             elif row['item_id'] and row['field_value']:
-                response[row['field_id']] = {row['item_id']: row['field_value']}
+                if check_if_datetime(row['field_value']):
+                    # Date&time with item_id: create dict with _date and _time keys
+                    date = row['field_value'].split('T')[0]
+                    time = row['field_value'].split('T')[1]
+
+                    date_key = f"{row['item_id']}_date"
+                    time_key = f"{row['item_id']}_time"
+
+                    response[row['field_id']] = {date_key: date, time_key: time}
+                else:
+                    # Non-datetime with item_id: create dict with item_id → field_value
+                    response[row['field_id']] = {row['item_id']: row['field_value']}
             elif not row['item_id'] and row['field_value']:
-                response[row['field_id']] = row['field_value']
-    
+                if check_if_datetime(row['field_value']):
+                    # Date&time with no item_id: use field_id as key prefix
+                    date = row['field_value'].split('T')[0]
+                    time = row['field_value'].split('T')[1]
+
+                    date_key = f"{row['field_id']}_date"
+                    time_key = f"{row['field_id']}_time"
+
+                    response[row['field_id']] = {date_key: date, time_key: time}
+                else:
+                    response[row['field_id']] = row['field_value']
+
     return response
 
 
@@ -80,6 +135,9 @@ def lambda_handler(event, context):
     cursor = None
     request_id = event.get("request_id")
     full_response = get_default_response(request_id)
+
+    if not request_id:
+        return build_response(400, {"error": "DE 1002: Internal Server Error"})
 
     try:
         conn = get_db_connection()
@@ -91,7 +149,7 @@ def lambda_handler(event, context):
 
         except Exception as error:
             print(f"Additional request info query failed: {error}")
-            full_response["additionalFields"] = {}
+            return build_response(500, {"error": "DE 1001: Internal Server Error"})
 
         return build_response(200, full_response)
 
@@ -107,6 +165,7 @@ def lambda_handler(event, context):
 
 
 if __name__ == "__main__":
-    result_default = lambda_handler({}, None)
-    print(json.dumps(result_default, indent=2))
+    result = lambda_handler({"request_id": "test-request-id"}, None)
+    print(json.dumps(result, indent=2))
+
 

--- a/data-analytics/lambda_functions/additional_request_details.py
+++ b/data-analytics/lambda_functions/additional_request_details.py
@@ -1,0 +1,101 @@
+import json
+import os
+import boto3 
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+
+SCHEMA_NAME = "virginia_dev_saayam_rdbms"
+
+
+def get_default_response(request_id):
+    return {"request_id": request_id,
+        "add_info": []
+    }
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*"
+        },
+        "body": json.dumps(body, default=str)
+    }
+
+def get_db_connection():
+    ssm = boto3.client("ssm", region_name="us-east-1")
+
+    response = ssm.get_parameter(
+    Name="/dev/saayam/db/Virginia/Analytics/user",
+    WithDecryption=True
+    )
+
+    creds = json.loads(response["Parameter"]["Value"])
+    db_name = creds["DATABASE NAME"]
+    return psycopg2.connect(
+        host=creds["HOST"],
+        database=db_name,
+        user=creds["USERNAME"],
+        password=creds["PASSWORD"],
+        port=creds["PORT"],
+        sslmode="require"
+    )
+
+def fetch_additional_request_info(cursor, request_id):
+
+    query = f"""
+        SELECT *
+        FROM {SCHEMA_NAME}.req_add_info r
+        WHERE r.req_id = %s
+    """
+
+    cursor.execute(query, (request_id,))
+    rows = cursor.fetchall()
+
+
+    return [
+        {
+            "field_id": row["field_id"],
+            "item_id": row["item_id"],
+            "field_value": row["field_value"]
+        }
+        for row in rows
+    ]
+
+
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+    request_id = event.get("request_id")
+    full_response = get_default_response(request_id)
+
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+        try:
+            response = fetch_additional_request_info(cursor, request_id)
+            full_response["add_info"] = response
+
+        except Exception as error:
+            print(f"Additional request info query failed: {error}")
+            full_response["add_info"] = []
+
+        return build_response(200, full_response)
+
+    except Exception as error:
+        print(f"DB connection failed: {error}")
+        return build_response(500, {"error": "DE 1000: Internal Server Error"})
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+
+if __name__ == "__main__":
+    result_default = lambda_handler({}, None)
+    print(json.dumps(result_default, indent=2))
+

--- a/data-analytics/lambda_functions/additional_request_details.py
+++ b/data-analytics/lambda_functions/additional_request_details.py
@@ -9,8 +9,8 @@ SCHEMA_NAME = "virginia_dev_saayam_rdbms"
 
 
 def get_default_response(request_id):
-    return {"request_id": request_id,
-        "add_info": []
+    return {"requestId": request_id,
+        "additionalFields": {}
     }
 
 def build_response(status_code, body):
@@ -54,14 +54,25 @@ def fetch_additional_request_info(cursor, request_id):
     rows = cursor.fetchall()
 
 
-    return [
-        {
-            "field_id": row["field_id"],
-            "item_id": row["item_id"],
-            "field_value": row["field_value"]
-        }
-        for row in rows
-    ]
+    response = {}
+
+    for row in rows:
+        if row['field_id'] in response:
+            if row['item_id'] and not row['field_value']:
+                response[row['field_id']].append(row['item_id'])
+            elif row['item_id'] and row['field_value']:
+                response[row['field_id']][row['item_id']] = row['field_value']
+            elif not row['item_id'] and row['field_value']:
+                response[row['field_id']] = row['field_value']
+        else:
+            if row['item_id'] and not row['field_value']:
+                response[row['field_id']] = [row['item_id']]
+            elif row['item_id'] and row['field_value']:
+                response[row['field_id']] = {row['item_id']: row['field_value']}
+            elif not row['item_id'] and row['field_value']:
+                response[row['field_id']] = row['field_value']
+    
+    return response
 
 
 def lambda_handler(event, context):
@@ -76,11 +87,11 @@ def lambda_handler(event, context):
 
         try:
             response = fetch_additional_request_info(cursor, request_id)
-            full_response["add_info"] = response
+            full_response["additionalFields"] = response
 
         except Exception as error:
             print(f"Additional request info query failed: {error}")
-            full_response["add_info"] = []
+            full_response["additionalFields"] = {}
 
         return build_response(200, full_response)
 


### PR DESCRIPTION
## Summary

This PR implements the `additional_request_details` Lambda function for the Request Details tab. The frontend passes a `request_id` and the Lambda queries `req_add_info` in Virginia RDS and returns all additional fields for that request, grouped and structured by field type.

## What was built

**New file:** `data-analytics/lambda_functions/additional_request_details.py`

Modelled after the existing `kpi_api_analytics.py` structure with:
- AWS SSM Parameter Store for DB credentials (no hardcoded values)
- `RealDictCursor` for named column access
- `build_response()` helper for consistent HTTP response format
- `finally` block to guarantee DB connection cleanup

## Field value mapping logic

The core of this Lambda is a loop that groups rows from `req_add_info` by `field_id` and maps them differently based on the `item_id` / `field_value` combination:

| `item_id` | `field_value` | Output |
|---|---|---|
| not null | null | `"field_id": ["item_id1", "item_id2"]` |
| not null | not null (non-datetime) | `"field_id": {"item_id1": "val1", "item_id2": "val2"}` |
| null | not null (non-datetime) | `"field_id": "field_value"` |
| not null | not null (datetime) | `"field_id": {"item_id_date": "...", "item_id_time": "..."}` |
| null | not null (datetime) | `"field_id": {"field_id_date": "...", "field_id_time": "..."}` |

## Date & time bifurcation

Date fields are detected dynamically using regex `^\d{4}-\d{2}-\d{2}T` on `field_value` — no field IDs are hardcoded. When matched, the value is split on `T` into `_date` and `_time` keys. If `item_id` is present, it is used as the key prefix; if null, `field_id` is used as the prefix.

## Error handling

| Scenario | Status Code | Error Code |
|---|---|---|
| DB connection failure | `500` | `DE 1000` |
| Query execution failure | `500` | `DE 1001` |
| Missing `request_id` in payload | `400` | `DE 1002` |
| `request_id` not found in DB | `200` | empty `additionalFields: {}` |

Error codes avoid leaking internal DB details to the browser.

## Testing

Tested locally against `req_add_info.csv` loaded into `saayam_local` PostgreSQL. Verified all field type combinations including:
- Multi-select checkboxes (multiple item_ids under same field_id)
- Textbox fields (null item_id, direct field_value mapping)
- Date&time fields with item_id (`6.1.B` — PREFERRED_MOVE_OUT_DATE)
- Date&time fields without item_id (`3.7.B`)
- Mixed field types in the same request

Closes #203
