### PR TITLE
#228: Organization Analytics API (finalized dashboard requirements)

### DIFF
--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,793 @@
+"""
+Organization Analytics API
+
+Provides the data backing the Saayam "Organization Dashboard":
+  1. Organization Overview Dashboard  -> get_organization_overview()
+  2. Organization Performance Dashboard -> get_organization_performance()
+
+Source table: virginia_dev_saayam_rdbms.organizations
+Reference:    virginia_dev_saayam_rdbms.state
+
+Follows the same structure/coding standards used by the existing
+Volunteer, Beneficiary, and KPI analytics lambda functions in this folder:
+  - a single Virginia RDS connection pulled from SSM
+  - small `fetch_*` functions, one per metric, each returning plain
+    dict/list structures that map 1:1 onto the JSON response
+  - every metric fetch is wrapped in its own try/except in the handler
+    so a single failing query never breaks the whole dashboard response
+  - a `__main__` block that runs the module against a local Postgres
+    instance for manual/local testing (see bottom of file)
+
+NOTE on `is_contributor`:
+  The `organizations` table (see database/ddl/Tables/ddl_organizations.sql)
+  currently only has `is_collaborator`. The dashboard spec (issue #228)
+  additionally asks for a "Contributor" split. Until an `is_contributor`
+  column is added to the table via a migration, every contributor-related
+  fetch function below is isolated behind its own try/except and will
+  degrade gracefully to empty/zeroed results instead of failing the whole
+  request. Once the column exists, no code changes are required.
+"""
+
+import json
+import boto3
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+
+SCHEMA_NAME = "virginia_dev_saayam_rdbms"
+ORGANIZATIONS_TABLE = f"{SCHEMA_NAME}.organizations"
+STATE_TABLE = f"{SCHEMA_NAME}.state"
+
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+GROUP_BY_TRUNC = {
+    "daily": "day",
+    "weekly": "week",
+    "monthly": "month",
+    "yearly": "year",
+}
+GROUP_BY_FORMAT = {
+    "daily": "YYYY-MM-DD",
+    "weekly": "YYYY-MM-DD",
+    "monthly": "YYYY-MM",
+    "yearly": "YYYY",
+}
+
+TOP_N_DEFAULT = 10
+
+
+def safe_rollback(cursor):
+    """
+    Rolls back the current transaction on `cursor`'s connection.
+    Needed because Postgres aborts the whole transaction after a failed
+    statement (e.g. a query referencing a column that doesn't exist yet,
+    such as `is_contributor`) -- without a rollback, every subsequent
+    query on that same connection would fail too, even unrelated ones.
+    """
+    try:
+        cursor.connection.rollback()
+    except Exception as rollback_error:
+        print(f"rollback failed: {rollback_error}")
+
+
+# ---------------------------------------------------------------------------
+# Response / connection helpers (mirrors kpi_api_analytics.py)
+# ---------------------------------------------------------------------------
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+        },
+        "body": json.dumps(body, default=str),
+    }
+
+
+def get_db_connection():
+    ssm = boto3.client("ssm", region_name="us-east-1")
+
+    response = ssm.get_parameter(
+        Name="/dev/saayam/db/Virginia/Analytics/user",
+        WithDecryption=True,
+    )
+
+    creds = json.loads(response["Parameter"]["Value"])
+    db_name = creds["DATABASE NAME"]
+    return psycopg2.connect(
+        host=creds["HOST"],
+        database=db_name,
+        user=creds["USERNAME"],
+        password=creds["PASSWORD"],
+        port=creds["PORT"],
+        sslmode="require",
+    )
+
+
+def parse_event_body(event):
+    if not event:
+        return {}
+    body = event.get("body")
+    if body is None:
+        return event
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+    if isinstance(body, dict):
+        return body
+    return {}
+
+
+def get_default_overview_response():
+    return {
+        "organization_overview": {
+            "summary": {
+                "total_organizations": 0,
+                "non_profit_organizations": 0,
+                "for_profit_organizations": 0,
+                "collaborator_organizations": 0,
+                "non_collaborator_organizations": 0,
+                "contributor_organizations": 0,
+                "non_contributor_organizations": 0,
+            },
+            "organization_activity_trend": [],
+            "organizations_by_type": [],
+            "organizations_by_size": [],
+            "organizations_by_location": [],
+            "collaborator_distribution": [],
+            "contributor_distribution": [],
+        }
+    }
+
+
+def get_default_performance_response():
+    return {
+        "organization_performance": {
+            "summary": {
+                "average_rating": 0,
+                "rated_organizations": 0,
+                "unrated_organizations": 0,
+                "five_star_organizations": 0,
+            },
+            "rating_distribution": [],
+            "top_rated_organizations": [],
+            "top_collaborator_organizations": [],
+            "top_contributor_organizations": [],
+            "ratings_by_organization_type": [],
+            "ratings_by_organization_size": [],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filter helpers
+# ---------------------------------------------------------------------------
+
+def build_date_filter(time_filter, start_date=None, end_date=None, column="o.created_at"):
+    """
+    Returns (sql_condition, params_tuple) for the registration-date filter.
+
+    time_filter values: "7D", "30D", "1Y", "ALL", "CUSTOM"
+    """
+    time_filter = (time_filter or "ALL").upper()
+
+    if time_filter == "CUSTOM" and start_date and end_date:
+        return f"{column} BETWEEN %s AND %s", (start_date, end_date)
+    elif time_filter == "7D":
+        return f"{column} >= CURRENT_DATE - INTERVAL '7 days'", ()
+    elif time_filter == "30D":
+        return f"{column} >= CURRENT_DATE - INTERVAL '30 days'", ()
+    elif time_filter == "1Y":
+        return f"{column} >= CURRENT_DATE - INTERVAL '1 year'", ()
+    else:
+        # "ALL" or unrecognized -> no date filter
+        return "", ()
+
+
+def build_common_filters(filters):
+    """
+    Builds SQL conditions + params from the shared filter set described in
+    issue #228 ("Common Filters for Both Dashboards"):
+        org_type, org_size, state_id, city_name, org_rating,
+        is_collaborator, is_contributor, time_filter/start_date/end_date.
+
+    `is_contributor` is intentionally left out of the WHERE clause here
+    (see module docstring) and is applied only by the isolated contributor
+    fetch functions, guarded by their own try/except.
+    """
+    conditions = []
+    params = []
+
+    org_type = filters.get("org_type")
+    if org_type:
+        conditions.append("o.org_type = %s::org_type_enum")
+        params.append(org_type)
+
+    org_size = filters.get("org_size")
+    if org_size:
+        conditions.append("o.org_size = %s::org_size_enum")
+        params.append(org_size)
+
+    state_id = filters.get("state_id")
+    if state_id:
+        conditions.append("o.state_id = %s")
+        params.append(state_id)
+
+    city_name = filters.get("city_name")
+    if city_name:
+        conditions.append("o.city_name = %s")
+        params.append(city_name)
+
+    org_rating = filters.get("org_rating")
+    if org_rating is not None:
+        conditions.append("o.org_rating = %s")
+        params.append(org_rating)
+
+    is_collaborator = filters.get("is_collaborator")
+    if is_collaborator is not None:
+        conditions.append("o.is_collaborator = %s")
+        params.append(bool(is_collaborator))
+
+    date_condition, date_params = build_date_filter(
+        filters.get("time_filter", "ALL"),
+        filters.get("start_date"),
+        filters.get("end_date"),
+    )
+    if date_condition:
+        conditions.append(date_condition)
+        params.extend(date_params)
+
+    return conditions, params
+
+
+def where_clause(conditions):
+    return f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+
+def get_group_by_unit(group_by):
+    group_by = (group_by or "daily").lower()
+    if group_by not in GROUP_BY_TRUNC:
+        group_by = "daily"
+    return GROUP_BY_TRUNC[group_by], GROUP_BY_FORMAT[group_by]
+
+
+# ---------------------------------------------------------------------------
+# Dashboard 1: Organization Overview
+# ---------------------------------------------------------------------------
+
+def fetch_overview_summary(cursor, filters):
+    """total / org_type / collaborator counts (always present in schema)."""
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COUNT(*) AS total_organizations,
+            COUNT(*) FILTER (WHERE o.org_type = 'non_profit') AS non_profit_organizations,
+            COUNT(*) FILTER (WHERE o.org_type = 'for_profit') AS for_profit_organizations,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborator_organizations,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS NOT TRUE) AS non_collaborator_organizations
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)};
+    """
+    cursor.execute(query, params)
+    row = cursor.fetchone()
+    return {
+        "total_organizations": int(row["total_organizations"] or 0),
+        "non_profit_organizations": int(row["non_profit_organizations"] or 0),
+        "for_profit_organizations": int(row["for_profit_organizations"] or 0),
+        "collaborator_organizations": int(row["collaborator_organizations"] or 0),
+        "non_collaborator_organizations": int(row["non_collaborator_organizations"] or 0),
+    }
+
+
+def fetch_contributor_summary(cursor, filters):
+    """
+    Isolated so a missing `is_contributor` column only zeroes out this
+    piece of the summary instead of failing the whole overview dashboard.
+    """
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COUNT(*) FILTER (WHERE o.is_contributor IS TRUE) AS contributor_organizations,
+            COUNT(*) FILTER (WHERE o.is_contributor IS NOT TRUE) AS non_contributor_organizations
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)};
+    """
+    cursor.execute(query, params)
+    row = cursor.fetchone()
+    return {
+        "contributor_organizations": int(row["contributor_organizations"] or 0),
+        "non_contributor_organizations": int(row["non_contributor_organizations"] or 0),
+    }
+
+
+def fetch_organization_activity_trend(cursor, filters):
+    """Registration trend, grouped daily/weekly/monthly/yearly."""
+    conditions, params = build_common_filters(filters)
+    trunc_unit, fmt = get_group_by_unit(filters.get("group_by"))
+
+    query = f"""
+        SELECT
+            TO_CHAR(DATE_TRUNC('{trunc_unit}', o.created_at), '{fmt}') AS period,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY DATE_TRUNC('{trunc_unit}', o.created_at)
+        ORDER BY DATE_TRUNC('{trunc_unit}', o.created_at);
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [{"period": row["period"], "count": int(row["count"])} for row in rows]
+
+
+def fetch_organizations_by_type(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COALESCE(o.org_type::text, 'unknown') AS org_type,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY o.org_type
+        ORDER BY count DESC;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [{"org_type": row["org_type"], "count": int(row["count"])} for row in rows]
+
+
+def fetch_organizations_by_size(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COALESCE(o.org_size::text, 'unknown') AS org_size,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY o.org_size
+        ORDER BY count DESC;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [{"org_size": row["org_size"], "count": int(row["count"])} for row in rows]
+
+
+def fetch_organizations_by_location(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COALESCE(s.state_name, o.state_id, 'Unknown') AS state,
+            COALESCE(o.city_name, 'Unknown') AS city,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        LEFT JOIN {STATE_TABLE} s ON o.state_id = s.state_id
+        {where_clause(conditions)}
+        GROUP BY COALESCE(s.state_name, o.state_id, 'Unknown'), COALESCE(o.city_name, 'Unknown')
+        ORDER BY count DESC;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [
+        {"state": row["state"], "city": row["city"], "count": int(row["count"])}
+        for row in rows
+    ]
+
+
+def fetch_collaborator_distribution(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            CASE WHEN o.is_collaborator IS TRUE THEN 'collaborator' ELSE 'non_collaborator' END AS category,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY 1
+        ORDER BY 1;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [{"category": row["category"], "count": int(row["count"])} for row in rows]
+
+
+def fetch_contributor_distribution(cursor, filters):
+    """Isolated for the same `is_contributor` reason as fetch_contributor_summary."""
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            CASE WHEN o.is_contributor IS TRUE THEN 'contributor' ELSE 'non_contributor' END AS category,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY 1
+        ORDER BY 1;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [{"category": row["category"], "count": int(row["count"])} for row in rows]
+
+
+def get_organization_overview(cursor, filters):
+    response = get_default_overview_response()["organization_overview"]
+
+    try:
+        response["summary"].update(fetch_overview_summary(cursor, filters))
+    except Exception as error:
+        print(f"[overview] summary query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["summary"].update(fetch_contributor_summary(cursor, filters))
+    except Exception as error:
+        print(f"[overview] contributor summary query failed (is_contributor column may not exist yet): {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["organization_activity_trend"] = fetch_organization_activity_trend(cursor, filters)
+    except Exception as error:
+        print(f"[overview] activity trend query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["organizations_by_type"] = fetch_organizations_by_type(cursor, filters)
+    except Exception as error:
+        print(f"[overview] organizations_by_type query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["organizations_by_size"] = fetch_organizations_by_size(cursor, filters)
+    except Exception as error:
+        print(f"[overview] organizations_by_size query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["organizations_by_location"] = fetch_organizations_by_location(cursor, filters)
+    except Exception as error:
+        print(f"[overview] organizations_by_location query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["collaborator_distribution"] = fetch_collaborator_distribution(cursor, filters)
+    except Exception as error:
+        print(f"[overview] collaborator_distribution query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["contributor_distribution"] = fetch_contributor_distribution(cursor, filters)
+    except Exception as error:
+        print(f"[overview] contributor_distribution query failed (is_contributor column may not exist yet): {error}")
+        safe_rollback(cursor)
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Dashboard 2: Organization Performance
+# ---------------------------------------------------------------------------
+
+def fetch_performance_summary(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_organizations,
+            COUNT(*) FILTER (WHERE o.org_rating IS NULL) AS unrated_organizations,
+            COUNT(*) FILTER (WHERE o.org_rating = 5) AS five_star_organizations
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)};
+    """
+    cursor.execute(query, params)
+    row = cursor.fetchone()
+    return {
+        "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
+        "rated_organizations": int(row["rated_organizations"] or 0),
+        "unrated_organizations": int(row["unrated_organizations"] or 0),
+        "five_star_organizations": int(row["five_star_organizations"] or 0),
+    }
+
+
+def fetch_rating_distribution(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            o.org_rating AS rating,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY o.org_rating
+        ORDER BY o.org_rating NULLS LAST;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [
+        {"rating": row["rating"], "count": int(row["count"])}
+        for row in rows
+    ]
+
+
+def fetch_top_rated_organizations(cursor, filters, limit=TOP_N_DEFAULT):
+    conditions, params = build_common_filters(filters)
+    conditions = conditions + ["o.org_rating IS NOT NULL"]
+    query = f"""
+        SELECT
+            o.org_id,
+            o.org_name,
+            o.org_type::text AS org_type,
+            o.org_size::text AS org_size,
+            o.org_rating,
+            o.city_name,
+            o.state_id
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        ORDER BY o.org_rating DESC, o.org_name ASC
+        LIMIT %s;
+    """
+    cursor.execute(query, params + [limit])
+    rows = cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+def fetch_top_collaborator_organizations(cursor, filters, limit=TOP_N_DEFAULT):
+    conditions, params = build_common_filters(filters)
+    conditions = conditions + ["o.is_collaborator IS TRUE"]
+    query = f"""
+        SELECT
+            o.org_id,
+            o.org_name,
+            o.org_type::text AS org_type,
+            o.org_size::text AS org_size,
+            o.org_rating,
+            o.city_name,
+            o.state_id
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        ORDER BY o.org_rating DESC NULLS LAST, o.org_name ASC
+        LIMIT %s;
+    """
+    cursor.execute(query, params + [limit])
+    rows = cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+def fetch_top_contributor_organizations(cursor, filters, limit=TOP_N_DEFAULT):
+    """Isolated: relies on the not-yet-existing `is_contributor` column."""
+    conditions, params = build_common_filters(filters)
+    conditions = conditions + ["o.is_contributor IS TRUE"]
+    query = f"""
+        SELECT
+            o.org_id,
+            o.org_name,
+            o.org_type::text AS org_type,
+            o.org_size::text AS org_size,
+            o.org_rating,
+            o.city_name,
+            o.state_id
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        ORDER BY o.org_rating DESC NULLS LAST, o.org_name ASC
+        LIMIT %s;
+    """
+    cursor.execute(query, params + [limit])
+    rows = cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+def fetch_ratings_by_organization_type(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COALESCE(o.org_type::text, 'unknown') AS org_type,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY o.org_type
+        ORDER BY average_rating DESC NULLS LAST;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [
+        {
+            "org_type": row["org_type"],
+            "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
+            "rated_count": int(row["rated_count"] or 0),
+        }
+        for row in rows
+    ]
+
+
+def fetch_ratings_by_organization_size(cursor, filters):
+    conditions, params = build_common_filters(filters)
+    query = f"""
+        SELECT
+            COALESCE(o.org_size::text, 'unknown') AS org_size,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY o.org_size
+        ORDER BY average_rating DESC NULLS LAST;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [
+        {
+            "org_size": row["org_size"],
+            "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
+            "rated_count": int(row["rated_count"] or 0),
+        }
+        for row in rows
+    ]
+
+
+def get_organization_performance(cursor, filters):
+    response = get_default_performance_response()["organization_performance"]
+
+    try:
+        response["summary"].update(fetch_performance_summary(cursor, filters))
+    except Exception as error:
+        print(f"[performance] summary query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["rating_distribution"] = fetch_rating_distribution(cursor, filters)
+    except Exception as error:
+        print(f"[performance] rating_distribution query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["top_rated_organizations"] = fetch_top_rated_organizations(cursor, filters)
+    except Exception as error:
+        print(f"[performance] top_rated_organizations query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["top_collaborator_organizations"] = fetch_top_collaborator_organizations(cursor, filters)
+    except Exception as error:
+        print(f"[performance] top_collaborator_organizations query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["top_contributor_organizations"] = fetch_top_contributor_organizations(cursor, filters)
+    except Exception as error:
+        print(f"[performance] top_contributor_organizations query failed (is_contributor column may not exist yet): {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["ratings_by_organization_type"] = fetch_ratings_by_organization_type(cursor, filters)
+    except Exception as error:
+        print(f"[performance] ratings_by_organization_type query failed: {error}")
+        safe_rollback(cursor)
+
+    try:
+        response["ratings_by_organization_size"] = fetch_ratings_by_organization_size(cursor, filters)
+    except Exception as error:
+        print(f"[performance] ratings_by_organization_size query failed: {error}")
+        safe_rollback(cursor)
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Lambda handlers
+#
+# Supports both endpoint designs suggested in issue #228:
+#   - two separate endpoints: /analytics/organizations/overview
+#                              /analytics/organizations/performance
+#     -> overview_lambda_handler / performance_lambda_handler
+#   - one endpoint + "dashboard_type": /analytics/organizations
+#     -> lambda_handler (dashboard_type: "overview" | "performance" | "both")
+# ---------------------------------------------------------------------------
+
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+
+    filters = parse_event_body(event)
+    dashboard_type = (filters.get("dashboard_type") or "overview").lower()
+
+    response_body = {}
+    if dashboard_type in ("overview", "both"):
+        response_body.update(get_default_overview_response())
+    if dashboard_type in ("performance", "both"):
+        response_body.update(get_default_performance_response())
+    if dashboard_type not in ("overview", "performance", "both"):
+        return build_response(400, {
+            "error": "Invalid dashboard_type. Expected 'overview', 'performance', or 'both'."
+        })
+
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+        if dashboard_type in ("overview", "both"):
+            response_body["organization_overview"] = get_organization_overview(cursor, filters)
+
+        if dashboard_type in ("performance", "both"):
+            response_body["organization_performance"] = get_organization_performance(cursor, filters)
+
+        return build_response(200, response_body)
+
+    except Exception as error:
+        print(f"DB connection failed: {error}")
+        return build_response(500, response_body)
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+
+def overview_lambda_handler(event, context):
+    filters = parse_event_body(event)
+    filters["dashboard_type"] = "overview"
+    return lambda_handler({"body": json.dumps(filters, default=str)}, context)
+
+
+def performance_lambda_handler(event, context):
+    filters = parse_event_body(event)
+    filters["dashboard_type"] = "performance"
+    return lambda_handler({"body": json.dumps(filters, default=str)}, context)
+
+
+# ---------------------------------------------------------------------------
+# Local testing
+#
+# Run against a local PostgreSQL instance (no AWS/SSM required):
+#
+#   export LOCAL_DB_HOST=localhost
+#   export LOCAL_DB_NAME=saayam_local
+#   export LOCAL_DB_USER=postgres
+#   export LOCAL_DB_PASSWORD=postgres
+#   export LOCAL_DB_PORT=5432
+#   python organization_analytics.py
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import os
+
+    conn = psycopg2.connect(
+        host=os.environ.get("LOCAL_DB_HOST", "localhost"),
+        database=os.environ.get("LOCAL_DB_NAME", "saayam_local"),
+        user=os.environ.get("LOCAL_DB_USER", "postgres"),
+        password=os.environ.get("LOCAL_DB_PASSWORD", "postgres"),
+        port=os.environ.get("LOCAL_DB_PORT", "5432"),
+    )
+    local_cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+    print("=" * 70)
+    print("LOCAL TESTING — organization_analytics.py")
+    print("=" * 70)
+
+    test_scenarios = [
+        ("Overview - ALL time", {"dashboard_type": "overview", "time_filter": "ALL", "group_by": "monthly"}),
+        ("Overview - 30D", {"dashboard_type": "overview", "time_filter": "30D", "group_by": "daily"}),
+        ("Overview - filtered (non_profit, VA)", {
+            "dashboard_type": "overview", "org_type": "non_profit", "state_id": "VA"
+        }),
+        ("Performance - ALL", {"dashboard_type": "performance", "time_filter": "ALL"}),
+        ("Performance - filtered (rating=5)", {"dashboard_type": "performance", "org_rating": 5}),
+        ("Both dashboards", {"dashboard_type": "both", "time_filter": "1Y", "group_by": "yearly"}),
+    ]
+
+    for label, filters in test_scenarios:
+        print(f"\n--- Scenario: {label} ---")
+        dashboard_type = filters.get("dashboard_type", "overview")
+        result = {}
+        if dashboard_type in ("overview", "both"):
+            result["organization_overview"] = get_organization_overview(local_cursor, filters)
+        if dashboard_type in ("performance", "both"):
+            result["organization_performance"] = get_organization_performance(local_cursor, filters)
+        print(json.dumps(result, indent=2, default=str))
+
+    cursor_close_ok = True
+    try:
+        local_cursor.close()
+        conn.close()
+    except Exception:
+        cursor_close_ok = False
+
+    print("\n" + "=" * 70)
+    print("LOCAL TESTING COMPLETE" if cursor_close_ok else "LOCAL TESTING COMPLETE (cleanup warning)")
+    print("=" * 70)

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,106 +1,136 @@
 """
-Organization Analytics API
+Organization Analytics API (Lambda handler)
 
-Provides the data backing the Saayam "Organization Dashboard":
-  1. Organization Overview Dashboard  -> get_organization_overview()
-  2. Organization Performance Dashboard -> get_organization_performance()
+Provides all three tabs of the Saayam "Organization Dashboard" in a single
+response from one endpoint: `POST /analytics/organizations`.
 
-Source table: virginia_dev_saayam_rdbms.organizations
-Reference:    virginia_dev_saayam_rdbms.state
+Follows the finalized dashboard requirements captured on issue #228:
+  - summary                          (4 KPI cards)
+  - growth_trend                     (org + collaborator growth over time)
+  - organizations_by_location        (state -> nested cities, with %)
+  - organizations_by_size            (small / medium / large)
+  - collaborator_vs_contributor      (counts + percentages)
+  - rating_distribution              (1-5 stars)
+  - organization_type_distribution   (for-profit vs non-profit over time)
 
-Follows the same structure/coding standards used by the existing
-Volunteer, Beneficiary, and KPI analytics lambda functions in this folder:
-  - a single Virginia RDS connection pulled from SSM
-  - small `fetch_*` functions, one per metric, each returning plain
-    dict/list structures that map 1:1 onto the JSON response
-  - every metric fetch is wrapped in its own try/except in the handler
-    so a single failing query never breaks the whole dashboard response
-  - a `__main__` block that runs the module against a local Postgres
-    instance for manual/local testing (see bottom of file)
+Connection:
+  Per the issue's explicit note, this module does NOT use AWS Systems
+  Manager Parameter Store. Credentials are read from `DATABASE_URL`, or
+  from the individual `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USER` /
+  `DB_PASSWORD` environment variables (with PG* as a fallback).
 
-NOTE on `is_contributor`:
-  The `organizations` table (see database/ddl/Tables/ddl_organizations.sql)
-  currently only has `is_collaborator`. The dashboard spec (issue #228)
-  additionally asks for a "Contributor" split. Until an `is_contributor`
-  column is added to the table via a migration, every contributor-related
-  fetch function below is isolated behind its own try/except and will
-  degrade gracefully to empty/zeroed results instead of failing the whole
-  request. Once the column exists, no code changes are required.
+State table naming:
+  `ddl_organizations.sql` declares the FK against `states` (plural), but
+  a locally-available copy of the schema may only have `state` (singular,
+  per `ddl_state.sql`) -- see the known DDL mismatch flagged on this issue.
+  The table name is configurable via `STATE_TABLE_NAME` (defaults to the
+  ticket-correct `states`) so this module works against either schema
+  without code changes.
+
+is_contributor:
+  Not guaranteed to exist yet. Rather than guessing, this module checks
+  `information_schema.columns` once per request and only includes
+  contributor counts in queries when the column is actually present.
+  When it's missing, contributor-related figures come back as `0`
+  (or `0.0%`) instead of failing the request or fabricating data.
 """
 
 import json
-import boto3
+import logging
+import os
+import re
+from datetime import date, timedelta
+from decimal import Decimal
+
 import psycopg2
 from psycopg2.extras import RealDictCursor
 
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
 
-SCHEMA_NAME = "virginia_dev_saayam_rdbms"
-ORGANIZATIONS_TABLE = f"{SCHEMA_NAME}.organizations"
-STATE_TABLE = f"{SCHEMA_NAME}.state"
+DB_SCHEMA = os.environ.get("DB_SCHEMA", "virginia_dev_saayam_rdbms")
+STATE_TABLE_NAME = os.environ.get("STATE_TABLE_NAME", "states")
+if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", DB_SCHEMA):
+    raise ValueError("DB_SCHEMA must be a valid PostgreSQL identifier")
+if STATE_TABLE_NAME not in ("state", "states"):
+    raise ValueError("STATE_TABLE_NAME must be 'state' or 'states'")
 
-VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
-GROUP_BY_TRUNC = {
-    "daily": "day",
-    "weekly": "week",
-    "monthly": "month",
-    "yearly": "year",
+ORGANIZATIONS_TABLE = f"{DB_SCHEMA}.organizations"
+STATE_TABLE = f"{DB_SCHEMA}.{STATE_TABLE_NAME}"
+
+TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+ORG_TYPES = {"for_profit", "non_profit"}
+ORG_SIZES = ["small", "medium", "large"]
+RATINGS = [1, 2, 3, 4, 5]
+
+GROUP_BY_UNITS = {
+    "daily": ("day", "YYYY-MM-DD"),
+    "weekly": ("week", 'IYYY-"W"IW'),
+    "monthly": ("month", "YYYY-MM"),
+    "yearly": ("year", "YYYY"),
 }
-GROUP_BY_FORMAT = {
-    "daily": "YYYY-MM-DD",
-    "weekly": "YYYY-MM-DD",
-    "monthly": "YYYY-MM",
-    "yearly": "YYYY",
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
 }
 
-TOP_N_DEFAULT = 10
 
-
-def safe_rollback(cursor):
-    """
-    Rolls back the current transaction on `cursor`'s connection.
-    Needed because Postgres aborts the whole transaction after a failed
-    statement (e.g. a query referencing a column that doesn't exist yet,
-    such as `is_contributor`) -- without a rollback, every subsequent
-    query on that same connection would fail too, even unrelated ones.
-    """
-    try:
-        cursor.connection.rollback()
-    except Exception as rollback_error:
-        print(f"rollback failed: {rollback_error}")
+class InvalidFilterError(ValueError):
+    """Raised when the request payload fails filter validation."""
 
 
 # ---------------------------------------------------------------------------
-# Response / connection helpers (mirrors kpi_api_analytics.py)
+# Response / connection helpers
 # ---------------------------------------------------------------------------
+
+def _json_default(value):
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
 
 def build_response(status_code, body):
     return {
         "statusCode": status_code,
-        "headers": {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*",
+        "headers": CORS_HEADERS,
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def get_default_response():
+    return {
+        "summary": {
+            "total_organizations": 0,
+            "total_collaborators": 0,
+            "total_contributors": 0,
+            "average_org_rating": 0.0,
         },
-        "body": json.dumps(body, default=str),
+        "growth_trend": [],
+        "organizations_by_location": [],
+        "organizations_by_size": [],
+        "collaborator_vs_contributor": [],
+        "rating_distribution": [],
+        "organization_type_distribution": [],
     }
 
 
 def get_db_connection():
-    ssm = boto3.client("ssm", region_name="us-east-1")
+    """Local/runtime Postgres connection only -- no AWS Parameter Store."""
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url:
+        return psycopg2.connect(database_url)
 
-    response = ssm.get_parameter(
-        Name="/dev/saayam/db/Virginia/Analytics/user",
-        WithDecryption=True,
-    )
-
-    creds = json.loads(response["Parameter"]["Value"])
-    db_name = creds["DATABASE NAME"]
     return psycopg2.connect(
-        host=creds["HOST"],
-        database=db_name,
-        user=creds["USERNAME"],
-        password=creds["PASSWORD"],
-        port=creds["PORT"],
-        sslmode="require",
+        host=os.environ.get("DB_HOST", os.environ.get("PGHOST", "localhost")),
+        dbname=os.environ.get("DB_NAME", os.environ.get("PGDATABASE", "saayam")),
+        user=os.environ.get("DB_USER", os.environ.get("PGUSER", "postgres")),
+        password=os.environ.get("DB_PASSWORD", os.environ.get("PGPASSWORD", "")),
+        port=int(os.environ.get("DB_PORT", os.environ.get("PGPORT", "5432"))),
     )
 
 
@@ -110,684 +140,519 @@ def parse_event_body(event):
     body = event.get("body")
     if body is None:
         return event
-    if isinstance(body, str):
-        try:
-            return json.loads(body)
-        except json.JSONDecodeError:
-            return {}
     if isinstance(body, dict):
         return body
-    return {}
-
-
-def get_default_overview_response():
-    return {
-        "organization_overview": {
-            "summary": {
-                "total_organizations": 0,
-                "non_profit_organizations": 0,
-                "for_profit_organizations": 0,
-                "collaborator_organizations": 0,
-                "non_collaborator_organizations": 0,
-                "contributor_organizations": 0,
-                "non_contributor_organizations": 0,
-            },
-            "organization_activity_trend": [],
-            "organizations_by_type": [],
-            "organizations_by_size": [],
-            "organizations_by_location": [],
-            "collaborator_distribution": [],
-            "contributor_distribution": [],
-        }
-    }
-
-
-def get_default_performance_response():
-    return {
-        "organization_performance": {
-            "summary": {
-                "average_rating": 0,
-                "rated_organizations": 0,
-                "unrated_organizations": 0,
-                "five_star_organizations": 0,
-            },
-            "rating_distribution": [],
-            "top_rated_organizations": [],
-            "top_collaborator_organizations": [],
-            "top_contributor_organizations": [],
-            "ratings_by_organization_type": [],
-            "ratings_by_organization_size": [],
-        }
-    }
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise InvalidFilterError("Request body must contain valid JSON") from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise InvalidFilterError("Request body must be a JSON object")
 
 
 # ---------------------------------------------------------------------------
-# Filter helpers
+# Filter validation
 # ---------------------------------------------------------------------------
 
-def build_date_filter(time_filter, start_date=None, end_date=None, column="o.created_at"):
-    """
-    Returns (sql_condition, params_tuple) for the registration-date filter.
-
-    time_filter values: "7D", "30D", "1Y", "ALL", "CUSTOM"
-    """
-    time_filter = (time_filter or "ALL").upper()
-
-    if time_filter == "CUSTOM" and start_date and end_date:
-        return f"{column} BETWEEN %s AND %s", (start_date, end_date)
-    elif time_filter == "7D":
-        return f"{column} >= CURRENT_DATE - INTERVAL '7 days'", ()
-    elif time_filter == "30D":
-        return f"{column} >= CURRENT_DATE - INTERVAL '30 days'", ()
-    elif time_filter == "1Y":
-        return f"{column} >= CURRENT_DATE - INTERVAL '1 year'", ()
-    else:
-        # "ALL" or unrecognized -> no date filter
-        return "", ()
+def _parse_iso_date(value, field_name):
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(str(value))
+    except ValueError as exc:
+        raise InvalidFilterError(f"{field_name} must use YYYY-MM-DD format") from exc
 
 
-def build_common_filters(filters):
-    """
-    Builds SQL conditions + params from the shared filter set described in
-    issue #228 ("Common Filters for Both Dashboards"):
-        org_type, org_size, state_id, city_name, org_rating,
-        is_collaborator, is_contributor, time_filter/start_date/end_date.
+def _normalize_org_type(value):
+    return re.sub(r"[\s-]+", "_", str(value).strip().lower())
 
-    `is_contributor` is intentionally left out of the WHERE clause here
-    (see module docstring) and is applied only by the isolated contributor
-    fetch functions, guarded by their own try/except.
-    """
-    conditions = []
-    params = []
 
-    org_type = filters.get("org_type")
-    if org_type:
-        conditions.append("o.org_type = %s::org_type_enum")
-        params.append(org_type)
+def validate_filters(payload):
+    time_filter = str(payload.get("time_filter", "30D") or "30D").strip().upper()
+    if time_filter not in TIME_FILTERS:
+        raise InvalidFilterError("time_filter must be one of 7D, 30D, 1Y, ALL, CUSTOM")
 
-    org_size = filters.get("org_size")
-    if org_size:
-        conditions.append("o.org_size = %s::org_size_enum")
-        params.append(org_size)
+    group_by = str(payload.get("group_by", "daily") or "daily").strip().lower()
+    if group_by not in GROUP_BY_UNITS:
+        raise InvalidFilterError("group_by must be one of daily, weekly, monthly, yearly")
 
-    state_id = filters.get("state_id")
-    if state_id:
-        conditions.append("o.state_id = %s")
-        params.append(state_id)
+    start_date = _parse_iso_date(payload.get("start_date"), "start_date")
+    end_date = _parse_iso_date(payload.get("end_date"), "end_date")
+    if time_filter == "CUSTOM":
+        if start_date is None or end_date is None:
+            raise InvalidFilterError("CUSTOM time_filter requires start_date and end_date")
+        if start_date > end_date:
+            raise InvalidFilterError("start_date cannot be after end_date")
 
-    city_name = filters.get("city_name")
-    if city_name:
-        conditions.append("o.city_name = %s")
-        params.append(city_name)
+    region = payload.get("region") or "ALL"
+    region = str(region).strip() or "ALL"
 
-    org_rating = filters.get("org_rating")
-    if org_rating is not None:
-        conditions.append("o.org_rating = %s")
-        params.append(org_rating)
-
-    is_collaborator = filters.get("is_collaborator")
-    if is_collaborator is not None:
-        conditions.append("o.is_collaborator = %s")
-        params.append(bool(is_collaborator))
-
-    date_condition, date_params = build_date_filter(
-        filters.get("time_filter", "ALL"),
-        filters.get("start_date"),
-        filters.get("end_date"),
+    raw_org_type = payload.get("organization_type") or "ALL"
+    organization_type = str(raw_org_type).strip()
+    organization_type = (
+        "ALL" if organization_type.upper() == "ALL" else _normalize_org_type(organization_type)
     )
-    if date_condition:
-        conditions.append(date_condition)
-        params.extend(date_params)
+    if organization_type != "ALL" and organization_type not in ORG_TYPES:
+        raise InvalidFilterError("organization_type must be ALL, for_profit, or non_profit")
+
+    return {
+        "time_filter": time_filter,
+        "start_date": start_date,
+        "end_date": end_date,
+        "group_by": group_by,
+        "region": region,
+        "organization_type": organization_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SQL condition builders
+# ---------------------------------------------------------------------------
+
+def _window_condition(filters):
+    """SQL condition + params restricting rows to the selected time window."""
+    time_filter = filters["time_filter"]
+    if time_filter == "7D":
+        return "o.created_at >= CURRENT_DATE - INTERVAL '7 days'", {}
+    if time_filter == "30D":
+        return "o.created_at >= CURRENT_DATE - INTERVAL '30 days'", {}
+    if time_filter == "1Y":
+        return "o.created_at >= CURRENT_DATE - INTERVAL '1 year'", {}
+    if time_filter == "CUSTOM":
+        return (
+            "o.created_at >= %(start_date)s AND o.created_at < %(end_exclusive)s",
+            {
+                "start_date": filters["start_date"],
+                "end_exclusive": filters["end_date"] + timedelta(days=1),
+            },
+        )
+    return "", {}  # ALL
+
+
+def _window_start_bound(filters):
+    """The lower-bound expression/params used to compute a "before window" baseline."""
+    time_filter = filters["time_filter"]
+    if time_filter == "7D":
+        return "CURRENT_DATE - INTERVAL '7 days'", {}
+    if time_filter == "30D":
+        return "CURRENT_DATE - INTERVAL '30 days'", {}
+    if time_filter == "1Y":
+        return "CURRENT_DATE - INTERVAL '1 year'", {}
+    if time_filter == "CUSTOM":
+        return "%(start_date)s", {"start_date": filters["start_date"]}
+    return None, {}  # ALL has no baseline period
+
+
+def _shared_conditions(filters):
+    """Region / organization_type conditions applied to every query."""
+    conditions = []
+    params = {}
+
+    if filters["region"].upper() != "ALL":
+        conditions.append(
+            "(LOWER(COALESCE(s.state_name, '')) = LOWER(%(region)s) "
+            "OR LOWER(COALESCE(s.state_id::text, '')) = LOWER(%(region)s))"
+        )
+        params["region"] = filters["region"]
+
+    if filters["organization_type"] != "ALL":
+        conditions.append(
+            "LOWER(REGEXP_REPLACE(TRIM(o.org_type::text), '[\\s-]+', '_', 'g')) = %(org_type)s"
+        )
+        params["org_type"] = filters["organization_type"]
 
     return conditions, params
 
 
-def where_clause(conditions):
+def _where(conditions):
     return f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
 
-def get_group_by_unit(group_by):
-    group_by = (group_by or "daily").lower()
-    if group_by not in GROUP_BY_TRUNC:
-        group_by = "daily"
-    return GROUP_BY_TRUNC[group_by], GROUP_BY_FORMAT[group_by]
+def _base_from():
+    return (
+        f"FROM {ORGANIZATIONS_TABLE} o "
+        f"LEFT JOIN {STATE_TABLE} s ON o.state_id = s.state_id"
+    )
+
+
+def _filtered_where(filters, include_window=True):
+    conditions, params = _shared_conditions(filters)
+    if include_window:
+        window_sql, window_params = _window_condition(filters)
+        if window_sql:
+            conditions.insert(0, window_sql)
+        params.update(window_params)
+    return _where(conditions), params
 
 
 # ---------------------------------------------------------------------------
-# Dashboard 1: Organization Overview
+# Contributor-column detection
 # ---------------------------------------------------------------------------
 
-def fetch_overview_summary(cursor, filters):
-    """total / org_type / collaborator counts (always present in schema)."""
-    conditions, params = build_common_filters(filters)
-    query = f"""
+def has_contributor_column(cursor):
+    cursor.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = %s
+          AND table_name = 'organizations'
+          AND column_name = 'is_contributor'
+        LIMIT 1
+        """,
+        (DB_SCHEMA,),
+    )
+    return cursor.fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# Metric fetchers
+# ---------------------------------------------------------------------------
+
+def fetch_summary(cursor, filters, contributor_available):
+    where_sql, params = _filtered_where(filters)
+    contributor_expr = (
+        "COUNT(*) FILTER (WHERE o.is_contributor IS TRUE)" if contributor_available else "0"
+    )
+    cursor.execute(
+        f"""
         SELECT
             COUNT(*) AS total_organizations,
-            COUNT(*) FILTER (WHERE o.org_type = 'non_profit') AS non_profit_organizations,
-            COUNT(*) FILTER (WHERE o.org_type = 'for_profit') AS for_profit_organizations,
-            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborator_organizations,
-            COUNT(*) FILTER (WHERE o.is_collaborator IS NOT TRUE) AS non_collaborator_organizations
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)};
-    """
-    cursor.execute(query, params)
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS total_collaborators,
+            {contributor_expr} AS total_contributors,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_org_rating
+        {_base_from()}
+        {where_sql}
+        """,
+        params,
+    )
     row = cursor.fetchone()
