### PR TITLE
#228: Add Organization Analytics API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+.env
+venv/
+__pycache__/
+*.pyc

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,602 @@
+import json
+import os
+from datetime import date
+
+import psycopg2
+from dotenv import load_dotenv
+from psycopg2.extras import RealDictCursor
+
+load_dotenv()
+
+SCHEMA_NAME = "virginia_dev_saayam_rdbms"
+ORGANIZATIONS = f"{SCHEMA_NAME}.organizations"
+STATE = f"{SCHEMA_NAME}.state"
+
+VALID_DASHBOARD_TYPES = {"overview", "performance"}
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+VALID_GROUP_BY = {"daily", "weekly", "monthly", "yearly"}
+VALID_ORG_TYPES = {"non_profit", "for_profit"}
+VALID_ORG_SIZES = {"small", "medium", "large"}
+
+
+def build_response(status_code, body):
+    """Build an API Gateway-compatible JSON response."""
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "Content-Type,Authorization",
+            "Access-Control-Allow-Methods": "POST,OPTIONS",
+        },
+        "body": json.dumps(body, default=str),
+    }
+
+
+def parse_event_body(event):
+    """Return a request dictionary from an API Gateway event or direct input."""
+    if not event:
+        return {}
+
+    body = event.get("body") if isinstance(event, dict) else None
+    if body is None:
+        return event if isinstance(event, dict) else {}
+
+    if isinstance(body, dict):
+        return body
+
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as error:
+            raise ValueError("Request body must contain valid JSON.") from error
+        if not isinstance(parsed, dict):
+            raise ValueError("Request body must be a JSON object.")
+        return parsed
+
+    raise ValueError("Request body must be a JSON object.")
+
+
+def get_db_connection():
+    """Connect to the locally configured PostgreSQL database."""
+    return psycopg2.connect(
+        host=os.getenv("DB_HOST", "localhost"),
+        port=os.getenv("DB_PORT", "5432"),
+        database=os.getenv("DB_NAME", "saayam_analytics"),
+        user=os.getenv("DB_USER"),
+        password=os.getenv("DB_PASSWORD", ""),
+    )
+
+
+def has_contributor_column(cursor):
+    """Check whether organizations.is_contributor exists in the current database."""
+    cursor.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = %s
+              AND table_name = 'organizations'
+              AND column_name = 'is_contributor'
+        ) AS exists
+        """,
+        (SCHEMA_NAME,),
+    )
+    return bool(cursor.fetchone()["exists"])
+
+
+def validate_bool(value, field_name):
+    """Validate optional boolean request values."""
+    if value is not None and not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be true, false, or null.")
+
+
+def validate_date(value, field_name):
+    """Validate an optional ISO-8601 date value."""
+    if value is None:
+        return
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be an ISO date string (YYYY-MM-DD).")
+    try:
+        date.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(
+            f"{field_name} must use YYYY-MM-DD format."
+        ) from error
+
+
+def validate_request(payload, contributor_available):
+    """Validate dashboard options and return normalized request options."""
+    dashboard_type = payload.get("dashboard_type", "overview")
+    time_filter = payload.get("time_filter", "30D")
+    group_by = payload.get("group_by", "daily")
+    start_date = payload.get("start_date")
+    end_date = payload.get("end_date")
+
+    if dashboard_type not in VALID_DASHBOARD_TYPES:
+        raise ValueError("dashboard_type must be overview or performance.")
+    if time_filter not in VALID_TIME_FILTERS:
+        raise ValueError("time_filter must be one of 7D, 30D, 1Y, ALL, CUSTOM.")
+    if group_by not in VALID_GROUP_BY:
+        raise ValueError("group_by must be daily, weekly, monthly, or yearly.")
+
+    validate_date(start_date, "start_date")
+    validate_date(end_date, "end_date")
+
+    if time_filter == "CUSTOM" and not (start_date or end_date):
+        raise ValueError(
+            "CUSTOM time_filter requires start_date, end_date, or both."
+        )
+    if start_date and end_date and start_date > end_date:
+        raise ValueError("start_date cannot be after end_date.")
+
+    org_type = payload.get("org_type")
+    org_size = payload.get("org_size")
+    org_rating = payload.get("org_rating")
+
+    if org_type is not None and org_type not in VALID_ORG_TYPES:
+        raise ValueError("org_type must be non_profit or for_profit.")
+    if org_size is not None and org_size not in VALID_ORG_SIZES:
+        raise ValueError("org_size must be small, medium, or large.")
+    if org_rating is not None and (
+        not isinstance(org_rating, int) or isinstance(org_rating, bool)
+        or not 1 <= org_rating <= 5
+    ):
+        raise ValueError("org_rating must be an integer from 1 through 5.")
+
+    validate_bool(payload.get("is_collaborator"), "is_collaborator")
+    validate_bool(payload.get("is_contributor"), "is_contributor")
+
+    if payload.get("is_contributor") is not None and not contributor_available:
+        raise ValueError(
+            "is_contributor filtering is unavailable because the database "
+            "does not yet contain the is_contributor column."
+        )
+
+    return {
+        "dashboard_type": dashboard_type,
+        "time_filter": time_filter,
+        "group_by": group_by,
+        "start_date": start_date,
+        "end_date": end_date,
+        "org_type": org_type,
+        "org_size": org_size,
+        "state_id": payload.get("state_id"),
+        "city_name": payload.get("city_name"),
+        "org_rating": org_rating,
+        "is_collaborator": payload.get("is_collaborator"),
+        "is_contributor": payload.get("is_contributor"),
+    }
+
+
+def build_where_clause(options, contributor_available):
+    """Build parameterized filters shared by all metric queries."""
+    clauses = []
+    params = []
+
+    time_filter = options["time_filter"]
+    if time_filter == "7D":
+        clauses.append("o.created_at >= CURRENT_DATE - INTERVAL '7 days'")
+    elif time_filter == "30D":
+        clauses.append("o.created_at >= CURRENT_DATE - INTERVAL '30 days'")
+    elif time_filter == "1Y":
+        clauses.append("o.created_at >= CURRENT_DATE - INTERVAL '1 year'")
+    elif time_filter == "CUSTOM":
+        if options["start_date"]:
+            clauses.append("o.created_at >= %s")
+            params.append(options["start_date"])
+        if options["end_date"]:
+            clauses.append("o.created_at < (%s::date + INTERVAL '1 day')")
+            params.append(options["end_date"])
+
+    if options["org_type"] is not None:
+        clauses.append("o.org_type = %s")
+        params.append(options["org_type"])
+    if options["org_size"] is not None:
+        clauses.append("o.org_size = %s")
+        params.append(options["org_size"])
+    if options["state_id"] is not None:
+        clauses.append("o.state_id = %s")
+        params.append(options["state_id"])
+    if options["city_name"] is not None:
+        clauses.append("o.city_name ILIKE %s")
+        params.append(options["city_name"])
+    if options["org_rating"] is not None:
+        clauses.append("o.org_rating = %s")
+        params.append(options["org_rating"])
+    if options["is_collaborator"] is not None:
+        clauses.append("o.is_collaborator = %s")
+        params.append(options["is_collaborator"])
+    if contributor_available and options["is_contributor"] is not None:
+        clauses.append("o.is_contributor = %s")
+        params.append(options["is_contributor"])
+
+    where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    return where_sql, params
+
+
+def query_rows(cursor, query, params):
+    """Execute a query and return JSON-serializable dictionary rows."""
+    cursor.execute(query, params)
+    return cursor.fetchall()
+
+
+def get_overview(cursor, options, contributor_available):
+    """Return metrics for the Organization Overview dashboard."""
+    where_sql, params = build_where_clause(options, contributor_available)
+
+    contributor_summary = """
+        COUNT(*) FILTER (WHERE o.is_contributor IS TRUE) AS contributor_organizations,
+        COUNT(*) FILTER (
+            WHERE o.is_contributor IS NOT TRUE
+        ) AS non_contributor_organizations
+    """ if contributor_available else """
+        NULL::integer AS contributor_organizations,
+        NULL::integer AS non_contributor_organizations
+    """
+
+    cursor.execute(
+        f"""
+        SELECT
+            COUNT(*) AS total_organizations,
+            COUNT(*) FILTER (
+                WHERE o.org_type = 'non_profit'
+            ) AS non_profit_organizations,
+            COUNT(*) FILTER (
+                WHERE o.org_type = 'for_profit'
+            ) AS for_profit_organizations,
+            COUNT(*) FILTER (
+                WHERE o.is_collaborator IS TRUE
+            ) AS collaborator_organizations,
+            COUNT(*) FILTER (
+                WHERE o.is_collaborator IS NOT TRUE
+            ) AS non_collaborator_organizations,
+            {contributor_summary}
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        """,
+        params,
+    )
+    summary = dict(cursor.fetchone())
+    for key, value in summary.items():
+        if value is not None:
+            summary[key] = int(value)
+
+    period, date_format = {
+        "daily": ("day", "YYYY-MM-DD"),
+        "weekly": ("week", 'IYYY-"W"IW'),
+        "monthly": ("month", "YYYY-MM"),
+        "yearly": ("year", "YYYY"),
+    }[options["group_by"]]
+
+    activity_rows = query_rows(
+        cursor,
+        f"""
+        SELECT
+            TO_CHAR(
+                DATE_TRUNC('{period}', o.created_at),
+                '{date_format}'
+            ) AS period,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY 1
+        ORDER BY 1
+        """,
+        params,
+    )
+
+    type_rows = query_rows(
+        cursor,
+        f"""
+        SELECT o.org_type AS type, COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY o.org_type
+        ORDER BY o.org_type
+        """,
+        params,
+    )
+
+    size_rows = query_rows(
+        cursor,
+        f"""
+        SELECT o.org_size AS size, COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY o.org_size
+        ORDER BY o.org_size
+        """,
+        params,
+    )
+
+    location_rows = query_rows(
+        cursor,
+        f"""
+        SELECT
+            s.state_name AS state,
+            s.state_code AS state_code,
+            o.city_name AS city,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        LEFT JOIN {STATE} s ON s.state_id = o.state_id
+        {where_sql}
+        GROUP BY s.state_name, s.state_code, o.city_name
+        ORDER BY count DESC, state, city
+        """,
+        params,
+    )
+
+    collaborator_rows = query_rows(
+        cursor,
+        f"""
+        SELECT
+            COALESCE(o.is_collaborator, FALSE) AS is_collaborator,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY COALESCE(o.is_collaborator, FALSE)
+        ORDER BY is_collaborator DESC
+        """,
+        params,
+    )
+
+    contributor_rows = []
+    if contributor_available:
+        contributor_rows = query_rows(
+            cursor,
+            f"""
+            SELECT
+                COALESCE(o.is_contributor, FALSE) AS is_contributor,
+                COUNT(*) AS count
+            FROM {ORGANIZATIONS} o
+            {where_sql}
+            GROUP BY COALESCE(o.is_contributor, FALSE)
+            ORDER BY is_contributor DESC
+            """,
+            params,
+        )
+
+    return {
+        "organization_overview": {
+            "summary": summary,
+            "organization_activity_trend": [
+                {"period": row["period"], "count": int(row["count"])}
+                for row in activity_rows
+            ],
+            "organizations_by_type": [
+                {"type": row["type"], "count": int(row["count"])}
+                for row in type_rows
+            ],
+            "organizations_by_size": [
+                {"size": row["size"], "count": int(row["count"])}
+                for row in size_rows
+            ],
+            "organizations_by_location": [
+                {
+                    "state": row["state"],
+                    "state_code": row["state_code"],
+                    "city": row["city"],
+                    "count": int(row["count"]),
+                }
+                for row in location_rows
+            ],
+            "collaborator_distribution": [
+                {
+                    "is_collaborator": bool(row["is_collaborator"]),
+                    "count": int(row["count"]),
+                }
+                for row in collaborator_rows
+            ],
+            "contributor_distribution": [
+                {
+                    "is_contributor": bool(row["is_contributor"]),
+                    "count": int(row["count"]),
+                }
+                for row in contributor_rows
+            ],
+        }
+    }
+
+
+def get_performance(cursor, options, contributor_available):
+    """Return metrics for the Organization Performance dashboard."""
+    where_sql, params = build_where_clause(options, contributor_available)
+
+    cursor.execute(
+        f"""
+        SELECT
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) FILTER (
+                WHERE o.org_rating IS NOT NULL
+            ) AS rated_organizations,
+            COUNT(*) FILTER (
+                WHERE o.org_rating IS NULL
+            ) AS unrated_organizations,
+            COUNT(*) FILTER (
+                WHERE o.org_rating = 5
+            ) AS five_star_organizations
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        """,
+        params,
+    )
+    summary = dict(cursor.fetchone())
+    summary["average_rating"] = (
+        float(summary["average_rating"])
+        if summary["average_rating"] is not None
+        else None
+    )
+    for key in (
+        "rated_organizations",
+        "unrated_organizations",
+        "five_star_organizations",
+    ):
+        summary[key] = int(summary[key])
+
+    rating_rows = query_rows(
+        cursor,
+        f"""
+        SELECT o.org_rating AS rating, COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY o.org_rating
+        ORDER BY o.org_rating NULLS LAST
+        """,
+        params,
+    )
+
+    def top_organizations(extra_clause):
+        combined_where = (
+            f"{where_sql} AND {extra_clause}"
+            if where_sql
+            else f"WHERE {extra_clause}"
+        )
+        rows = query_rows(
+            cursor,
+            f"""
+            SELECT
+                o.org_id,
+                o.org_name,
+                o.org_rating AS rating,
+                o.org_type AS type,
+                o.org_size AS size
+            FROM {ORGANIZATIONS} o
+            {combined_where}
+            ORDER BY o.org_rating DESC NULLS LAST, o.org_name
+            LIMIT 10
+            """,
+            params,
+        )
+        return [
+            {
+                "org_id": row["org_id"],
+                "org_name": row["org_name"],
+                "rating": row["rating"],
+                "type": row["type"],
+                "size": row["size"],
+            }
+            for row in rows
+        ]
+
+    type_rating_rows = query_rows(
+        cursor,
+        f"""
+        SELECT
+            o.org_type AS type,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY o.org_type
+        ORDER BY o.org_type
+        """,
+        params,
+    )
+
+    size_rating_rows = query_rows(
+        cursor,
+        f"""
+        SELECT
+            o.org_size AS size,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) AS count
+        FROM {ORGANIZATIONS} o
+        {where_sql}
+        GROUP BY o.org_size
+        ORDER BY o.org_size
+        """,
+        params,
+    )
+
+    return {
+        "organization_performance": {
+            "summary": summary,
+            "rating_distribution": [
+                {"rating": row["rating"], "count": int(row["count"])}
+                for row in rating_rows
+            ],
+            "top_rated_organizations": top_organizations(
+                "o.org_rating IS NOT NULL"
+            ),
+            "top_collaborator_organizations": top_organizations(
+                "o.is_collaborator IS TRUE"
+            ),
+            "top_contributor_organizations": (
+                top_organizations("o.is_contributor IS TRUE")
+                if contributor_available
+                else []
+            ),
+            "ratings_by_organization_type": [
+                {
+                    "type": row["type"],
+                    "average_rating": (
+                        float(row["average_rating"])
+                        if row["average_rating"] is not None
+                        else None
+                    ),
+                    "count": int(row["count"]),
+                }
+                for row in type_rating_rows
+            ],
+            "ratings_by_organization_size": [
+                {
+                    "size": row["size"],
+                    "average_rating": (
+                        float(row["average_rating"])
+                        if row["average_rating"] is not None
+                        else None
+                    ),
+                    "count": int(row["count"]),
+                }
+                for row in size_rating_rows
+            ],
+        }
+    }
+
+
+def lambda_handler(event, context):
+    """Handle Organization Overview and Performance analytics requests."""
+    connection = None
+    cursor = None
+
+    try:
+        request = parse_event_body(event)
+        connection = get_db_connection()
+        cursor = connection.cursor(cursor_factory=RealDictCursor)
+
+        contributor_available = has_contributor_column(cursor)
+        options = validate_request(request, contributor_available)
+
+        if options["dashboard_type"] == "performance":
+            response_body = get_performance(
+                cursor,
+                options,
+                contributor_available,
+            )
+        else:
+            response_body = get_overview(
+                cursor,
+                options,
+                contributor_available,
+            )
+
+        return build_response(200, response_body)
+
+    except ValueError as error:
+        return build_response(400, {"error": str(error)})
+    except psycopg2.Error as error:
+        return build_response(
+            500,
+            {"error": "Database query failed.", "details": str(error)},
+        )
+    except Exception as error:
+        return build_response(
+            500,
+            {"error": "Unexpected server error.", "details": str(error)},
+        )
+    finally:
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()

--- a/data-analytics/lambda_functions/test_organization_analytics.py
+++ b/data-analytics/lambda_functions/test_organization_analytics.py
@@ -1,0 +1,180 @@
+import json
+from datetime import date, timedelta
+
+from organization_analytics import lambda_handler
+
+
+def run_case(name, payload, expected_status=200):
+    """Run one API request and print the result."""
+    result = lambda_handler({"body": json.dumps(payload)}, None)
+    status_code = result["statusCode"]
+    response_body = json.loads(result["body"])
+
+    print(f"\n{'=' * 70}")
+    print(name)
+    print(f"Request: {json.dumps(payload)}")
+    print(f"Status code: {status_code}")
+
+    if status_code != expected_status:
+        raise AssertionError(
+            f"{name}: expected {expected_status}, received {status_code}"
+        )
+
+    print(json.dumps(response_body, indent=2, default=str))
+    return response_body
+
+def test_missing_contributor_column():
+    """Verify the API works when is_contributor is absent."""
+    import os
+    import psycopg2
+
+    connection = psycopg2.connect(
+        host=os.getenv("DB_HOST", "localhost"),
+        port=os.getenv("DB_PORT", "5432"),
+        database=os.getenv("DB_NAME", "saayam_analytics"),
+        user=os.getenv("DB_USER"),
+        password=os.getenv("DB_PASSWORD", ""),
+    )
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                ALTER TABLE virginia_dev_saayam_rdbms.organizations
+                DROP COLUMN is_contributor
+                """
+            )
+            connection.commit()
+
+        overview = run_case(
+            "11. Overview — database without is_contributor",
+            {"time_filter": "ALL"},
+        )
+        summary = overview["organization_overview"]["summary"]
+        assert summary["contributor_organizations"] is None
+        assert summary["non_contributor_organizations"] is None
+        assert overview["organization_overview"]["contributor_distribution"] == []
+
+        performance = run_case(
+            "12. Performance — database without is_contributor",
+            {"dashboard_type": "performance", "time_filter": "ALL"},
+        )
+        assert (
+            performance["organization_performance"][
+                "top_contributor_organizations"
+            ]
+            == []
+        )
+
+        run_case(
+            "13. Contributor filter without database column",
+            {"time_filter": "ALL", "is_contributor": True},
+            expected_status=400,
+        )
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                ALTER TABLE virginia_dev_saayam_rdbms.organizations
+                ADD COLUMN IF NOT EXISTS is_contributor BOOLEAN
+                """
+            )
+        connection.commit()
+        connection.close()
+def main():
+    """Run local Organization Analytics API test cases."""
+    overview = run_case(
+        "1. Overview dashboard — default filters",
+        {},
+    )
+    assert (
+        overview["organization_overview"]["summary"]["total_organizations"]
+        == 8
+    )
+
+    run_case(
+        "2. Overview dashboard — all organizations",
+        {
+            "dashboard_type": "overview",
+            "time_filter": "ALL",
+            "group_by": "monthly",
+        },
+    )
+
+    run_case(
+        "3. Overview dashboard — type, state, and size filters",
+        {
+            "dashboard_type": "overview",
+            "time_filter": "ALL",
+            "org_type": "non_profit",
+            "org_size": "large",
+            "state_id": "CA",
+        },
+    )
+
+    run_case(
+        "4. Overview dashboard — case-insensitive city filter",
+        {
+            "dashboard_type": "overview",
+            "time_filter": "ALL",
+            "city_name": "chicago",
+        },
+    )
+
+    run_case(
+        "5. Overview dashboard — collaborator and contributor filters",
+        {
+            "dashboard_type": "overview",
+            "time_filter": "ALL",
+            "is_collaborator": False,
+            "is_contributor": True,
+        },
+    )
+
+    run_case(
+        "6. Overview dashboard — custom date range",
+        {
+            "dashboard_type": "overview",
+            "time_filter": "CUSTOM",
+            "start_date": str(date.today() - timedelta(days=30)),
+            "end_date": str(date.today()),
+            "group_by": "weekly",
+        },
+    )
+
+    run_case(
+        "7. Performance dashboard — all organizations",
+        {
+            "dashboard_type": "performance",
+            "time_filter": "ALL",
+        },
+    )
+
+    run_case(
+        "8. Performance dashboard — five-star organizations",
+        {
+            "dashboard_type": "performance",
+            "time_filter": "ALL",
+            "org_rating": 5,
+        },
+    )
+
+    run_case(
+        "9. Invalid dashboard type",
+        {
+            "dashboard_type": "invalid",
+        },
+        expected_status=400,
+    )
+
+    run_case(
+        "10. Invalid organization rating",
+        {
+            "org_rating": 6,
+        },
+        expected_status=400,
+    )
+    test_missing_contributor_column()
+
+if __name__ == "__main__":
+    main()

--- a/data-analytics/organization_analytics_test_output.txt
+++ b/data-analytics/organization_analytics_test_output.txt
@@ -1,0 +1,1681 @@
+
+======================================================================
+1. Overview dashboard — default filters
+Request: {}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 8,
+      "non_profit_organizations": 6,
+      "for_profit_organizations": 2,
+      "collaborator_organizations": 4,
+      "non_collaborator_organizations": 4,
+      "contributor_organizations": 4,
+      "non_contributor_organizations": 4
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2026-07-09",
+        "count": 1
+      },
+      {
+        "period": "2026-07-15",
+        "count": 1
+      },
+      {
+        "period": "2026-07-19",
+        "count": 1
+      },
+      {
+        "period": "2026-07-27",
+        "count": 1
+      },
+      {
+        "period": "2026-07-31",
+        "count": 1
+      },
+      {
+        "period": "2026-08-01",
+        "count": 1
+      },
+      {
+        "period": "2026-08-03",
+        "count": 1
+      },
+      {
+        "period": "2026-08-05",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 6
+      },
+      {
+        "type": "for_profit",
+        "count": 2
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "small",
+        "count": 3
+      },
+      {
+        "size": "medium",
+        "count": 3
+      },
+      {
+        "size": "large",
+        "count": 2
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Fresno",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Sacramento",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Chicago",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Albany",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Buffalo",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Austin",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Ashburn",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Richmond",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 4
+      },
+      {
+        "is_collaborator": false,
+        "count": 4
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 4
+      },
+      {
+        "is_contributor": false,
+        "count": 4
+      }
+    ]
+  }
+}
+
+======================================================================
+2. Overview dashboard — all organizations
+Request: {"dashboard_type": "overview", "time_filter": "ALL", "group_by": "monthly"}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 20,
+      "non_profit_organizations": 14,
+      "for_profit_organizations": 6,
+      "collaborator_organizations": 10,
+      "non_collaborator_organizations": 10,
+      "contributor_organizations": 11,
+      "non_contributor_organizations": 9
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2024-12",
+        "count": 1
+      },
+      {
+        "period": "2025-03",
+        "count": 1
+      },
+      {
+        "period": "2025-05",
+        "count": 1
+      },
+      {
+        "period": "2025-07",
+        "count": 1
+      },
+      {
+        "period": "2025-10",
+        "count": 1
+      },
+      {
+        "period": "2025-11",
+        "count": 1
+      },
+      {
+        "period": "2026-01",
+        "count": 1
+      },
+      {
+        "period": "2026-03",
+        "count": 1
+      },
+      {
+        "period": "2026-04",
+        "count": 1
+      },
+      {
+        "period": "2026-05",
+        "count": 2
+      },
+      {
+        "period": "2026-06",
+        "count": 1
+      },
+      {
+        "period": "2026-07",
+        "count": 5
+      },
+      {
+        "period": "2026-08",
+        "count": 3
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 14
+      },
+      {
+        "type": "for_profit",
+        "count": 6
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "small",
+        "count": 7
+      },
+      {
+        "size": "medium",
+        "count": 8
+      },
+      {
+        "size": "large",
+        "count": 5
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Fresno",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Oakland",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Sacramento",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "San Jose",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Chicago",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Naperville",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Peoria",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Springfield",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Albany",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Buffalo",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Rochester",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Syracuse",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Austin",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Dallas",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Houston",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "San Antonio",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Alexandria",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Ashburn",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Norfolk",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Richmond",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 10
+      },
+      {
+        "is_collaborator": false,
+        "count": 10
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 11
+      },
+      {
+        "is_contributor": false,
+        "count": 9
+      }
+    ]
+  }
+}
+
+======================================================================
+3. Overview dashboard — type, state, and size filters
+Request: {"dashboard_type": "overview", "time_filter": "ALL", "org_type": "non_profit", "org_size": "large", "state_id": "CA"}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 3,
+      "non_profit_organizations": 3,
+      "for_profit_organizations": 0,
+      "collaborator_organizations": 2,
+      "non_collaborator_organizations": 1,
+      "contributor_organizations": 2,
+      "non_contributor_organizations": 1
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2025-05-13",
+        "count": 1
+      },
+      {
+        "period": "2026-07-09",
+        "count": 1
+      },
+      {
+        "period": "2026-08-01",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 3
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "large",
+        "count": 3
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Fresno",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Sacramento",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "San Jose",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 2
+      },
+      {
+        "is_collaborator": false,
+        "count": 1
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 2
+      },
+      {
+        "is_contributor": false,
+        "count": 1
+      }
+    ]
+  }
+}
+
+======================================================================
+4. Overview dashboard — case-insensitive city filter
+Request: {"dashboard_type": "overview", "time_filter": "ALL", "city_name": "chicago"}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 1,
+      "non_profit_organizations": 1,
+      "for_profit_organizations": 0,
+      "collaborator_organizations": 1,
+      "non_collaborator_organizations": 0,
+      "contributor_organizations": 1,
+      "non_contributor_organizations": 0
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2026-07-27",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 1
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "small",
+        "count": 1
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Chicago",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 1
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 1
+      }
+    ]
+  }
+}
+
+======================================================================
+5. Overview dashboard — collaborator and contributor filters
+Request: {"dashboard_type": "overview", "time_filter": "ALL", "is_collaborator": false, "is_contributor": true}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 5,
+      "non_profit_organizations": 2,
+      "for_profit_organizations": 3,
+      "collaborator_organizations": 0,
+      "non_collaborator_organizations": 5,
+      "contributor_organizations": 5,
+      "non_contributor_organizations": 0
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2025-10-10",
+        "count": 1
+      },
+      {
+        "period": "2026-03-09",
+        "count": 1
+      },
+      {
+        "period": "2026-05-28",
+        "count": 1
+      },
+      {
+        "period": "2026-07-19",
+        "count": 1
+      },
+      {
+        "period": "2026-08-01",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 2
+      },
+      {
+        "type": "for_profit",
+        "count": 3
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "small",
+        "count": 1
+      },
+      {
+        "size": "medium",
+        "count": 2
+      },
+      {
+        "size": "large",
+        "count": 2
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Oakland",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Sacramento",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Springfield",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Norfolk",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Richmond",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": false,
+        "count": 5
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 5
+      }
+    ]
+  }
+}
+
+======================================================================
+6. Overview dashboard — custom date range
+Request: {"dashboard_type": "overview", "time_filter": "CUSTOM", "start_date": "2026-07-07", "end_date": "2026-08-06", "group_by": "weekly"}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 8,
+      "non_profit_organizations": 6,
+      "for_profit_organizations": 2,
+      "collaborator_organizations": 4,
+      "non_collaborator_organizations": 4,
+      "contributor_organizations": 4,
+      "non_contributor_organizations": 4
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2026-W28",
+        "count": 1
+      },
+      {
+        "period": "2026-W29",
+        "count": 2
+      },
+      {
+        "period": "2026-W31",
+        "count": 3
+      },
+      {
+        "period": "2026-W32",
+        "count": 2
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 6
+      },
+      {
+        "type": "for_profit",
+        "count": 2
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "small",
+        "count": 3
+      },
+      {
+        "size": "medium",
+        "count": 3
+      },
+      {
+        "size": "large",
+        "count": 2
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Fresno",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Sacramento",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Chicago",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Albany",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Buffalo",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Austin",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Ashburn",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Richmond",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 4
+      },
+      {
+        "is_collaborator": false,
+        "count": 4
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 4
+      },
+      {
+        "is_contributor": false,
+        "count": 4
+      }
+    ]
+  }
+}
+
+======================================================================
+7. Performance dashboard — all organizations
+Request: {"dashboard_type": "performance", "time_filter": "ALL"}
+Status code: 200
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.56,
+      "rated_organizations": 16,
+      "unrated_organizations": 4,
+      "five_star_organizations": 5
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 1
+      },
+      {
+        "rating": 2,
+        "count": 3
+      },
+      {
+        "rating": 3,
+        "count": 3
+      },
+      {
+        "rating": 4,
+        "count": 4
+      },
+      {
+        "rating": 5,
+        "count": 5
+      },
+      {
+        "rating": null,
+        "count": 4
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG-LOCAL-011",
+        "org_name": "Capitol Care VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-015",
+        "org_name": "Windy City Works IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-002",
+        "org_name": "Community Bridge NY",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-008",
+        "org_name": "Golden State Aid CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-013",
+        "org_name": "Pacific Relief CA",
+        "rating": 4,
+        "type": "for_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-018",
+        "org_name": "Sunshine Support CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-009",
+        "org_name": "Lone Star Volunteers TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "medium"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG-LOCAL-011",
+        "org_name": "Capitol Care VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-015",
+        "org_name": "Windy City Works IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-002",
+        "org_name": "Community Bridge NY",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-008",
+        "org_name": "Golden State Aid CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-018",
+        "org_name": "Sunshine Support CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-009",
+        "org_name": "Lone Star Volunteers TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-014",
+        "org_name": "Southern Cross TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "large"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-013",
+        "org_name": "Pacific Relief CA",
+        "rating": 4,
+        "type": "for_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-018",
+        "org_name": "Sunshine Support CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-009",
+        "org_name": "Lone Star Volunteers TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-014",
+        "org_name": "Southern Cross TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-006",
+        "org_name": "Care Collective VA",
+        "rating": 2,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-010",
+        "org_name": "Prairie Partners IL",
+        "rating": 2,
+        "type": "for_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-016",
+        "org_name": "Old Dominion Outreach VA",
+        "rating": 1,
+        "type": "for_profit",
+        "size": "medium"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "type": "non_profit",
+        "average_rating": 4.09,
+        "count": 14
+      },
+      {
+        "type": "for_profit",
+        "average_rating": 2.4,
+        "count": 6
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "size": "small",
+        "average_rating": 4.2,
+        "count": 7
+      },
+      {
+        "size": "medium",
+        "average_rating": 3.29,
+        "count": 8
+      },
+      {
+        "size": "large",
+        "average_rating": 3.25,
+        "count": 5
+      }
+    ]
+  }
+}
+
+======================================================================
+8. Performance dashboard — five-star organizations
+Request: {"dashboard_type": "performance", "time_filter": "ALL", "org_rating": 5}
+Status code: 200
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 5.0,
+      "rated_organizations": 5,
+      "unrated_organizations": 0,
+      "five_star_organizations": 5
+    },
+    "rating_distribution": [
+      {
+        "rating": 5,
+        "count": 5
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG-LOCAL-011",
+        "org_name": "Capitol Care VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-015",
+        "org_name": "Windy City Works IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG-LOCAL-011",
+        "org_name": "Capitol Care VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-015",
+        "org_name": "Windy City Works IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "type": "non_profit",
+        "average_rating": 5.0,
+        "count": 5
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "size": "small",
+        "average_rating": 5.0,
+        "count": 3
+      },
+      {
+        "size": "medium",
+        "average_rating": 5.0,
+        "count": 2
+      }
+    ]
+  }
+}
+
+======================================================================
+9. Invalid dashboard type
+Request: {"dashboard_type": "invalid"}
+Status code: 400
+{
+  "error": "dashboard_type must be overview or performance."
+}
+
+======================================================================
+10. Invalid organization rating
+Request: {"org_rating": 6}
+Status code: 400
+{
+  "error": "org_rating must be an integer from 1 through 5."
+}
+
+======================================================================
+11. Overview — database without is_contributor
+Request: {"time_filter": "ALL"}
+Status code: 200
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 20,
+      "non_profit_organizations": 14,
+      "for_profit_organizations": 6,
+      "collaborator_organizations": 10,
+      "non_collaborator_organizations": 10,
+      "contributor_organizations": null,
+      "non_contributor_organizations": null
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2024-12-14",
+        "count": 1
+      },
+      {
+        "period": "2025-03-24",
+        "count": 1
+      },
+      {
+        "period": "2025-05-13",
+        "count": 1
+      },
+      {
+        "period": "2025-07-02",
+        "count": 1
+      },
+      {
+        "period": "2025-10-10",
+        "count": 1
+      },
+      {
+        "period": "2025-11-29",
+        "count": 1
+      },
+      {
+        "period": "2026-01-18",
+        "count": 1
+      },
+      {
+        "period": "2026-03-09",
+        "count": 1
+      },
+      {
+        "period": "2026-04-08",
+        "count": 1
+      },
+      {
+        "period": "2026-05-08",
+        "count": 1
+      },
+      {
+        "period": "2026-05-28",
+        "count": 1
+      },
+      {
+        "period": "2026-06-22",
+        "count": 1
+      },
+      {
+        "period": "2026-07-09",
+        "count": 1
+      },
+      {
+        "period": "2026-07-15",
+        "count": 1
+      },
+      {
+        "period": "2026-07-19",
+        "count": 1
+      },
+      {
+        "period": "2026-07-27",
+        "count": 1
+      },
+      {
+        "period": "2026-07-31",
+        "count": 1
+      },
+      {
+        "period": "2026-08-01",
+        "count": 1
+      },
+      {
+        "period": "2026-08-03",
+        "count": 1
+      },
+      {
+        "period": "2026-08-05",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "type": "non_profit",
+        "count": 14
+      },
+      {
+        "type": "for_profit",
+        "count": 6
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "size": "small",
+        "count": 7
+      },
+      {
+        "size": "medium",
+        "count": 8
+      },
+      {
+        "size": "large",
+        "count": 5
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Fresno",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Oakland",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "Sacramento",
+        "count": 1
+      },
+      {
+        "state": "California",
+        "state_code": "CA",
+        "city": "San Jose",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Chicago",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Naperville",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Peoria",
+        "count": 1
+      },
+      {
+        "state": "Illinois",
+        "state_code": "IL",
+        "city": "Springfield",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Albany",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Buffalo",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Rochester",
+        "count": 1
+      },
+      {
+        "state": "New York",
+        "state_code": "NY",
+        "city": "Syracuse",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Austin",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Dallas",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "Houston",
+        "count": 1
+      },
+      {
+        "state": "Texas",
+        "state_code": "TX",
+        "city": "San Antonio",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Alexandria",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Ashburn",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Norfolk",
+        "count": 1
+      },
+      {
+        "state": "Virginia",
+        "state_code": "VA",
+        "city": "Richmond",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 10
+      },
+      {
+        "is_collaborator": false,
+        "count": 10
+      }
+    ],
+    "contributor_distribution": []
+  }
+}
+
+======================================================================
+12. Performance — database without is_contributor
+Request: {"dashboard_type": "performance", "time_filter": "ALL"}
+Status code: 200
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.56,
+      "rated_organizations": 16,
+      "unrated_organizations": 4,
+      "five_star_organizations": 5
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 1
+      },
+      {
+        "rating": 2,
+        "count": 3
+      },
+      {
+        "rating": 3,
+        "count": 3
+      },
+      {
+        "rating": 4,
+        "count": 4
+      },
+      {
+        "rating": 5,
+        "count": 5
+      },
+      {
+        "rating": null,
+        "count": 4
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG-LOCAL-011",
+        "org_name": "Capitol Care VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-015",
+        "org_name": "Windy City Works IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-002",
+        "org_name": "Community Bridge NY",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-008",
+        "org_name": "Golden State Aid CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-013",
+        "org_name": "Pacific Relief CA",
+        "rating": 4,
+        "type": "for_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-018",
+        "org_name": "Sunshine Support CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-009",
+        "org_name": "Lone Star Volunteers TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "medium"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG-LOCAL-011",
+        "org_name": "Capitol Care VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-020",
+        "org_name": "Great Lakes Giving IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-001",
+        "org_name": "Helping Hands VA",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-005",
+        "org_name": "Neighbor Network IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "small"
+      },
+      {
+        "org_id": "ORG-LOCAL-015",
+        "org_name": "Windy City Works IL",
+        "rating": 5,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-002",
+        "org_name": "Community Bridge NY",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-008",
+        "org_name": "Golden State Aid CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-018",
+        "org_name": "Sunshine Support CA",
+        "rating": 4,
+        "type": "non_profit",
+        "size": "large"
+      },
+      {
+        "org_id": "ORG-LOCAL-009",
+        "org_name": "Lone Star Volunteers TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "medium"
+      },
+      {
+        "org_id": "ORG-LOCAL-014",
+        "org_name": "Southern Cross TX",
+        "rating": 3,
+        "type": "non_profit",
+        "size": "large"
+      }
+    ],
+    "top_contributor_organizations": [],
+    "ratings_by_organization_type": [
+      {
+        "type": "non_profit",
+        "average_rating": 4.09,
+        "count": 14
+      },
+      {
+        "type": "for_profit",
+        "average_rating": 2.4,
+        "count": 6
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "size": "small",
+        "average_rating": 4.2,
+        "count": 7
+      },
+      {
+        "size": "medium",
+        "average_rating": 3.29,
+        "count": 8
+      },
+      {
+        "size": "large",
+        "average_rating": 3.25,
+        "count": 5
+      }
+    ]
+  }
+}
+
+======================================================================
+13. Contributor filter without database column
+Request: {"time_filter": "ALL", "is_contributor": true}
+Status code: 400
+{
+  "error": "is_contributor filtering is unavailable because the database does not yet contain the is_contributor column."
+}

--- a/data-analytics/sql/organizations_local_setup.sql
+++ b/data-analytics/sql/organizations_local_setup.sql
@@ -1,0 +1,106 @@
+-- Local-only schema + seed data for developing/testing the Organization Analytics API.
+-- Mirrors ddl_organizations.sql / ddl_state.sql from saayam-for-all/database, minus the
+-- org_id sequence/trigger (we insert explicit org_id values instead) and minus the FK to
+-- `country`, since we're not standing up that whole table just for this.
+-- Safe to re-run: types/tables are guarded, inserts use ON CONFLICT DO NOTHING.
+
+CREATE SCHEMA IF NOT EXISTS virginia_dev_saayam_rdbms;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'org_type_enum') THEN
+        CREATE TYPE org_type_enum AS ENUM ('non_profit', 'for_profit');
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'org_size_enum') THEN
+        CREATE TYPE org_size_enum AS ENUM ('small', 'medium', 'large');
+    END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS virginia_dev_saayam_rdbms.state (
+    state_id VARCHAR(50) PRIMARY KEY,
+    country_id INT NOT NULL,
+    state_name VARCHAR(100) NOT NULL,
+    state_code VARCHAR(6),
+    last_update_date TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS virginia_dev_saayam_rdbms.organizations (
+    org_id VARCHAR(255) PRIMARY KEY,
+    org_name VARCHAR(125) NOT NULL,
+    street VARCHAR(255),
+    city_name VARCHAR(100),
+    state_id VARCHAR(50),
+    zip_code VARCHAR(10),
+    mission TEXT,
+    web_url VARCHAR(255) CHECK (web_url IS NULL OR web_url LIKE 'http%'),
+    phone VARCHAR(20),
+    email VARCHAR(255) CHECK (email IS NULL OR email LIKE '%@%'),
+    org_type org_type_enum,
+    org_size org_size_enum,
+    org_rating INTEGER CHECK (org_rating >= 1 AND org_rating <= 5),
+    is_collaborator BOOLEAN,
+    is_contributor BOOLEAN,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
+    last_updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
+    FOREIGN KEY (state_id) REFERENCES virginia_dev_saayam_rdbms.state(state_id) ON DELETE SET NULL
+);
+
+-- Covers the case where this script already ran before is_contributor existed:
+-- CREATE TABLE IF NOT EXISTS is a no-op on an existing table, so the column
+-- needs its own guarded ADD.
+ALTER TABLE virginia_dev_saayam_rdbms.organizations
+    ADD COLUMN IF NOT EXISTS is_contributor BOOLEAN;
+
+CREATE INDEX IF NOT EXISTS idx_org_name ON virginia_dev_saayam_rdbms.organizations(org_name);
+CREATE INDEX IF NOT EXISTS idx_org_state_id ON virginia_dev_saayam_rdbms.organizations(state_id);
+CREATE INDEX IF NOT EXISTS idx_org_city_state ON virginia_dev_saayam_rdbms.organizations(city_name, state_id);
+
+INSERT INTO virginia_dev_saayam_rdbms.state (state_id, country_id, state_name, state_code, last_update_date) VALUES
+    ('VA', 1, 'Virginia', 'VA', now()),
+    ('NY', 1, 'New York', 'NY', now()),
+    ('CA', 1, 'California', 'CA', now()),
+    ('TX', 1, 'Texas', 'TX', now()),
+    ('IL', 1, 'Illinois', 'IL', now())
+ON CONFLICT (state_id) DO NOTHING;
+
+-- created_at is seeded relative to "now" (not hardcoded dates) so the 7D/30D/1Y/ALL time
+-- filters and daily/weekly/monthly/yearly grouping all have real data every time this runs.
+-- is_contributor is deliberately NOT a copy of is_collaborator on every row --
+-- keeping them independent is what actually exercises that the two filters/
+-- distributions are querying different columns instead of coincidentally
+-- agreeing because the seed data always sets them the same way.
+INSERT INTO virginia_dev_saayam_rdbms.organizations
+    (org_id, org_name, city_name, state_id, org_type, org_size, org_rating, is_collaborator, is_contributor, created_at) VALUES
+    ('ORG-LOCAL-001', 'Helping Hands VA',        'Ashburn',    'VA', 'non_profit', 'small',  5,    TRUE,  TRUE,  now() - INTERVAL '1 day'),
+    ('ORG-LOCAL-002', 'Community Bridge NY',      'Albany',     'NY', 'non_profit', 'medium', 4,    TRUE,  FALSE, now() - INTERVAL '3 days'),
+    ('ORG-LOCAL-003', 'Bright Future CA',         'Sacramento', 'CA', 'non_profit', 'large',  NULL, FALSE, TRUE,  now() - INTERVAL '5 days'),
+    ('ORG-LOCAL-004', 'TechForGood TX',           'Austin',     'TX', 'for_profit', 'medium', 3,    FALSE, FALSE, now() - INTERVAL '6 days'),
+    ('ORG-LOCAL-005', 'Neighbor Network IL',      'Chicago',    'IL', 'non_profit', 'small',  5,    TRUE,  TRUE,  now() - INTERVAL '10 days'),
+    ('ORG-LOCAL-006', 'Care Collective VA',       'Richmond',   'VA', 'non_profit', 'medium', 2,    FALSE, TRUE,  now() - INTERVAL '18 days'),
+    ('ORG-LOCAL-007', 'Urban Uplift NY',          'Buffalo',    'NY', 'for_profit', 'small',  NULL, FALSE, FALSE, now() - INTERVAL '22 days'),
+    ('ORG-LOCAL-008', 'Golden State Aid CA',      'Fresno',     'CA', 'non_profit', 'large',  4,    TRUE,  FALSE, now() - INTERVAL '28 days'),
+    ('ORG-LOCAL-009', 'Lone Star Volunteers TX',  'Houston',    'TX', 'non_profit', 'medium', 3,    TRUE,  TRUE,  now() - INTERVAL '45 days'),
+    ('ORG-LOCAL-010', 'Prairie Partners IL',      'Springfield','IL', 'for_profit', 'large',  2,    FALSE, TRUE,  now() - INTERVAL '70 days'),
+    ('ORG-LOCAL-011', 'Capitol Care VA',          'Alexandria', 'VA', 'non_profit', 'small',  5,    TRUE,  FALSE, now() - INTERVAL '90 days'),
+    ('ORG-LOCAL-012', 'Empire Outreach NY',       'Rochester',  'NY', 'non_profit', 'medium', NULL, FALSE, FALSE, now() - INTERVAL '120 days'),
+    ('ORG-LOCAL-013', 'Pacific Relief CA',        'Oakland',    'CA', 'for_profit', 'small',  4,    FALSE, TRUE,  now() - INTERVAL '150 days'),
+    ('ORG-LOCAL-014', 'Southern Cross TX',        'Dallas',     'TX', 'non_profit', 'large',  3,    TRUE,  TRUE,  now() - INTERVAL '200 days'),
+    ('ORG-LOCAL-015', 'Windy City Works IL',      'Naperville', 'IL', 'non_profit', 'medium', 5,    TRUE,  FALSE, now() - INTERVAL '250 days'),
+    ('ORG-LOCAL-016', 'Old Dominion Outreach VA', 'Norfolk',    'VA', 'for_profit', 'medium', 1,    FALSE, TRUE,  now() - INTERVAL '300 days'),
+    ('ORG-LOCAL-017', 'Empire State Aid NY',      'Syracuse',   'NY', 'non_profit', 'small',  NULL, FALSE, FALSE, now() - INTERVAL '400 days'),
+    ('ORG-LOCAL-018', 'Sunshine Support CA',      'San Jose',   'CA', 'non_profit', 'large',  4,    TRUE,  TRUE,  now() - INTERVAL '450 days'),
+    ('ORG-LOCAL-019', 'Texas Together TX',        'San Antonio','TX', 'for_profit', 'small',  2,    FALSE, FALSE, now() - INTERVAL '500 days'),
+    ('ORG-LOCAL-020', 'Great Lakes Giving IL',    'Peoria',     'IL', 'non_profit', 'medium', 5,    TRUE,  TRUE,  now() - INTERVAL '600 days')
+ON CONFLICT (org_id) DO NOTHING;
+
+-- Backfills is_contributor for rows inserted before this column existed (the
+-- ON CONFLICT DO NOTHING above skips existing rows entirely, so it won't
+-- touch this). Harmless no-op if every row is already correct.
+UPDATE virginia_dev_saayam_rdbms.organizations SET is_contributor = TRUE
+WHERE org_id IN ('ORG-LOCAL-001','ORG-LOCAL-003','ORG-LOCAL-005','ORG-LOCAL-006','ORG-LOCAL-009',
+                  'ORG-LOCAL-010','ORG-LOCAL-013','ORG-LOCAL-014','ORG-LOCAL-016','ORG-LOCAL-018','ORG-LOCAL-020')
+  AND is_contributor IS DISTINCT FROM TRUE;
+UPDATE virginia_dev_saayam_rdbms.organizations SET is_contributor = FALSE
+WHERE org_id IN ('ORG-LOCAL-002','ORG-LOCAL-004','ORG-LOCAL-007','ORG-LOCAL-008','ORG-LOCAL-011',
+                  'ORG-LOCAL-012','ORG-LOCAL-015','ORG-LOCAL-017','ORG-LOCAL-019')
+  AND is_contributor IS DISTINCT FROM FALSE;


### PR DESCRIPTION
## Summary
Implements the Organization Analytics API for issue #228.

## Included
- Organization Overview dashboard metrics: totals, type, size, location, collaborator/contributor distributions, and registration trends
- Organization Performance dashboard metrics: ratings, top organizations, and ratings by type/size
- Supported common filters, including time range, custom dates, type, size, state, city, rating, collaborator, and contributor status
- Local PostgreSQL schema, synthetic seed data, test runner, and captured test output

## Compatibility and security
- Uses local PostgreSQL configuration through environment variables.
- Does not use AWS Parameter Store, `boto3`, AWS credentials, or deployment code.
- Safely handles databases where `is_contributor` is unavailable:
  - Contributor counts return `null`
  - Contributor results return empty lists
  - Contributor filtering returns HTTP 400 with an explanatory error

## Testing
- Loaded and tested against 20 synthetic local organization records.
- Tested overview and performance responses, valid filters, custom dates, and invalid inputs.
- Tested missing `is_contributor` database-column behavior.

Closes #228