### PR TITLE
Add date filter support to KPI Analytics API

### DIFF
--- a/data-analytics/lambda_functions/kpi_api_analytics.py
+++ b/data-analytics/lambda_functions/kpi_api_analytics.py
@@ -1,6 +1,6 @@
 import json
 import os
-import boto3 
+import boto3
 import psycopg2
 from psycopg2.extras import RealDictCursor
 
@@ -35,11 +35,30 @@ def build_response(status_code, body):
     }
 
 def get_db_connection():
+    """
+    Returns a psycopg2 connection to the Virginia RDS PostgreSQL database.
+
+    Local testing path: set LOCAL_DB=true and supply connection details via
+    environment variables (e.g. a .env file that is NOT committed). No
+    production credentials are ever hardcoded here.
+
+    Production/dev path (default): credentials are pulled from AWS SSM
+    Parameter Store, as before.
+    """
+    if os.environ.get("LOCAL_DB", "false").lower() == "true":
+        return psycopg2.connect(
+            host=os.environ.get("LOCAL_DB_HOST", "localhost"),
+            port=int(os.environ.get("LOCAL_DB_PORT", "5432")),
+            database=os.environ.get("LOCAL_DB_NAME", "saayam"),
+            user=os.environ.get("LOCAL_DB_USER", "postgres"),
+            password=os.environ.get("LOCAL_DB_PASSWORD", ""),
+        )
+
     ssm = boto3.client("ssm", region_name="us-east-1")
 
     response = ssm.get_parameter(
-    Name="/dev/saayam/db/Virginia/Analytics/user",
-    WithDecryption=True
+        Name="/dev/saayam/db/Virginia/Analytics/user",
+        WithDecryption=True
     )
 
     creds = json.loads(response["Parameter"]["Value"])
@@ -53,25 +72,41 @@ def get_db_connection():
         sslmode="require"
     )
 
+
 def build_date_filter(time_range, start_date=None, end_date=None):
-    sql_date_condition = ""
-    sql_params = ()
+    """
+    Builds the SQL date-filter condition (against r.submission_date) and its
+    query parameters for the given time_range. Meant to be spliced directly
+    into a WHERE/AND clause. Never interpolates start_date/end_date directly
+    into the SQL string - they are always passed back as bind params.
 
-    if time_range == "Custom" and start_date and end_date:
-        sql_date_condition = f"r.submission_date BETWEEN %s AND %s"
-        sql_params = (start_date, end_date)
-    elif time_range == "7D":
-        sql_date_condition = "r.submission_date >= CURRENT_DATE - INTERVAL '7 days'"
-    elif time_range == "30D":
-        sql_date_condition = "r.submission_date >= CURRENT_DATE - INTERVAL '30 days'"
-    elif time_range == "1Y":
-        sql_date_condition = "r.submission_date >= CURRENT_DATE - INTERVAL '1 year'"
-    
-    return sql_date_condition, sql_params
+    Returns a tuple (sql_condition, params):
+        - sql_condition is "1=1" (a no-op filter) when no filter should be
+          applied (time_range "All", an unrecognized value, or an incomplete
+          "Custom" range), so callers can always splice it in unconditionally.
+        - params is a list of values to bind to any %s placeholders.
+    """
+    if time_range == "7D":
+        return "r.submission_date >= CURRENT_DATE - INTERVAL '7 days'", []
 
-def fetch_request_status_distribution(cursor, time_range="All", start_date=None, end_date=None):
-    date_filter, params = build_date_filter(time_range, start_date, end_date)
-    date_filter_clause = f"WHERE {date_filter}" if date_filter else ""
+    if time_range == "30D":
+        return "r.submission_date >= CURRENT_DATE - INTERVAL '30 days'", []
+
+    if time_range == "1Y":
+        return "r.submission_date >= CURRENT_DATE - INTERVAL '1 year'", []
+
+    if time_range == "Custom":
+        if start_date and end_date:
+            return "r.submission_date BETWEEN %s AND %s", [start_date, end_date]
+        print("Custom time_range requested without both start_date and end_date; no date filter applied")
+        return "1=1", []
+
+    # "All" (default) or any unrecognized value -> no filter
+    return "1=1", []
+
+
+def fetch_request_status_distribution(cursor, time_range, start_date=None, end_date=None):
+    date_condition, params = build_date_filter(time_range, start_date, end_date)
 
     query = f"""
         SELECT
@@ -80,7 +115,7 @@ def fetch_request_status_distribution(cursor, time_range="All", start_date=None,
         FROM {SCHEMA_NAME}.request r
         JOIN {SCHEMA_NAME}.request_status rs
             ON r.req_status_id = rs.req_status_id
-        {date_filter_clause}
+        WHERE {date_condition}
         GROUP BY rs.req_status
         ORDER BY rs.req_status;
     """
@@ -96,14 +131,13 @@ def fetch_request_status_distribution(cursor, time_range="All", start_date=None,
         for row in rows
     ]
 