+    rating = row["average_org_rating"]
     return {
         "total_organizations": int(row["total_organizations"] or 0),
-        "non_profit_organizations": int(row["non_profit_organizations"] or 0),
-        "for_profit_organizations": int(row["for_profit_organizations"] or 0),
-        "collaborator_organizations": int(row["collaborator_organizations"] or 0),
-        "non_collaborator_organizations": int(row["non_collaborator_organizations"] or 0),
+        "total_collaborators": int(row["total_collaborators"] or 0),
+        "total_contributors": int(row["total_contributors"] or 0),
+        "average_org_rating": float(rating) if rating is not None else 0.0,
     }
 
 
-def fetch_contributor_summary(cursor, filters):
+def _period_counts(cursor, filters, select_exprs):
     """
-    Isolated so a missing `is_contributor` column only zeroes out this
-    piece of the summary instead of failing the whole overview dashboard.
+    Shared helper: returns (baseline_row, [period_rows]) where baseline_row
+    is the pre-window totals (for cumulative "growth" math) and period_rows
+    are the new-in-period counts, ordered chronologically.
+    `select_exprs` is a dict of {output_name: SQL aggregate expression}.
     """
-    conditions, params = build_common_filters(filters)
-    query = f"""
+    trunc_unit, date_format = GROUP_BY_UNITS[filters["group_by"]]
+    select_list = ",\n            ".join(f"{expr} AS {name}" for name, expr in select_exprs.items())
+
+    baseline_row = {name: 0 for name in select_exprs}
+    lower_bound_sql, lower_bound_params = _window_start_bound(filters)
+    if lower_bound_sql is not None:
+        shared_conditions, shared_params = _shared_conditions(filters)
+        baseline_conditions = shared_conditions + [f"o.created_at < {lower_bound_sql}"]
+        baseline_params = {**shared_params, **lower_bound_params}
+        cursor.execute(
+            f"""
+            SELECT {select_list}
+            {_base_from()}
+            {_where(baseline_conditions)}
+            """,
+            baseline_params,
+        )
+        fetched = cursor.fetchone()
+        if fetched:
+            baseline_row = {name: int(fetched[name] or 0) for name in select_exprs}
+
+    where_sql, params = _filtered_where(filters)
+    cursor.execute(
+        f"""
         SELECT
-            COUNT(*) FILTER (WHERE o.is_contributor IS TRUE) AS contributor_organizations,
-            COUNT(*) FILTER (WHERE o.is_contributor IS NOT TRUE) AS non_contributor_organizations
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)};
-    """
-    cursor.execute(query, params)
-    row = cursor.fetchone()
-    return {
-        "contributor_organizations": int(row["contributor_organizations"] or 0),
-        "non_contributor_organizations": int(row["non_contributor_organizations"] or 0),
-    }
+            TO_CHAR(DATE_TRUNC('{trunc_unit}', o.created_at), '{date_format}') AS period,
+            DATE_TRUNC('{trunc_unit}', o.created_at) AS period_start,
+            {select_list}
+        {_base_from()}
+        {where_sql}
+        GROUP BY 1, 2
+        ORDER BY 2
+        """,
+        params,
+    )
+    period_rows = cursor.fetchall()
+    return baseline_row, period_rows
 
 
-def fetch_organization_activity_trend(cursor, filters):
-    """Registration trend, grouped daily/weekly/monthly/yearly."""
-    conditions, params = build_common_filters(filters)
-    trunc_unit, fmt = get_group_by_unit(filters.get("group_by"))
-
-    query = f"""
-        SELECT
-            TO_CHAR(DATE_TRUNC('{trunc_unit}', o.created_at), '{fmt}') AS period,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY DATE_TRUNC('{trunc_unit}', o.created_at)
-        ORDER BY DATE_TRUNC('{trunc_unit}', o.created_at);
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [{"period": row["period"], "count": int(row["count"])} for row in rows]
-
-
-def fetch_organizations_by_type(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            COALESCE(o.org_type::text, 'unknown') AS org_type,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY o.org_type
-        ORDER BY count DESC;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [{"org_type": row["org_type"], "count": int(row["count"])} for row in rows]
+def fetch_growth_trend(cursor, filters):
+    baseline, period_rows = _period_counts(
+        cursor,
+        filters,
+        {
+            "total_organizations": "COUNT(*)",
+            "total_collaborators": "COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE)",
+        },
+    )
+    running_orgs = baseline["total_organizations"]
+    running_collaborators = baseline["total_collaborators"]
+    trend = []
+    for row in period_rows:
+        running_orgs += int(row["total_organizations"] or 0)
+        running_collaborators += int(row["total_collaborators"] or 0)
+        trend.append(
+            {
+                "period": row["period"],
+                "total_organizations": running_orgs,
+                "total_collaborators": running_collaborators,
+            }
+        )
+    return trend
 
 
-def fetch_organizations_by_size(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            COALESCE(o.org_size::text, 'unknown') AS org_size,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY o.org_size
-        ORDER BY count DESC;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [{"org_size": row["org_size"], "count": int(row["count"])} for row in rows]
+def fetch_organization_type_distribution(cursor, filters):
+    normalized_type = "LOWER(REGEXP_REPLACE(TRIM(o.org_type::text), '[\\s-]+', '_', 'g'))"
+    baseline, period_rows = _period_counts(
+        cursor,
+        filters,
+        {
+            "for_profit": f"COUNT(*) FILTER (WHERE {normalized_type} = 'for_profit')",
+            "non_profit": f"COUNT(*) FILTER (WHERE {normalized_type} = 'non_profit')",
+        },
+    )
+    running_for_profit = baseline["for_profit"]
+    running_non_profit = baseline["non_profit"]
+    trend = []
+    for row in period_rows:
+        running_for_profit += int(row["for_profit"] or 0)
+        running_non_profit += int(row["non_profit"] or 0)
+        trend.append(
+            {
+                "period": row["period"],
+                "for_profit": running_for_profit,
+                "non_profit": running_non_profit,
+                "total": running_for_profit + running_non_profit,
+            }
+        )
+    return trend
 
 
 def fetch_organizations_by_location(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
+    where_sql, params = _filtered_where(filters)
+    cursor.execute(
+        f"""
         SELECT