-def fetch_total_requests(cursor, time_range="All", start_date=None, end_date=None):
-    date_filter, params = build_date_filter(time_range, start_date, end_date)
-    date_filter_clause = f"WHERE {date_filter}" if date_filter else ""
+def fetch_total_requests(cursor, time_range, start_date=None, end_date=None):
+    date_condition, params = build_date_filter(time_range, start_date, end_date)
 
     query = f"""
         SELECT COUNT(r.req_id) AS total_requests
         FROM {SCHEMA_NAME}.request r
-        {date_filter_clause};
+        WHERE {date_condition};
     """
 
     cursor.execute(query, params)
@@ -112,9 +146,8 @@ def fetch_total_requests(cursor, time_range="All", start_date=None, end_date=Non
     return int(row["total_requests"]) if row and row["total_requests"] is not None else 0
 
 
-def fetch_average_resolution_time_by_category(cursor, time_range="All", start_date=None, end_date=None):
-    date_filter, params = build_date_filter(time_range, start_date, end_date)
-    date_filter_clause = f"AND {date_filter}" if date_filter else ""
+def fetch_average_resolution_time_by_category(cursor, time_range, start_date=None, end_date=None):
+    date_condition, params = build_date_filter(time_range, start_date, end_date)
 
     query = f"""
         SELECT
@@ -134,7 +167,7 @@ def fetch_average_resolution_time_by_category(cursor, time_range="All", start_da
           AND r.serviced_date IS NOT NULL
           AND r.serviced_date >= r.submission_date
           AND UPPER(rs.req_status) IN ('COMPLETED', 'RESOLVED')
-          {date_filter_clause}
+          AND {date_condition}
         GROUP BY hc.cat_name
         ORDER BY avg_hours DESC;
     """
@@ -154,29 +187,36 @@ def lambda_handler(event, context):
     conn = None
     cursor = None
     response_body = get_default_response()
-    
+
+    event = event or {}
     time_range = event.get("time_range", "All")
-    start_date = event.get("start_date", None)
-    end_date = event.get("end_date", None)
+    start_date = event.get("start_date")
+    end_date = event.get("end_date")
 
     try:
         conn = get_db_connection()
         cursor = conn.cursor(cursor_factory=RealDictCursor)
 
         try:
-            response_body["request_status_distribution"] = fetch_request_status_distribution(cursor, time_range, start_date, end_date)
+            response_body["request_status_distribution"] = fetch_request_status_distribution(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Status distribution query failed: {error}")
             response_body["request_status_distribution"] = []
 
         try:
-            response_body["total_requests"] = fetch_total_requests(cursor, time_range, start_date, end_date)
+            response_body["total_requests"] = fetch_total_requests(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Total request count query failed: {error}")
             response_body["total_requests"] = 0
 
         try:
-            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(cursor, time_range, start_date, end_date)
+            response_body["average_resolution_time_by_category"] = fetch_average_resolution_time_by_category(
+                cursor, time_range, start_date, end_date
+            )
         except Exception as error:
             print(f"Average resolution time query failed: {error}")
             response_body["average_resolution_time_by_category"] = []
@@ -195,6 +235,19 @@ def lambda_handler(event, context):
 
 
 if __name__ == "__main__":
-    result_default = lambda_handler({}, None)
-    print(json.dumps(result_default, indent=2))
+    # Local run: set LOCAL_DB=true (plus LOCAL_DB_HOST/PORT/NAME/USER/PASSWORD
+    # env vars pointing at a local Postgres loaded with the real schema) before
+    # running `python kpi_api_analytics.py`.
+    test_events = [
+        {},
+        {"time_range": "7D"},
+        {"time_range": "30D"},
+        {"time_range": "1Y"},
+        {"time_range": "All"},
+        {"time_range": "Custom", "start_date": "2026-05-01", "end_date": "2026-05-31"},
+    ]
 
+    for test_event in test_events:
+        print(f"--- Testing payload: {test_event} ---")
+        result = lambda_handler(test_event, None)
+        print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary
Adds date filter support (7D / 30D / 1Y / All / Custom) to the KPI Analytics API — request status distribution, total requests, and average resolution time by category.

## Changes
- Added `build_date_filter()` helper function.
- Updated `fetch_request_status_distribution()`, `fetch_total_requests()`, and `fetch_average_resolution_time_by_category()` to accept and apply `time_range`/`start_date`/`end_date`.
- Updated `lambda_handler()` to read `time_range`/`start_date`/`end_date` from the event payload and pass them through.
- Added a local-testing path to `get_db_connection()` (`LOCAL_DB` env var, same convention as #179) — no credentials hardcoded.

## Testing
Verified locally against Postgres loaded with `local_test_seed.sql` — all time ranges (7D/30D/1Y/All/Custom) return correct totals, status distributions, and avg resolution times, matching hand-calculated expected values.