-            COALESCE(s.state_name, o.state_id, 'Unknown') AS state,
-            COALESCE(o.city_name, 'Unknown') AS city,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        LEFT JOIN {STATE_TABLE} s ON o.state_id = s.state_id
-        {where_clause(conditions)}
-        GROUP BY COALESCE(s.state_name, o.state_id, 'Unknown'), COALESCE(o.city_name, 'Unknown')
-        ORDER BY count DESC;
-    """
-    cursor.execute(query, params)
+            COALESCE(s.state_id::text, o.state_id::text, 'UNKNOWN') AS state_id,
+            COALESCE(s.state_name, 'Unknown') AS state_name,
+            COALESCE(NULLIF(TRIM(o.city_name), ''), 'Unknown') AS city_name,
+            COUNT(*) AS organization_count
+        {_base_from()}
+        {where_sql}
+        GROUP BY 1, 2, 3
+        """,
+        params,
+    )
     rows = cursor.fetchall()
-    return [
-        {"state": row["state"], "city": row["city"], "count": int(row["count"])}
-        for row in rows
-    ]
+
+    states = {}
+    grand_total = 0
+    for row in rows:
+        count = int(row["organization_count"] or 0)
+        grand_total += count
+        state_id = row["state_id"]
+        state = states.setdefault(
+            state_id,
+            {"state_id": state_id, "state_name": row["state_name"], "count": 0, "cities": []},
+        )
+        state["count"] += count
+        state["cities"].append({"city_name": row["city_name"], "organization_count": count})
+
+    result = []
+    for state in states.values():
+        state["cities"].sort(key=lambda c: c["organization_count"], reverse=True)
+        percentage = round(state["count"] * 100.0 / grand_total, 1) if grand_total else 0.0
+        result.append(
+            {
+                "state_id": state["state_id"],
+                "state_name": state["state_name"],
+                "organization_count": state["count"],
+                "percentage": percentage,
+                "cities": state["cities"],
+            }
+        )
+    result.sort(key=lambda s: s["organization_count"], reverse=True)
+    return result
 
 
-def fetch_collaborator_distribution(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            CASE WHEN o.is_collaborator IS TRUE THEN 'collaborator' ELSE 'non_collaborator' END AS category,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
+def fetch_organizations_by_size(cursor, filters):
+    where_sql, params = _filtered_where(filters)
+    cursor.execute(
+        f"""
+        SELECT LOWER(TRIM(o.org_size::text)) AS org_size, COUNT(*) AS organization_count
+        {_base_from()}
+        {where_sql}
         GROUP BY 1
-        ORDER BY 1;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [{"category": row["category"], "count": int(row["count"])} for row in rows]
+        """,
+        params,
+    )
+    counts = {row["org_size"]: int(row["organization_count"] or 0) for row in cursor.fetchall()}
+    return [{"org_size": size, "organization_count": counts.get(size, 0)} for size in ORG_SIZES]
 
 
-def fetch_contributor_distribution(cursor, filters):
-    """Isolated for the same `is_contributor` reason as fetch_contributor_summary."""
-    conditions, params = build_common_filters(filters)
-    query = f"""
+def fetch_collaborator_vs_contributor(cursor, filters, contributor_available):
+    where_sql, params = _filtered_where(filters)
+    contributor_expr = (
+        "COUNT(*) FILTER (WHERE o.is_contributor IS TRUE)" if contributor_available else "0"
+    )
+    cursor.execute(
+        f"""
         SELECT
-            CASE WHEN o.is_contributor IS TRUE THEN 'contributor' ELSE 'non_contributor' END AS category,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY 1
-        ORDER BY 1;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [{"category": row["category"], "count": int(row["count"])} for row in rows]
-
-
-def get_organization_overview(cursor, filters):
-    response = get_default_overview_response()["organization_overview"]
-
-    try:
-        response["summary"].update(fetch_overview_summary(cursor, filters))
-    except Exception as error:
-        print(f"[overview] summary query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["summary"].update(fetch_contributor_summary(cursor, filters))
-    except Exception as error:
-        print(f"[overview] contributor summary query failed (is_contributor column may not exist yet): {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["organization_activity_trend"] = fetch_organization_activity_trend(cursor, filters)
-    except Exception as error:
-        print(f"[overview] activity trend query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["organizations_by_type"] = fetch_organizations_by_type(cursor, filters)
-    except Exception as error:
-        print(f"[overview] organizations_by_type query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["organizations_by_size"] = fetch_organizations_by_size(cursor, filters)
-    except Exception as error:
-        print(f"[overview] organizations_by_size query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["organizations_by_location"] = fetch_organizations_by_location(cursor, filters)
-    except Exception as error:
-        print(f"[overview] organizations_by_location query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["collaborator_distribution"] = fetch_collaborator_distribution(cursor, filters)
-    except Exception as error:
-        print(f"[overview] collaborator_distribution query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["contributor_distribution"] = fetch_contributor_distribution(cursor, filters)
-    except Exception as error:
-        print(f"[overview] contributor_distribution query failed (is_contributor column may not exist yet): {error}")
-        safe_rollback(cursor)
-
-    return response
-
-
-# ---------------------------------------------------------------------------
-# Dashboard 2: Organization Performance
-# ---------------------------------------------------------------------------
-
-def fetch_performance_summary(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
-            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_organizations,
-            COUNT(*) FILTER (WHERE o.org_rating IS NULL) AS unrated_organizations,
-            COUNT(*) FILTER (WHERE o.org_rating = 5) AS five_star_organizations
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)};
-    """
-    cursor.execute(query, params)
+            COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborators,
+            {contributor_expr} AS contributors
+        {_base_from()}
+        {where_sql}
+        """,
+        params,
+    )
     row = cursor.fetchone()
-    return {
-        "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
-        "rated_organizations": int(row["rated_organizations"] or 0),
-        "unrated_organizations": int(row["unrated_organizations"] or 0),
-        "five_star_organizations": int(row["five_star_organizations"] or 0),
-    }
+    total = int(row["total"] or 0)
+    collaborators = int(row["collaborators"] or 0)
+    contributors = int(row["contributors"] or 0)
+
+    def pct(count):
+        return round(count * 100.0 / total, 1) if total else 0.0
+
+    return [
+        {"type": "collaborator", "organization_count": collaborators, "percentage": pct(collaborators)},
+        {"type": "contributor", "organization_count": contributors, "percentage": pct(contributors)},
+    ]
 
 
 def fetch_rating_distribution(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            o.org_rating AS rating,
-            COUNT(*) AS count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY o.org_rating
-        ORDER BY o.org_rating NULLS LAST;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [
-        {"rating": row["rating"], "count": int(row["count"])}
-        for row in rows
-    ]
+    # Built explicitly (rather than via _filtered_where) so the
+    # rating-not-null condition combines correctly whether or not other
+    # filters are already present.
+    conditions, params = _shared_conditions(filters)
+    window_sql, window_params = _window_condition(filters)
+    if window_sql:
+        conditions.insert(0, window_sql)
+    params.update(window_params)
+    conditions.append("o.org_rating IS NOT NULL")
 
-
-def fetch_top_rated_organizations(cursor, filters, limit=TOP_N_DEFAULT):
-    conditions, params = build_common_filters(filters)
-    conditions = conditions + ["o.org_rating IS NOT NULL"]
-    query = f"""
-        SELECT
-            o.org_id,
-            o.org_name,
-            o.org_type::text AS org_type,
-            o.org_size::text AS org_size,
-            o.org_rating,
-            o.city_name,
-            o.state_id
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        ORDER BY o.org_rating DESC, o.org_name ASC
-        LIMIT %s;
-    """
-    cursor.execute(query, params + [limit])
-    rows = cursor.fetchall()
-    return [dict(row) for row in rows]
-
-
-def fetch_top_collaborator_organizations(cursor, filters, limit=TOP_N_DEFAULT):
-    conditions, params = build_common_filters(filters)
-    conditions = conditions + ["o.is_collaborator IS TRUE"]
-    query = f"""
-        SELECT
-            o.org_id,
-            o.org_name,
-            o.org_type::text AS org_type,
-            o.org_size::text AS org_size,
-            o.org_rating,
-            o.city_name,
-            o.state_id
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        ORDER BY o.org_rating DESC NULLS LAST, o.org_name ASC
-        LIMIT %s;
-    """
-    cursor.execute(query, params + [limit])
-    rows = cursor.fetchall()
-    return [dict(row) for row in rows]
-
-
-def fetch_top_contributor_organizations(cursor, filters, limit=TOP_N_DEFAULT):
-    """Isolated: relies on the not-yet-existing `is_contributor` column."""
-    conditions, params = build_common_filters(filters)
-    conditions = conditions + ["o.is_contributor IS TRUE"]
-    query = f"""
-        SELECT
-            o.org_id,
-            o.org_name,
-            o.org_type::text AS org_type,
-            o.org_size::text AS org_size,
-            o.org_rating,
-            o.city_name,
-            o.state_id
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        ORDER BY o.org_rating DESC NULLS LAST, o.org_name ASC
-        LIMIT %s;
-    """
-    cursor.execute(query, params + [limit])
-    rows = cursor.fetchall()
-    return [dict(row) for row in rows]
-
-
-def fetch_ratings_by_organization_type(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            COALESCE(o.org_type::text, 'unknown') AS org_type,
-            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
-            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY o.org_type
-        ORDER BY average_rating DESC NULLS LAST;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [
-        {
-            "org_type": row["org_type"],
-            "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
-            "rated_count": int(row["rated_count"] or 0),
-        }
-        for row in rows
-    ]
-
-
-def fetch_ratings_by_organization_size(cursor, filters):
-    conditions, params = build_common_filters(filters)
-    query = f"""
-        SELECT
-            COALESCE(o.org_size::text, 'unknown') AS org_size,
-            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
-            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_count
-        FROM {ORGANIZATIONS_TABLE} o
-        {where_clause(conditions)}
-        GROUP BY o.org_size
-        ORDER BY average_rating DESC NULLS LAST;
-    """
-    cursor.execute(query, params)
-    rows = cursor.fetchall()
-    return [
-        {
-            "org_size": row["org_size"],
-            "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
-            "rated_count": int(row["rated_count"] or 0),
-        }
-        for row in rows
-    ]
-
-
-def get_organization_performance(cursor, filters):
-    response = get_default_performance_response()["organization_performance"]
-
-    try:
-        response["summary"].update(fetch_performance_summary(cursor, filters))
-    except Exception as error:
-        print(f"[performance] summary query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["rating_distribution"] = fetch_rating_distribution(cursor, filters)
-    except Exception as error:
-        print(f"[performance] rating_distribution query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["top_rated_organizations"] = fetch_top_rated_organizations(cursor, filters)
-    except Exception as error:
-        print(f"[performance] top_rated_organizations query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["top_collaborator_organizations"] = fetch_top_collaborator_organizations(cursor, filters)
-    except Exception as error:
-        print(f"[performance] top_collaborator_organizations query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["top_contributor_organizations"] = fetch_top_contributor_organizations(cursor, filters)
-    except Exception as error:
-        print(f"[performance] top_contributor_organizations query failed (is_contributor column may not exist yet): {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["ratings_by_organization_type"] = fetch_ratings_by_organization_type(cursor, filters)
-    except Exception as error:
-        print(f"[performance] ratings_by_organization_type query failed: {error}")
-        safe_rollback(cursor)
-
-    try:
-        response["ratings_by_organization_size"] = fetch_ratings_by_organization_size(cursor, filters)
-    except Exception as error:
-        print(f"[performance] ratings_by_organization_size query failed: {error}")
-        safe_rollback(cursor)
-
-    return response
+    cursor.execute(
+        f"""
+        SELECT o.org_rating AS rating, COUNT(*) AS organization_count
+        {_base_from()}
+        {_where(conditions)}
+        GROUP BY 1
+        """,
+        params,
+    )
+    counts = {int(row["rating"]): int(row["organization_count"] or 0) for row in cursor.fetchall()}
+    return [{"rating": rating, "organization_count": counts.get(rating, 0)} for rating in RATINGS]
 
 
 # ---------------------------------------------------------------------------
-# Lambda handlers
-#
-# Supports both endpoint designs suggested in issue #228:
-#   - two separate endpoints: /analytics/organizations/overview
-#                              /analytics/organizations/performance
-#     -> overview_lambda_handler / performance_lambda_handler
-#   - one endpoint + "dashboard_type": /analytics/organizations
-#     -> lambda_handler (dashboard_type: "overview" | "performance" | "both")
+# Lambda handler
 # ---------------------------------------------------------------------------
+
+def _run_metric(label, default, connection, fn):
+    try:
+        return fn()
+    except Exception as error:
+        LOGGER.warning("organization_analytics: %s failed: %s", label, error)
+        try:
+            connection.rollback()
+        except Exception as rollback_error:
+            LOGGER.warning("organization_analytics: rollback after %s failed: %s", label, rollback_error)
+        return default
+
 
 def lambda_handler(event, context):
-    conn = None
-    cursor = None
-
-    filters = parse_event_body(event)
-    dashboard_type = (filters.get("dashboard_type") or "overview").lower()
-
-    response_body = {}
-    if dashboard_type in ("overview", "both"):
-        response_body.update(get_default_overview_response())
-    if dashboard_type in ("performance", "both"):
-        response_body.update(get_default_performance_response())
-    if dashboard_type not in ("overview", "performance", "both"):
-        return build_response(400, {
-            "error": "Invalid dashboard_type. Expected 'overview', 'performance', or 'both'."
-        })
+    response_body = get_default_response()
 
     try:
-        conn = get_db_connection()
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        payload = parse_event_body(event)
+        filters = validate_filters(payload)
+    except InvalidFilterError as error:
+        return build_response(400, {"error": str(error), **response_body})
 
-        if dashboard_type in ("overview", "both"):
-            response_body["organization_overview"] = get_organization_overview(cursor, filters)
+    connection = None
+    cursor = None
+    try:
+        connection = get_db_connection()
+        cursor = connection.cursor(cursor_factory=RealDictCursor)
 
-        if dashboard_type in ("performance", "both"):
-            response_body["organization_performance"] = get_organization_performance(cursor, filters)
+        contributor_available = _run_metric(
+            "contributor_column_check", False, connection, lambda: has_contributor_column(cursor)
+        )
+
+        response_body["summary"] = _run_metric(
+            "summary", response_body["summary"], connection,
+            lambda: fetch_summary(cursor, filters, contributor_available),
+        )
+        response_body["growth_trend"] = _run_metric(
+            "growth_trend", [], connection, lambda: fetch_growth_trend(cursor, filters)
+        )
+        response_body["organizations_by_location"] = _run_metric(
+            "organizations_by_location", [], connection,
+            lambda: fetch_organizations_by_location(cursor, filters),
+        )
+        response_body["organizations_by_size"] = _run_metric(
+            "organizations_by_size", [], connection, lambda: fetch_organizations_by_size(cursor, filters)
+        )
+        response_body["collaborator_vs_contributor"] = _run_metric(
+            "collaborator_vs_contributor", [], connection,
+            lambda: fetch_collaborator_vs_contributor(cursor, filters, contributor_available),
+        )
+        response_body["rating_distribution"] = _run_metric(
+            "rating_distribution", [], connection, lambda: fetch_rating_distribution(cursor, filters)
+        )
+        response_body["organization_type_distribution"] = _run_metric(
+            "organization_type_distribution", [], connection,
+            lambda: fetch_organization_type_distribution(cursor, filters),
+        )
 
         return build_response(200, response_body)
 
     except Exception as error:
-        print(f"DB connection failed: {error}")
+        LOGGER.error("organization_analytics: database connection failed: %s", error)
         return build_response(500, response_body)
 
     finally:
         if cursor:
             cursor.close()
-        if conn:
-            conn.close()
-
-
-def overview_lambda_handler(event, context):
-    filters = parse_event_body(event)
-    filters["dashboard_type"] = "overview"
-    return lambda_handler({"body": json.dumps(filters, default=str)}, context)
-
-
-def performance_lambda_handler(event, context):
-    filters = parse_event_body(event)
-    filters["dashboard_type"] = "performance"
-    return lambda_handler({"body": json.dumps(filters, default=str)}, context)
+        if connection:
+            connection.close()
 
 
 # ---------------------------------------------------------------------------
 # Local testing
 #
-# Run against a local PostgreSQL instance (no AWS/SSM required):
-#
-#   export LOCAL_DB_HOST=localhost
-#   export LOCAL_DB_NAME=saayam_local
-#   export LOCAL_DB_USER=postgres
-#   export LOCAL_DB_PASSWORD=postgres
-#   export LOCAL_DB_PORT=5432
+#   export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/saayam
+#   # or export DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_PASSWORD
+#   # export STATE_TABLE_NAME=state   (only if your local schema is singular)
 #   python organization_analytics.py
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    import os
-
-    conn = psycopg2.connect(
-        host=os.environ.get("LOCAL_DB_HOST", "localhost"),
-        database=os.environ.get("LOCAL_DB_NAME", "saayam_local"),
-        user=os.environ.get("LOCAL_DB_USER", "postgres"),
-        password=os.environ.get("LOCAL_DB_PASSWORD", "postgres"),
-        port=os.environ.get("LOCAL_DB_PORT", "5432"),
-    )
-    local_cursor = conn.cursor(cursor_factory=RealDictCursor)
-
-    print("=" * 70)
-    print("LOCAL TESTING — organization_analytics.py")
-    print("=" * 70)
-
     test_scenarios = [
-        ("Overview - ALL time", {"dashboard_type": "overview", "time_filter": "ALL", "group_by": "monthly"}),
-        ("Overview - 30D", {"dashboard_type": "overview", "time_filter": "30D", "group_by": "daily"}),
-        ("Overview - filtered (non_profit, VA)", {
-            "dashboard_type": "overview", "org_type": "non_profit", "state_id": "VA"
-        }),
-        ("Performance - ALL", {"dashboard_type": "performance", "time_filter": "ALL"}),
-        ("Performance - filtered (rating=5)", {"dashboard_type": "performance", "org_rating": 5}),
-        ("Both dashboards", {"dashboard_type": "both", "time_filter": "1Y", "group_by": "yearly"}),
+        ("Default (30D, daily)", {}),
+        ("ALL time, monthly", {"time_filter": "ALL", "group_by": "monthly"}),
+        ("Region + org type filter", {"time_filter": "1Y", "group_by": "monthly", "region": "Virginia", "organization_type": "non_profit"}),
+        ("CUSTOM range", {"time_filter": "CUSTOM", "start_date": "2025-01-01", "end_date": "2026-08-25", "group_by": "yearly"}),
+        ("Invalid time_filter", {"time_filter": "5Y"}),
     ]
 
-    for label, filters in test_scenarios:
-        print(f"\n--- Scenario: {label} ---")
-        dashboard_type = filters.get("dashboard_type", "overview")
-        result = {}
-        if dashboard_type in ("overview", "both"):
-            result["organization_overview"] = get_organization_overview(local_cursor, filters)
-        if dashboard_type in ("performance", "both"):
-            result["organization_performance"] = get_organization_performance(local_cursor, filters)
-        print(json.dumps(result, indent=2, default=str))
+    print("=" * 70)
+    print("LOCAL TESTING - organization_analytics.py")
+    print("=" * 70)
 
-    cursor_close_ok = True
-    try:
-        local_cursor.close()
-        conn.close()
-    except Exception:
-        cursor_close_ok = False
+    for label, payload in test_scenarios:
+        print(f"\n--- Scenario: {label} ---")
+        result = lambda_handler({"body": json.dumps(payload)}, None)
+        print(f"statusCode: {result['statusCode']}")
+        print(json.dumps(json.loads(result["body"]), indent=2))
 
     print("\n" + "=" * 70)
-    print("LOCAL TESTING COMPLETE" if cursor_close_ok else "LOCAL TESTING COMPLETE (cleanup warning)")
+    print("LOCAL TESTING COMPLETE")
     print("=" * 70)


### PR DESCRIPTION
Summary

Adds organization_analytics.py, a Lambda handler returning all three Organization Dashboard tabs from a single endpoint (POST /analytics/organizations), aligned with the finalized dashboard requirements on issue #228.

Related work

Issue #228 was previously implemented in #272 (merged, FastAPI-based) and has an open follow-up, #278, aligning it with finalized requirements. This PR follows the same finalized response shape as #278 but is an independent implementation (Lambda-handler pattern, matching kpi_api_analytics.py's conventions) rather than the FastAPI approach used there.

Response shape

Single combined response for all three dashboard tabs:

summary — 4 KPI cards: total_organizations, total_collaborators, total_contributors, average_org_rating
growth_trend — cumulative organization + collaborator growth per period
organizations_by_location — state breakdown with nested cities and percentages
organizations_by_size — small / medium / large counts
collaborator_vs_contributor — counts + percentages
rating_distribution — counts for ratings 1–5
organization_type_distribution — for-profit vs non-profit, cumulative per period

Filters: time_filter (7D/30D/1Y/ALL/CUSTOM), group_by (daily/weekly/monthly/yearly), region (ALL, a state name, or state ID), organization_type (ALL/for_profit/non_profit). CUSTOM requires start_date and end_date.

Local testing

Tested against local Postgres — no AWS Parameter Store used. Connection reads DATABASE_URL, or DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD env vars. See local_test_setup.sql (schema + 25 mock organizations) and local_test_results.txt (5 scenarios: default filters, all-time, region+type filter, custom date range, invalid filter → 400).

Sample response (default 30D filter, summary excerpt):

{
  "total_organizations": 6,
  "total_collaborators": 4,
  "total_contributors": 0,
  "average_org_rating": 4.2
}

Known gaps / flags for review

is_contributor isn't in the current schema. Rather than guessing, the handler checks information_schema.columns once per request and only includes contributor counts in queries when the column is actually present — contributor figures return 0 / 0.0% otherwise, no fake data.
organizations.state_id FK references states in ddl_organizations.sql, but a locally-available copy of the schema may only have state (singular, per ddl_state.sql). The table name is configurable via STATE_TABLE_NAME (defaults to the ticket-correct states) so this works against either schema without code changes. Flagging so the DDL mismatch can be fixed upstream.