### PR TITLE
#228: Add Organization Analytics API for the Organization Dashboard

### DIFF
--- a/data-analytics/lambda_functions/README_organization_analytics.md
+++ b/data-analytics/lambda_functions/README_organization_analytics.md
@@ -1,0 +1,177 @@
+# Organization Analytics API
+
+Analytics API for the Saayam dashboard built on `virginia_dev_saayam_rdbms.organizations`
+(+ `state` for location names). Implemented as a single AWS Lambda
+(`organization_analytics.py`) following the same structure and coding standards as
+`kpi_api_analytics.py`, `volunteer_application_analytics.py`, and
+`beneficiariesTrendAnalysis.py` in `data-analytics/lambda_functions/`:
+
+- `psycopg2` + `RealDictCursor`, schema constant `SCHEMA_NAME`
+- Per-metric error isolation with a safe default response so one failed query never
+  takes down the whole dashboard. PostgreSQL aborts the surrounding transaction on
+  error, so the connection runs in autocommit and `run_metric()` rolls back after a
+  failure — otherwise the *next* metric would fail with `InFailedSqlTransaction` and
+  the degradation would cascade instead of staying contained
+- `build_response()` with CORS headers, `parse_event_body()` supporting both
+  direct invocation and API-Gateway-style stringified bodies
+- Parameterized SQL for every user-supplied filter value
+
+## Label normalization (org_type / org_size)
+
+`ddl_organizations.sql` declares both columns as lowercase enums
+(`non_profit`, `for_profit`, `small`, `medium`, `large`), but the source extracts
+in `data-analytics/sql/organizations.csv` carry display labels (`Non-Profit`,
+`For-profit`, `Small`). Matching on the raw value would silently report **0** for
+every type bucket wherever the labelled form is stored.
+
+Both sides are therefore normalized — the SQL applies
+`REPLACE(LOWER(column::text), '-', '_')`, and incoming filter values go through the
+same transform. `Non-Profit`, `non profit`, and `NON_PROFIT` all resolve to
+`non_profit`, and the API always reports the enum form so the dashboard keys stay
+stable regardless of how a given environment stores the data.
+
+## Database credentials
+
+**No Parameter Store path appears anywhere in the code.** The Lambda reads the
+parameter *name* from an environment variable and resolves it at runtime:
+
+| Env var | Purpose |
+|---|---|
+| `DB_CREDENTIALS_PARAMETER` | Parameter Store name holding the analytics DB credentials JSON |
+| `AWS_REGION` | Region for the SSM client (defaults to `us-east-1`) |
+| `LOCAL_DB=true` | Bypasses SSM entirely and connects to local PostgreSQL |
+| `DB_HOST` / `DB_NAME` / `DB_USER` / `DB_PASSWORD` / `DB_PORT` | Local connection overrides |
+
+If `DB_CREDENTIALS_PARAMETER` is unset outside local mode, the handler raises a
+clear configuration error instead of falling back to a hard-coded path.
+
+## Endpoint
+
+Single endpoint with a dashboard selector (the alternative suggested in the task):
+
+```
+POST /analytics/organizations
+{ "dashboard_type": "overview" | "performance", ...filters }
+```
+
+## Filters (both dashboards)
+
+| Filter | Values | Default |
+|---|---|---|
+| `time_filter` | `7D`, `30D`, `1Y`, `ALL`, `CUSTOM` | `ALL` |
+| `start_date` / `end_date` | ISO `YYYY-MM-DD`, required with `CUSTOM` | `null` |
+| `org_type` | `non_profit`, `for_profit` | `null` |
+| `org_size` | `small`, `medium`, `large` | `null` |
+| `state_id` | two-letter id as in `state.csv`, e.g. `NY` | `null` |
+| `city_name` | case-insensitive match | `null` |
+| `org_rating` | 1–5 | `null` |
+| `is_collaborator` / `is_contributor` | boolean | `null` |
+| `group_by` | `daily`, `weekly`, `monthly`, `yearly` | `daily` |
+
+Unknown values for `time_filter`, `group_by` and out-of-range `org_rating` are
+sanitized to defaults. Requests that cannot be honoured return `400`:
+
+- invalid `dashboard_type`
+- `time_filter=CUSTOM` without both `start_date` and `end_date`
+- dates that are not ISO `YYYY-MM-DD`, or `start_date` later than `end_date`
+
+## Dashboard 1 — Overview
+
+`summary` (total / non-profit / for-profit / collaborator / non-collaborator /
+contributor / non-contributor counts), `organization_activity_trend`
+(new + cumulative registrations per period via `DATE_TRUNC`),
+`organizations_by_type`, `organizations_by_size`, `organizations_by_location`
+(state + city), `collaborator_distribution`, `contributor_distribution`.
+
+## Dashboard 2 — Performance
+
+`summary` (average rating, rated/unrated, five-star count), `rating_distribution`
+(always all five buckets 1–5, zero-filled via `generate_series` so the chart never
+loses a bar), `top_rated_organizations` (top 10), `top_collaborator_organizations`,
+`top_contributor_organizations`, `ratings_by_organization_type`,
+`ratings_by_organization_size`.
+
+## Schema note — `is_contributor`
+
+`ddl_organizations.sql` currently has `is_collaborator` but **no `is_contributor`
+column**, which the spec requires. Two things handle this:
+
+1. `ddl_add_is_contributor.sql` — migration to be raised as a companion PR against
+   `saayam-for-all/database` (same pattern as the earlier collaborator-flag change).
+2. The Lambda detects the column at runtime via `information_schema.columns`. When
+   it is missing, contributor counts return `0`, `contributor_distribution` and
+   `top_contributor_organizations` return `[]`, the `is_contributor` filter is
+   ignored, and the response carries a `schema_notes` entry explaining why. Every
+   other metric is unaffected — so this deploys safely against the current dev DB
+   and lights up automatically once the migration lands.
+
+Also noted while reading the DDL: the FK in `ddl_organizations.sql` references
+`states(state_id)` but `ddl_state.sql` creates the table as `state` — this API
+joins on `state` to match the actual table definition.
+
+## Local setup & testing
+
+```bash
+# 1. PostgreSQL schema + tables
+psql -d saayam_local -f organization_analytics_local_setup.sql
+
+# 2a. Load the real source extracts (../sql/organizations.csv, ../sql/state.csv)
+python3 organization_analytics_load_csv.py
+
+# 2b. Optional: 120 synthetic organizations for denser recent-window coverage
+python3 organization_analytics_seed_data.py
+
+# 3. Run the API locally
+LOCAL_DB=true python3 organization_analytics.py
+
+# 4. Full test suite (works against either dataset)
+LOCAL_DB=true python3 test_organization_analytics_local.py
+
+# 5. Regenerate the committed sample responses
+LOCAL_DB=true python3 organization_analytics_generate_samples.py
+```
+
+The suite probes the loaded data for a state, city, size and rating that actually
+exist before asserting on them, so it is valid against the real extract and the
+synthetic seed alike.
+
+## Test results
+
+**57/57 checks passed on both datasets** — the 40-row real extract
+(`organizations.csv` + `state.csv`) and the 120-row synthetic seed:
+
+- Both dashboards return 200 with the full suggested response structure
+- Cross-metric consistency: collaborator + non-collaborator = total; contributor +
+  non-contributor = total; type/size/location distributions each sum to total;
+  rating distribution sums to rated count; five-star summary matches distribution;
+  cumulative trend total matches summary total
+- Real extract: 40 organizations split 21 non-profit / 19 for-profit, 21 collaborators,
+  19 contributors, average rating 3.23, 12 five-star — matching the CSV row counts
+- Time filters monotonic on both datasets (real extract 7D=0 ≤ 30D=0 ≤ 1Y=11 ≤ ALL=40;
+  synthetic seed 7D=2 ≤ 30D=14 ≤ 1Y=105 ≤ ALL=120); CUSTOM range works
+- Display labels accepted: `org_type="Non-Profit"` returns the same summary as
+  `org_type="non_profit"`, and `org_size="LARGE"` the same as `large`
+- CUSTOM rejected with 400 when `end_date` is missing, when a date is not ISO, and
+  when `start_date` is after `end_date`
+- Every dimension filter verified (org_type, org_size, state_id, case-insensitive
+  city_name, org_rating, is_collaborator, is_contributor)
+- `rating_distribution` always returns buckets 1–5, including zeros
+- All four `group_by` granularities produce correct bucket counts over the 1Y window
+  (real extract daily=11, weekly=8, monthly=5, yearly=2)
+- Invalid `dashboard_type` → 400; invalid filter values sanitized → 200
+- API-Gateway-style stringified body parsed correctly
+- No Parameter Store path present in the source (asserted by pattern, so no such
+  literal exists in the tests either); missing `DB_CREDENTIALS_PARAMETER` raises a
+  clear configuration error
+- Failure isolation: with one metric forced to raise a live SQL error, the request
+  still returns 200, that section falls back to its default, and every later metric
+  on the same connection still returns correct data
+- Graceful degradation with `is_contributor` absent: overview and performance still
+  return 200, non-contributor metrics unchanged, contributor metrics zero/empty,
+  `schema_notes` present, `is_contributor` filter ignored rather than fatal
+
+Sample responses (generated from the real extract):
+`sample_response_overview_ALL_monthly.json`,
+`sample_response_overview_1Y_daily.json`,
+`sample_response_performance_ALL.json`,
+`sample_response_performance_filtered_nonprofit_large.json`.

--- a/data-analytics/lambda_functions/ddl_add_is_contributor.sql
+++ b/data-analytics/lambda_functions/ddl_add_is_contributor.sql
@@ -1,0 +1,13 @@
+-- Migration: add is_contributor flag to organizations
+-- Required by the Organization Analytics API (contributor distribution,
+-- top contributor organizations). Follows the same pattern as is_collaborator
+-- (see branch sanobar_113_add_collaborator_flag).
+--
+-- To be raised as a separate PR against saayam-for-all/database
+-- (ddl/Tables/ddl_organizations.sql should also be updated to include the column).
+
+ALTER TABLE virginia_dev_saayam_rdbms.organizations
+    ADD COLUMN IF NOT EXISTS is_contributor BOOLEAN;
+
+COMMENT ON COLUMN virginia_dev_saayam_rdbms.organizations.is_contributor
+    IS 'TRUE if the organization contributes resources/funding to Saayam.';

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,809 @@
+import json
+import os
+from datetime import date
+
+import boto3
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+
+SCHEMA_NAME = "virginia_dev_saayam_rdbms"
+
+# Name of the environment variable holding the Parameter Store name for the DB
+# credentials. The path itself is configured on the Lambda, never in the code.
+DB_CREDENTIALS_ENV_VAR = "DB_CREDENTIALS_PARAMETER"
+
+# Column required by the analytics spec but not yet present in the deployed
+# organizations table; contributor metrics degrade gracefully without it.
+CONTRIBUTOR_COLUMN = "is_contributor"
+
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+VALID_GROUP_BY = {"daily", "weekly", "monthly", "yearly"}
+VALID_DASHBOARDS = {"overview", "performance"}
+
+MIN_RATING = 1
+MAX_RATING = 5
+
+# ddl_organizations.sql declares org_type/org_size as lowercase enums
+# ('non_profit', 'small'), but the source extracts in data-analytics/sql
+# carry display labels ('Non-Profit', 'For-profit', 'Small'). Both are
+# normalized to the enum form so the API reports the same buckets either way.
+NORMALIZED_ORG_TYPE = "REPLACE(LOWER(o.org_type::text), '-', '_')"
+NORMALIZED_ORG_SIZE = "REPLACE(LOWER(o.org_size::text), '-', '_')"
+
+
+def normalize_label(value):
+    """'Non-Profit' / 'non profit' / 'NON_PROFIT' -> 'non_profit'."""
+    if value is None:
+        return None
+    return str(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+GROUP_BY_TRUNC = {
+    "daily": "day",
+    "weekly": "week",
+    "monthly": "month",
+    "yearly": "year"
+}
+
+TOP_N_LIMIT = 10
+
+
+def get_default_overview_response():
+    return {
+        "organization_overview": {
+            "summary": {
+                "total_organizations": 0,
+                "non_profit_organizations": 0,
+                "for_profit_organizations": 0,
+                "collaborator_organizations": 0,
+                "non_collaborator_organizations": 0,
+                "contributor_organizations": 0,
+                "non_contributor_organizations": 0
+            },
+            "organization_activity_trend": [],
+            "organizations_by_type": [],
+            "organizations_by_size": [],
+            "organizations_by_location": [],
+            "collaborator_distribution": [],
+            "contributor_distribution": []
+        }
+    }
+
+
+def get_default_performance_response():
+    return {
+        "organization_performance": {
+            "summary": {
+                "average_rating": 0,
+                "rated_organizations": 0,
+                "unrated_organizations": 0,
+                "five_star_organizations": 0
+            },
+            "rating_distribution": [],
+            "top_rated_organizations": [],
+            "top_collaborator_organizations": [],
+            "top_contributor_organizations": [],
+            "ratings_by_organization_type": [],
+            "ratings_by_organization_size": []
+        }
+    }
+
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*"
+        },
+        "body": json.dumps(body, default=str)
+    }
+
+
+def get_db_connection():
+    if os.environ.get("LOCAL_DB", "").lower() == "true":
+        conn = psycopg2.connect(
+            host=os.environ.get("DB_HOST", "localhost"),
+            database=os.environ.get("DB_NAME", "saayam_local"),
+            user=os.environ.get("DB_USER", "saayam"),
+            password=os.environ.get("DB_PASSWORD", "saayam_local"),
+            port=os.environ.get("DB_PORT", "5432")
+        )
+        # Read-only workload: each statement stands alone, so one failed metric
+        # cannot leave the connection in an aborted transaction.
+        conn.autocommit = True
+        return conn
+
+    parameter_name = os.environ.get(DB_CREDENTIALS_ENV_VAR)
+    if not parameter_name:
+        raise RuntimeError(
+            f"{DB_CREDENTIALS_ENV_VAR} is not set. Configure it on the Lambda with "
+            "the Parameter Store name that holds the analytics DB credentials, "
+            "or set LOCAL_DB=true for local PostgreSQL testing."
+        )
+
+    ssm = boto3.client("ssm", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+    response = ssm.get_parameter(Name=parameter_name, WithDecryption=True)
+    creds = json.loads(response["Parameter"]["Value"])
+    conn = psycopg2.connect(
+        host=creds["HOST"],
+        database=creds["DATABASE NAME"],
+        user=creds["USERNAME"],
+        password=creds["PASSWORD"],
+        port=creds["PORT"],
+        sslmode="require"
+    )
+    conn.autocommit = True
+    return conn
+
+
+def parse_event_body(event):
+    if not event:
+        return {}
+
+    body = event.get("body")
+
+    if body is None:
+        return event
+
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+    if isinstance(body, dict):
+        return body
+
+    return {}
+
+
+def has_contributor_column(cursor):
+    """The organizations table may not carry is_contributor yet (see task notes)."""
+    cursor.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = %s
+          AND table_name = 'organizations'
+          AND column_name = %s;
+        """,
+        [SCHEMA_NAME, CONTRIBUTOR_COLUMN]
+    )
+    return cursor.fetchone() is not None
+
+
+def parse_filters(request_body):
+    time_filter = str(request_body.get("time_filter", "ALL")).upper()
+    if time_filter not in VALID_TIME_FILTERS:
+        time_filter = "ALL"
+
+    group_by = str(request_body.get("group_by", "daily")).lower()
+    if group_by not in VALID_GROUP_BY:
+        group_by = "daily"
+
+    org_rating = request_body.get("org_rating", None)
+    if org_rating is not None:
+        try:
+            org_rating = int(org_rating)
+            if org_rating < MIN_RATING or org_rating > MAX_RATING:
+                org_rating = None
+        except (TypeError, ValueError):
+            org_rating = None
+
+    return {
+        "time_filter": time_filter,
+        "start_date": request_body.get("start_date", None),
+        "end_date": request_body.get("end_date", None),
+        "org_type": request_body.get("org_type", None),
+        "org_size": request_body.get("org_size", None),
+        "state_id": request_body.get("state_id", None),
+        "city_name": request_body.get("city_name", None),
+        "org_rating": org_rating,
+        "is_collaborator": request_body.get("is_collaborator", None),
+        "is_contributor": request_body.get("is_contributor", None),
+        "group_by": group_by
+    }
+
+
+def validate_filters(filters):
+    """Return an error message for filter combinations that cannot be honoured."""
+    if filters["time_filter"] != "CUSTOM":
+        return None
+
+    start_date = filters["start_date"]
+    end_date = filters["end_date"]
+
+    if not start_date or not end_date:
+        return "time_filter 'CUSTOM' requires both start_date and end_date (YYYY-MM-DD)."
+
+    try:
+        parsed_start = date.fromisoformat(str(start_date))
+        parsed_end = date.fromisoformat(str(end_date))
+    except ValueError:
+        return "start_date and end_date must be ISO dates in YYYY-MM-DD format."
+
+    if parsed_start > parsed_end:
+        return "start_date must not be later than end_date."
+
+    return None
+
+
+def build_date_filter(filters, column="o.created_at"):
+    time_filter = filters["time_filter"]
+    start_date = filters["start_date"]
+    end_date = filters["end_date"]
+
+    if time_filter == "CUSTOM" and start_date and end_date:
+        return f"{column}::date BETWEEN %s AND %s", [start_date, end_date]
+    if time_filter == "7D":
+        return f"{column} >= CURRENT_DATE - INTERVAL '7 days'", []
+    if time_filter == "30D":
+        return f"{column} >= CURRENT_DATE - INTERVAL '30 days'", []
+    if time_filter == "1Y":
+        return f"{column} >= CURRENT_DATE - INTERVAL '1 year'", []
+
+    return "", []
+
+
+def build_condition_list(filters):
+    """SQL conditions + params for every active filter, without the WHERE keyword."""
+    conditions = []
+    params = []
+
+    date_condition, date_params = build_date_filter(filters)
+    if date_condition:
+        conditions.append(date_condition)
+        params.extend(date_params)
+
+    if filters["org_type"]:
+        conditions.append(f"{NORMALIZED_ORG_TYPE} = %s")
+        params.append(normalize_label(filters["org_type"]))
+
+    if filters["org_size"]:
+        conditions.append(f"{NORMALIZED_ORG_SIZE} = %s")
+        params.append(normalize_label(filters["org_size"]))
+
+    if filters["state_id"]:
+        conditions.append("o.state_id = %s")
+        params.append(filters["state_id"])
+
+    if filters["city_name"]:
+        conditions.append("LOWER(o.city_name) = LOWER(%s)")
+        params.append(filters["city_name"])
+
+    if filters["org_rating"] is not None:
+        conditions.append("o.org_rating = %s")
+        params.append(filters["org_rating"])
+
+    if filters["is_collaborator"] is not None:
+        conditions.append("o.is_collaborator = %s")
+        params.append(bool(filters["is_collaborator"]))
+
+    if filters["is_contributor"] is not None and filters.get("_has_contributor"):
+        conditions.append(f"o.{CONTRIBUTOR_COLUMN} = %s")
+        params.append(bool(filters["is_contributor"]))
+
+    return conditions, params
+
+
+def build_common_filters(filters):
+    conditions, params = build_condition_list(filters)
+    where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    return where_clause, params
+
+
+# ---------------------------------------------------------------------------
+# Dashboard 1: Organization Overview
+# ---------------------------------------------------------------------------
+
+def fetch_overview_summary(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+
+    if filters.get("_has_contributor"):
+        contributor_columns = f"""
+            COUNT(o.org_id) FILTER (WHERE o.{CONTRIBUTOR_COLUMN} IS TRUE) AS contributor_organizations,
+            COUNT(o.org_id) FILTER (WHERE o.{CONTRIBUTOR_COLUMN} IS NOT TRUE) AS non_contributor_organizations"""
+    else:
+        contributor_columns = """
+            0 AS contributor_organizations,
+            0 AS non_contributor_organizations"""
+
+    query = f"""
+        SELECT
+            COUNT(o.org_id) AS total_organizations,
+            COUNT(o.org_id) FILTER (WHERE {NORMALIZED_ORG_TYPE} = 'non_profit') AS non_profit_organizations,
+            COUNT(o.org_id) FILTER (WHERE {NORMALIZED_ORG_TYPE} = 'for_profit') AS for_profit_organizations,
+            COUNT(o.org_id) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborator_organizations,
+            COUNT(o.org_id) FILTER (WHERE o.is_collaborator IS NOT TRUE) AS non_collaborator_organizations,
+            {contributor_columns}
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause};
+    """
+
+    cursor.execute(query, params)
+    row = cursor.fetchone()
+
+    return {
+        "total_organizations": int(row["total_organizations"]),
+        "non_profit_organizations": int(row["non_profit_organizations"]),
+        "for_profit_organizations": int(row["for_profit_organizations"]),
+        "collaborator_organizations": int(row["collaborator_organizations"]),
+        "non_collaborator_organizations": int(row["non_collaborator_organizations"]),
+        "contributor_organizations": int(row["contributor_organizations"]),
+        "non_contributor_organizations": int(row["non_contributor_organizations"])
+    }
+
+
+def fetch_organization_activity_trend(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+    trunc_unit = GROUP_BY_TRUNC[filters["group_by"]]
+
+    query = f"""
+        SELECT
+            DATE_TRUNC('{trunc_unit}', o.created_at)::date AS period,
+            COUNT(o.org_id) AS new_organizations
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause}
+        GROUP BY period
+        ORDER BY period;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    trend = []
+    running_total = 0
+    for row in rows:
+        running_total += int(row["new_organizations"])
+        trend.append({
+            "period": str(row["period"]),
+            "new_organizations": int(row["new_organizations"]),
+            "total_organizations": running_total
+        })
+    return trend
+
+
+def fetch_organizations_by_type(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+
+    query = f"""
+        SELECT
+            {NORMALIZED_ORG_TYPE} AS type,
+            COUNT(o.org_id) AS count
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause}
+        GROUP BY {NORMALIZED_ORG_TYPE}
+        ORDER BY count DESC;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "type": row["type"] if row["type"] is not None else "unknown",
+            "count": int(row["count"])
+        }
+        for row in rows
+    ]
+
+
+def fetch_organizations_by_size(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+
+    query = f"""
+        SELECT
+            {NORMALIZED_ORG_SIZE} AS size,
+            COUNT(o.org_id) AS count
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause}
+        GROUP BY {NORMALIZED_ORG_SIZE}
+        ORDER BY count DESC;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "size": row["size"] if row["size"] is not None else "unknown",
+            "count": int(row["count"])
+        }
+        for row in rows
+    ]
+
+
+def fetch_organizations_by_location(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+
+    query = f"""
+        SELECT
+            COALESCE(s.state_name, 'Unknown') AS state,
+            COALESCE(o.city_name, 'Unknown') AS city,
+            COUNT(o.org_id) AS count
+        FROM {SCHEMA_NAME}.organizations o
+        LEFT JOIN {SCHEMA_NAME}.state s
+            ON o.state_id = s.state_id
+        {where_clause}
+        GROUP BY s.state_name, o.city_name
+        ORDER BY count DESC;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "state": row["state"],
+            "city": row["city"],
+            "count": int(row["count"])
+        }
+        for row in rows
+    ]
+
+
+def fetch_collaborator_distribution(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+
+    query = f"""
+        SELECT
+            CASE WHEN o.is_collaborator IS TRUE
+                 THEN 'collaborator' ELSE 'non_collaborator' END AS category,
+            COUNT(o.org_id) AS count
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause}
+        GROUP BY category
+        ORDER BY category;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "category": row["category"],
+            "count": int(row["count"])
+        }
+        for row in rows
+    ]
+
+
+def fetch_contributor_distribution(cursor, filters):
+    if not filters.get("_has_contributor"):
+        return []
+
+    where_clause, params = build_common_filters(filters)
+
+    query = f"""
+        SELECT
+            CASE WHEN o.{CONTRIBUTOR_COLUMN} IS TRUE
+                 THEN 'contributor' ELSE 'non_contributor' END AS category,
+            COUNT(o.org_id) AS count
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause}
+        GROUP BY category
+        ORDER BY category;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "category": row["category"],
+            "count": int(row["count"])
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dashboard 2: Organization Performance
+# ---------------------------------------------------------------------------
+
+def fetch_performance_summary(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+
+    query = f"""
+        SELECT
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(o.org_id) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_organizations,
+            COUNT(o.org_id) FILTER (WHERE o.org_rating IS NULL) AS unrated_organizations,
+            COUNT(o.org_id) FILTER (WHERE o.org_rating = 5) AS five_star_organizations
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause};
+    """
+
+    cursor.execute(query, params)
+    row = cursor.fetchone()
+
+    return {
+        "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
+        "rated_organizations": int(row["rated_organizations"]),
+        "unrated_organizations": int(row["unrated_organizations"]),
+        "five_star_organizations": int(row["five_star_organizations"])
+    }
+
+
+def fetch_rating_distribution(cursor, filters):
+    # LEFT JOIN against generate_series so every rating 1-5 is present, including
+    # the ones no organization currently holds (the dashboard charts all 5 bars).
+    conditions, params = build_condition_list(filters)
+    conditions.append("o.org_rating = r.rating")
+    join_clause = " AND ".join(conditions)
+
+    query = f"""
+        SELECT
+            r.rating AS rating,
+            COUNT(o.org_id) AS count
+        FROM generate_series({MIN_RATING}, {MAX_RATING}) AS r(rating)
+        LEFT JOIN {SCHEMA_NAME}.organizations o
+            ON {join_clause}
+        GROUP BY r.rating
+        ORDER BY r.rating;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "rating": int(row["rating"]),
+            "count": int(row["count"])
+        }
+        for row in rows
+    ]
+
+
+def fetch_top_rated_organizations(cursor, filters):
+    where_clause, params = build_common_filters(filters)
+    rating_condition = "o.org_rating IS NOT NULL"
+    where_clause = (f"{where_clause} AND {rating_condition}"
+                    if where_clause else f"WHERE {rating_condition}")
+
+    query = f"""
+        SELECT
+            o.org_id,
+            o.org_name,
+            {NORMALIZED_ORG_TYPE} AS org_type,
+            {NORMALIZED_ORG_SIZE} AS org_size,
+            o.org_rating,
+            COALESCE(s.state_name, 'Unknown') AS state,
+            COALESCE(o.city_name, 'Unknown') AS city
+        FROM {SCHEMA_NAME}.organizations o
+        LEFT JOIN {SCHEMA_NAME}.state s
+            ON o.state_id = s.state_id
+        {where_clause}
+        ORDER BY o.org_rating DESC, o.org_name ASC
+        LIMIT {TOP_N_LIMIT};
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "org_id": row["org_id"],
+            "org_name": row["org_name"],
+            "org_type": row["org_type"],
+            "org_size": row["org_size"],
+            "org_rating": int(row["org_rating"]),
+            "state": row["state"],
+            "city": row["city"]
+        }
+        for row in rows
+    ]
+
+
+def fetch_top_flagged_organizations(cursor, filters, flag_column):
+    where_clause, params = build_common_filters(filters)
+    flag_condition = f"o.{flag_column} IS TRUE AND o.org_rating IS NOT NULL"
+    where_clause = (f"{where_clause} AND {flag_condition}"
+                    if where_clause else f"WHERE {flag_condition}")
+
+    query = f"""
+        SELECT
+            o.org_id,
+            o.org_name,
+            {NORMALIZED_ORG_TYPE} AS org_type,
+            {NORMALIZED_ORG_SIZE} AS org_size,
+            o.org_rating,
+            COALESCE(s.state_name, 'Unknown') AS state,
+            COALESCE(o.city_name, 'Unknown') AS city
+        FROM {SCHEMA_NAME}.organizations o
+        LEFT JOIN {SCHEMA_NAME}.state s
+            ON o.state_id = s.state_id
+        {where_clause}
+        ORDER BY o.org_rating DESC, o.org_name ASC
+        LIMIT {TOP_N_LIMIT};
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "org_id": row["org_id"],
+            "org_name": row["org_name"],
+            "org_type": row["org_type"],
+            "org_size": row["org_size"],
+            "org_rating": int(row["org_rating"]),
+            "state": row["state"],
+            "city": row["city"]
+        }
+        for row in rows
+    ]
+
+
+def fetch_ratings_by_dimension(cursor, filters, dimension_expression, dimension_key):
+    where_clause, params = build_common_filters(filters)
+    rating_condition = "o.org_rating IS NOT NULL"
+    where_clause = (f"{where_clause} AND {rating_condition}"
+                    if where_clause else f"WHERE {rating_condition}")
+
+    query = f"""
+        SELECT
+            {dimension_expression} AS dimension,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(o.org_id) AS rated_organizations,
+            COUNT(o.org_id) FILTER (WHERE o.org_rating = {MAX_RATING}) AS five_star_organizations
+        FROM {SCHEMA_NAME}.organizations o
+        {where_clause}
+        GROUP BY {dimension_expression}
+        ORDER BY average_rating DESC;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    return [
+        {
+            dimension_key: row["dimension"] if row["dimension"] is not None else "unknown",
+            "average_rating": float(row["average_rating"]) if row["average_rating"] is not None else 0,
+            "rated_organizations": int(row["rated_organizations"]),
+            "five_star_organizations": int(row["five_star_organizations"])
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dashboard builders
+# ---------------------------------------------------------------------------
+
+def run_metric(cursor, description, fetcher, *args):
+    """Run one metric query, keeping the connection usable if it fails.
+
+    PostgreSQL aborts the surrounding transaction on any error, so without the
+    rollback below a single bad query would make every later metric fail with
+    InFailedSqlTransaction. Returns None when the metric could not be produced,
+    leaving the caller's safe default in place.
+    """
+    try:
+        return fetcher(cursor, *args)
+    except Exception as error:
+        print(f"{description} query failed: {error}")
+        try:
+            cursor.connection.rollback()
+        except Exception as rollback_error:
+            print(f"Rollback after {description} failed: {rollback_error}")
+        return None
+
+
+def assign_metric(target, key, cursor, description, fetcher, *args):
+    result = run_metric(cursor, description, fetcher, *args)
+    if result is not None:
+        target[key] = result
+
+
+def build_overview_dashboard(cursor, filters):
+    response_body = get_default_overview_response()
+    overview = response_body["organization_overview"]
+
+    metrics = [
+        ("summary", "Overview summary", fetch_overview_summary),
+        ("organization_activity_trend", "Organization activity trend", fetch_organization_activity_trend),
+        ("organizations_by_type", "Organizations by type", fetch_organizations_by_type),
+        ("organizations_by_size", "Organizations by size", fetch_organizations_by_size),
+        ("organizations_by_location", "Organizations by location", fetch_organizations_by_location),
+        ("collaborator_distribution", "Collaborator distribution", fetch_collaborator_distribution),
+        ("contributor_distribution", "Contributor distribution", fetch_contributor_distribution),
+    ]
+
+    for key, description, fetcher in metrics:
+        assign_metric(overview, key, cursor, description, fetcher, filters)
+
+    return response_body
+
+
+def build_performance_dashboard(cursor, filters):
+    response_body = get_default_performance_response()
+    performance = response_body["organization_performance"]
+
+    metrics = [
+        ("summary", "Performance summary", fetch_performance_summary, (filters,)),
+        ("rating_distribution", "Rating distribution", fetch_rating_distribution, (filters,)),
+        ("top_rated_organizations", "Top rated organizations", fetch_top_rated_organizations, (filters,)),
+        ("top_collaborator_organizations", "Top collaborator organizations",
+         fetch_top_flagged_organizations, (filters, "is_collaborator")),
+        ("ratings_by_organization_type", "Ratings by organization type",
+         fetch_ratings_by_dimension, (filters, NORMALIZED_ORG_TYPE, "type")),
+        ("ratings_by_organization_size", "Ratings by organization size",
+         fetch_ratings_by_dimension, (filters, NORMALIZED_ORG_SIZE, "size")),
+    ]
+
+    if filters.get("_has_contributor"):
+        metrics.insert(4, ("top_contributor_organizations", "Top contributor organizations",
+                           fetch_top_flagged_organizations, (filters, CONTRIBUTOR_COLUMN)))
+
+    for key, description, fetcher, args in metrics:
+        assign_metric(performance, key, cursor, description, fetcher, *args)
+
+    return response_body
+
+
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+
+    request_body = parse_event_body(event)
+
+    dashboard_type = str(request_body.get("dashboard_type", "overview")).lower()
+    if dashboard_type not in VALID_DASHBOARDS:
+        return build_response(400, {
+            "error": f"Invalid dashboard_type '{dashboard_type}'. "
+                     f"Supported values: {sorted(VALID_DASHBOARDS)}"
+        })
+
+    filters = parse_filters(request_body)
+
+    validation_error = validate_filters(filters)
+    if validation_error:
+        return build_response(400, {"error": validation_error})
+
+    if dashboard_type == "overview":
+        response_body = get_default_overview_response()
+    else:
+        response_body = get_default_performance_response()
+
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+        filters["_has_contributor"] = has_contributor_column(cursor)
+
+        if dashboard_type == "overview":
+            response_body = build_overview_dashboard(cursor, filters)
+        else:
+            response_body = build_performance_dashboard(cursor, filters)
+
+        response_body["filters_applied"] = {
+            key: value for key, value in filters.items() if not key.startswith("_")
+        }
+        if not filters["_has_contributor"]:
+            response_body["schema_notes"] = [
+                f"Column '{CONTRIBUTOR_COLUMN}' is not present in "
+                f"{SCHEMA_NAME}.organizations; contributor metrics return 0/empty "
+                "and the is_contributor filter is ignored."
+            ]
+        return build_response(200, response_body)
+
+    except Exception as error:
+        print(f"DB connection failed: {error}")
+        return build_response(500, response_body)
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+
+if __name__ == "__main__":
+    os.environ["LOCAL_DB"] = "true"
+
+    result_overview = lambda_handler({"dashboard_type": "overview", "time_filter": "ALL"}, None)
+    print(json.dumps(json.loads(result_overview["body"]), indent=2))
+
+    result_performance = lambda_handler({"dashboard_type": "performance", "time_filter": "ALL"}, None)
+    print(json.dumps(json.loads(result_performance["body"]), indent=2))

--- a/data-analytics/lambda_functions/organization_analytics_generate_samples.py
+++ b/data-analytics/lambda_functions/organization_analytics_generate_samples.py
@@ -1,0 +1,42 @@
+"""Regenerate the sample API responses committed alongside the Lambda.
+
+Runs the handler against local PostgreSQL (LOCAL_DB=true) and writes one JSON
+file per scenario, each recording the request, the status code and the response.
+"""
+import json
+import os
+
+os.environ["LOCAL_DB"] = "true"
+
+import organization_analytics as oa
+
+SCENARIOS = [
+    ("sample_response_overview_ALL_monthly.json",
+     {"dashboard_type": "overview", "time_filter": "ALL", "group_by": "monthly"}),
+    ("sample_response_overview_1Y_daily.json",
+     {"dashboard_type": "overview", "time_filter": "1Y", "group_by": "daily"}),
+    ("sample_response_performance_ALL.json",
+     {"dashboard_type": "performance", "time_filter": "ALL"}),
+    # Also demonstrates that the CSV display label is accepted for org_type.
+    ("sample_response_performance_filtered_nonprofit_large.json",
+     {"dashboard_type": "performance", "time_filter": "ALL",
+      "org_type": "Non-Profit", "org_size": "Large"}),
+]
+
+
+def main():
+    for filename, payload in SCENARIOS:
+        result = oa.lambda_handler(payload, None)
+        document = {
+            "request": payload,
+            "statusCode": result["statusCode"],
+            "response": json.loads(result["body"])
+        }
+        with open(filename, "w", encoding="utf-8") as handle:
+            json.dump(document, handle, indent=2)
+            handle.write("\n")
+        print(f"Wrote {filename} (statusCode={result['statusCode']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/data-analytics/lambda_functions/organization_analytics_load_csv.py
+++ b/data-analytics/lambda_functions/organization_analytics_load_csv.py
@@ -1,0 +1,122 @@
+"""Load the source extracts from data-analytics/sql into local PostgreSQL.
+
+Uses the same data the task points at (organizations.csv, state.csv) so the API
+is exercised against real source records rather than only synthetic ones.
+
+The CSVs carry display labels ('Non-Profit', 'For-profit', 'Small') while
+ddl_organizations.sql declares lowercase enums ('non_profit', 'small'), so the
+labels are normalized on the way in. The API normalizes on the way out too, and
+therefore reports the same buckets whichever form a database happens to hold.
+
+    python3 organization_analytics_load_csv.py [orgs_csv] [state_csv]
+
+Defaults resolve to ../sql/*.csv, i.e. the repo layout when this file sits in
+data-analytics/lambda_functions/.
+"""
+import csv
+import os
+import sys
+
+import psycopg2
+
+DB = dict(
+    host=os.environ.get("DB_HOST", "localhost"),
+    database=os.environ.get("DB_NAME", "saayam_local"),
+    user=os.environ.get("DB_USER", "saayam"),
+    password=os.environ.get("DB_PASSWORD", "saayam_local"),
+    port=os.environ.get("DB_PORT", "5432"),
+)
+SCHEMA = "virginia_dev_saayam_rdbms"
+
+DEFAULT_ORGS_CSV = os.path.join(os.path.dirname(__file__), "..", "sql", "organizations.csv")
+DEFAULT_STATE_CSV = os.path.join(os.path.dirname(__file__), "..", "sql", "state.csv")
+
+
+def normalize_label(value):
+    if value in (None, ""):
+        return None
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def to_bool(value):
+    if value in (None, ""):
+        return None
+    return value.strip().upper() == "TRUE"
+
+
+def to_int(value):
+    return int(value) if value not in (None, "") else None
+
+
+def blank_to_none(value):
+    return value if value not in (None, "") else None
+
+
+def load(orgs_csv, state_csv):
+    with open(state_csv, newline="", encoding="utf-8") as handle:
+        states = list(csv.DictReader(handle))
+    with open(orgs_csv, newline="", encoding="utf-8") as handle:
+        organizations = list(csv.DictReader(handle))
+
+    conn = psycopg2.connect(**DB)
+    cur = conn.cursor()
+    cur.execute(f"SET search_path TO {SCHEMA}")
+
+    # The org_id trigger would overwrite the identifiers coming from the extract.
+    trigger_disabled = True
+    try:
+        cur.execute("ALTER TABLE organizations DISABLE TRIGGER before_insert_organizations")
+    except psycopg2.Error as error:
+        conn.rollback()
+        cur = conn.cursor()
+        cur.execute(f"SET search_path TO {SCHEMA}")
+        trigger_disabled = False
+        print(f"WARNING: could not disable the org_id trigger ({error}); "
+              "org_id values will be regenerated instead of taken from the CSV.")
+
+    cur.execute("DELETE FROM organizations")
+    cur.execute("INSERT INTO country (country_id, country_name) VALUES (1, 'United States') "
+                "ON CONFLICT DO NOTHING")
+
+    for row in states:
+        cur.execute(
+            """INSERT INTO state (state_id, country_id, state_name, state_code, last_update_date)
+               VALUES (%s, %s, %s, %s, %s)
+               ON CONFLICT (state_id) DO UPDATE
+                   SET state_name = EXCLUDED.state_name,
+                       state_code = EXCLUDED.state_code""",
+            (row["state_id"], to_int(row["country_id"]), row["state_name"],
+             row["state_code"], blank_to_none(row["last_update_date"]))
+        )
+
+    for row in organizations:
+        cur.execute(
+            """INSERT INTO organizations
+               (org_id, org_name, street, city_name, state_id, zip_code, mission,
+                web_url, phone, email, org_type, org_size, org_rating,
+                is_collaborator, is_contributor, created_at, last_updated_at)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+            (row["org_id"], row["org_name"], blank_to_none(row["street"]),
+             blank_to_none(row["city_name"]), blank_to_none(row["state_id"]),
+             blank_to_none(row["zip_code"]), blank_to_none(row["mission"]),
+             blank_to_none(row["web_url"]), blank_to_none(row["phone"]),
+             blank_to_none(row["email"]), normalize_label(row["org_type"]),
+             normalize_label(row["org_size"]), to_int(row["org_rating"]),
+             to_bool(row["is_collaborator"]), to_bool(row.get("is_contributor")),
+             blank_to_none(row["created_at"]), blank_to_none(row["last_updated_at"]))
+        )
+
+    if trigger_disabled:
+        cur.execute("ALTER TABLE organizations ENABLE TRIGGER before_insert_organizations")
+
+    conn.commit()
+    cur.execute("SELECT COUNT(*) FROM organizations")
+    print(f"Loaded {cur.fetchone()[0]} organizations and {len(states)} states.")
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    orgs = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_ORGS_CSV
+    state = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_STATE_CSV
+    load(orgs, state)

--- a/data-analytics/lambda_functions/organization_analytics_local_setup.sql
+++ b/data-analytics/lambda_functions/organization_analytics_local_setup.sql
@@ -1,0 +1,71 @@
+-- Local test setup for Organization Analytics API
+-- Mirrors ddl_organizations.sql + ddl_state.sql from saayam-for-all/database
+-- NOTE: adds is_contributor BOOLEAN (required by analytics spec, missing in current DDL)
+
+SET search_path TO virginia_dev_saayam_rdbms;
+
+DROP TABLE IF EXISTS organizations CASCADE;
+DROP TABLE IF EXISTS state CASCADE;
+DROP TABLE IF EXISTS country CASCADE;
+DROP TYPE IF EXISTS org_type_enum;
+DROP TYPE IF EXISTS org_size_enum;
+
+CREATE TYPE org_type_enum AS ENUM ('non_profit', 'for_profit');
+CREATE TYPE org_size_enum AS ENUM ('small', 'medium', 'large');
+
+CREATE TABLE country (
+    country_id INT PRIMARY KEY,
+    country_name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE state (
+    state_id VARCHAR(50) PRIMARY KEY,
+    country_id INT NOT NULL,
+    state_name VARCHAR(100) NOT NULL,
+    state_code VARCHAR(6),
+    last_update_date TIMESTAMP,
+    FOREIGN KEY (country_id) REFERENCES country (country_id)
+);
+
+CREATE SEQUENCE IF NOT EXISTS org_id_seq;
+
+CREATE TABLE organizations (
+  org_id VARCHAR(255) PRIMARY KEY,
+  org_name VARCHAR(125) NOT NULL,
+  street VARCHAR(255),
+  city_name VARCHAR(100),
+  state_id VARCHAR(50),
+  zip_code VARCHAR(10),
+  mission TEXT,
+  web_url VARCHAR(255) CHECK (web_url IS NULL OR web_url LIKE 'http%'),
+  phone VARCHAR(20),
+  email VARCHAR(255) CHECK (email IS NULL OR email LIKE '%@%'),
+  org_type org_type_enum,
+  org_size org_size_enum,
+  org_rating INTEGER CHECK (org_rating >= 1 AND org_rating <= 5),
+  is_collaborator BOOLEAN,
+  is_contributor BOOLEAN,          -- ADDED: required by analytics spec (needs DDL PR in database repo)
+  created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
+  last_updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
+  FOREIGN KEY (state_id) REFERENCES state(state_id) ON DELETE SET NULL
+);
+
+CREATE OR REPLACE FUNCTION generate_org_id()
+    RETURNS trigger LANGUAGE plpgsql AS $BODY$
+DECLARE
+    seq_id INT;
+BEGIN
+    seq_id := nextval('virginia_dev_saayam_rdbms.org_id_seq');
+    NEW.org_id := 'ORG-00-' || LPAD(FLOOR(seq_id / 1000000)::TEXT, 3, '0') || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
+                  LPAD((seq_id % 1000)::TEXT, 3, '0');
+    RETURN NEW;
+END;
+$BODY$;
+
+CREATE OR REPLACE TRIGGER before_insert_organizations
+    BEFORE INSERT ON organizations
+    FOR EACH ROW EXECUTE FUNCTION generate_org_id();
+
+GRANT ALL ON ALL TABLES IN SCHEMA virginia_dev_saayam_rdbms TO saayam;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA virginia_dev_saayam_rdbms TO saayam;

--- a/data-analytics/lambda_functions/organization_analytics_samples/sample_response_overview_1Y_daily.json
+++ b/data-analytics/lambda_functions/organization_analytics_samples/sample_response_overview_1Y_daily.json
@@ -1,0 +1,192 @@
+{
+  "request": {
+    "dashboard_type": "overview",
+    "time_filter": "1Y",
+    "group_by": "daily"
+  },
+  "statusCode": 200,
+  "response": {
+    "organization_overview": {
+      "summary": {
+        "total_organizations": 11,
+        "non_profit_organizations": 8,
+        "for_profit_organizations": 3,
+        "collaborator_organizations": 5,
+        "non_collaborator_organizations": 6,
+        "contributor_organizations": 6,
+        "non_contributor_organizations": 5
+      },
+      "organization_activity_trend": [
+        {
+          "period": "2025-09-01",
+          "new_organizations": 1,
+          "total_organizations": 1
+        },
+        {
+          "period": "2025-09-03",
+          "new_organizations": 1,
+          "total_organizations": 2
+        },
+        {
+          "period": "2025-09-26",
+          "new_organizations": 1,
+          "total_organizations": 3
+        },
+        {
+          "period": "2025-10-01",
+          "new_organizations": 1,
+          "total_organizations": 4
+        },
+        {
+          "period": "2025-11-03",
+          "new_organizations": 1,
+          "total_organizations": 5
+        },
+        {
+          "period": "2025-11-20",
+          "new_organizations": 1,
+          "total_organizations": 6
+        },
+        {
+          "period": "2025-11-28",
+          "new_organizations": 1,
+          "total_organizations": 7
+        },
+        {
+          "period": "2025-12-16",
+          "new_organizations": 1,
+          "total_organizations": 8
+        },
+        {
+          "period": "2025-12-17",
+          "new_organizations": 1,
+          "total_organizations": 9
+        },
+        {
+          "period": "2025-12-19",
+          "new_organizations": 1,
+          "total_organizations": 10
+        },
+        {
+          "period": "2026-01-10",
+          "new_organizations": 1,
+          "total_organizations": 11
+        }
+      ],
+      "organizations_by_type": [
+        {
+          "type": "non_profit",
+          "count": 8
+        },
+        {
+          "type": "for_profit",
+          "count": 3
+        }
+      ],
+      "organizations_by_size": [
+        {
+          "size": "large",
+          "count": 7
+        },
+        {
+          "size": "medium",
+          "count": 2
+        },
+        {
+          "size": "small",
+          "count": 2
+        }
+      ],
+      "organizations_by_location": [
+        {
+          "state": "Florida",
+          "city": "West Amandastad",
+          "count": 1
+        },
+        {
+          "state": "Texas",
+          "city": "East Jenniferfort",
+          "count": 1
+        },
+        {
+          "state": "North Carolina",
+          "city": "Robinfort",
+          "count": 1
+        },
+        {
+          "state": "Missouri",
+          "city": "Lake Deniseville",
+          "count": 1
+        },
+        {
+          "state": "Texas",
+          "city": "Victoriaport",
+          "count": 1
+        },
+        {
+          "state": "Ohio",
+          "city": "South Jeffrey",
+          "count": 1
+        },
+        {
+          "state": "Minnesota",
+          "city": "Lake Nancyview",
+          "count": 1
+        },
+        {
+          "state": "Nebraska",
+          "city": "Barkerfurt",
+          "count": 1
+        },
+        {
+          "state": "Texas",
+          "city": "Hortonberg",
+          "count": 1
+        },
+        {
+          "state": "Michigan",
+          "city": "West Williamport",
+          "count": 1
+        },
+        {
+          "state": "Maine",
+          "city": "Martinezbury",
+          "count": 1
+        }
+      ],
+      "collaborator_distribution": [
+        {
+          "category": "collaborator",
+          "count": 5
+        },
+        {
+          "category": "non_collaborator",
+          "count": 6
+        }
+      ],
+      "contributor_distribution": [
+        {
+          "category": "contributor",
+          "count": 6
+        },
+        {
+          "category": "non_contributor",
+          "count": 5
+        }
+      ]
+    },
+    "filters_applied": {
+      "time_filter": "1Y",
+      "start_date": null,
+      "end_date": null,
+      "org_type": null,
+      "org_size": null,
+      "state_id": null,
+      "city_name": null,
+      "org_rating": null,
+      "is_collaborator": null,
+      "is_contributor": null,
+      "group_by": "daily"
+    }
+  }
+}

--- a/data-analytics/lambda_functions/organization_analytics_samples/sample_response_overview_ALL_monthly.json
+++ b/data-analytics/lambda_functions/organization_analytics_samples/sample_response_overview_ALL_monthly.json
@@ -1,0 +1,382 @@
+{
+  "request": {
+    "dashboard_type": "overview",
+    "time_filter": "ALL",
+    "group_by": "monthly"
+  },
+  "statusCode": 200,
+  "response": {
+    "organization_overview": {
+      "summary": {
+        "total_organizations": 40,
+        "non_profit_organizations": 21,
+        "for_profit_organizations": 19,
+        "collaborator_organizations": 21,
+        "non_collaborator_organizations": 19,
+        "contributor_organizations": 19,
+        "non_contributor_organizations": 21
+      },
+      "organization_activity_trend": [
+        {
+          "period": "2023-09-01",
+          "new_organizations": 2,
+          "total_organizations": 2
+        },
+        {
+          "period": "2023-11-01",
+          "new_organizations": 1,
+          "total_organizations": 3
+        },
+        {
+          "period": "2023-12-01",
+          "new_organizations": 2,
+          "total_organizations": 5
+        },
+        {
+          "period": "2024-02-01",
+          "new_organizations": 2,
+          "total_organizations": 7
+        },
+        {
+          "period": "2024-04-01",
+          "new_organizations": 2,
+          "total_organizations": 9
+        },
+        {
+          "period": "2024-06-01",
+          "new_organizations": 1,
+          "total_organizations": 10
+        },
+        {
+          "period": "2024-07-01",
+          "new_organizations": 2,
+          "total_organizations": 12
+        },
+        {
+          "period": "2024-08-01",
+          "new_organizations": 2,
+          "total_organizations": 14
+        },
+        {
+          "period": "2024-09-01",
+          "new_organizations": 3,
+          "total_organizations": 17
+        },
+        {
+          "period": "2024-11-01",
+          "new_organizations": 2,
+          "total_organizations": 19
+        },
+        {
+          "period": "2024-12-01",
+          "new_organizations": 1,
+          "total_organizations": 20
+        },
+        {
+          "period": "2025-01-01",
+          "new_organizations": 3,
+          "total_organizations": 23
+        },
+        {
+          "period": "2025-04-01",
+          "new_organizations": 1,
+          "total_organizations": 24
+        },
+        {
+          "period": "2025-06-01",
+          "new_organizations": 1,
+          "total_organizations": 25
+        },
+        {
+          "period": "2025-08-01",
+          "new_organizations": 4,
+          "total_organizations": 29
+        },
+        {
+          "period": "2025-09-01",
+          "new_organizations": 3,
+          "total_organizations": 32
+        },
+        {
+          "period": "2025-10-01",
+          "new_organizations": 1,
+          "total_organizations": 33
+        },
+        {
+          "period": "2025-11-01",
+          "new_organizations": 3,
+          "total_organizations": 36
+        },
+        {
+          "period": "2025-12-01",
+          "new_organizations": 3,
+          "total_organizations": 39
+        },
+        {
+          "period": "2026-01-01",
+          "new_organizations": 1,
+          "total_organizations": 40
+        }
+      ],
+      "organizations_by_type": [
+        {
+          "type": "non_profit",
+          "count": 21
+        },
+        {
+          "type": "for_profit",
+          "count": 19
+        }
+      ],
+      "organizations_by_size": [
+        {
+          "size": "large",
+          "count": 21
+        },
+        {
+          "size": "small",
+          "count": 10
+        },
+        {
+          "size": "medium",
+          "count": 9
+        }
+      ],
+      "organizations_by_location": [
+        {
+          "state": "North Carolina",
+          "city": "Robinfort",
+          "count": 1
+        },
+        {
+          "state": "Arkansas",
+          "city": "Robertfort",
+          "count": 1
+        },
+        {
+          "state": "Alaska",
+          "city": "North Judithbury",
+          "count": 1
+        },
+        {
+          "state": "Texas",
+          "city": "Victoriaport",
+          "count": 1
+        },
+        {
+          "state": "New Jersey",
+          "city": "South Williamton",
+          "count": 1
+        },
+        {
+          "state": "Alabama",
+          "city": "Smithberg",
+          "count": 1
+        },
+        {
+          "state": "California",
+          "city": "New Susanville",
+          "count": 1
+        },
+        {
+          "state": "Oklahoma",
+          "city": "Jeremyburgh",
+          "count": 1
+        },
+        {
+          "state": "Iowa",
+          "city": "Lake Debbie",
+          "count": 1
+        },
+        {
+          "state": "Rhode Island",
+          "city": "South Rachelborough",
+          "count": 1
+        },
+        {
+          "state": "Wyoming",
+          "city": "Kingborough",
+          "count": 1
+        },
+        {
+          "state": "Kansas",
+          "city": "Port Andrew",
+          "count": 1
+        },
+        {
+          "state": "Indiana",
+          "city": "South Monicamouth",
+          "count": 1
+        },
+        {
+          "state": "Iowa",
+          "city": "West Erik",
+          "count": 1
+        },
+        {
+          "state": "Rhode Island",
+          "city": "Mitchellside",
+          "count": 1
+        },
+        {
+          "state": "Oregon",
+          "city": "Johnberg",
+          "count": 1
+        },
+        {
+          "state": "Montana",
+          "city": "Wendyville",
+          "count": 1
+        },
+        {
+          "state": "Nevada",
+          "city": "Leehaven",
+          "count": 1
+        },
+        {
+          "state": "Virginia",
+          "city": "Sandrastad",
+          "count": 1
+        },
+        {
+          "state": "Florida",
+          "city": "West Amandastad",
+          "count": 1
+        },
+        {
+          "state": "Montana",
+          "city": "Williamview",
+          "count": 1
+        },
+        {
+          "state": "Washington",
+          "city": "Stephaniemouth",
+          "count": 1
+        },
+        {
+          "state": "Texas",
+          "city": "Hortonberg",
+          "count": 1
+        },
+        {
+          "state": "Vermont",
+          "city": "Ortizmouth",
+          "count": 1
+        },
+        {
+          "state": "Florida",
+          "city": "North Jamesborough",
+          "count": 1
+        },
+        {
+          "state": "Michigan",
+          "city": "West Williamport",
+          "count": 1
+        },
+        {
+          "state": "Utah",
+          "city": "New Thomas",
+          "count": 1
+        },
+        {
+          "state": "Minnesota",
+          "city": "New Amyhaven",
+          "count": 1
+        },
+        {
+          "state": "Maine",
+          "city": "Martinezbury",
+          "count": 1
+        },
+        {
+          "state": "North Carolina",
+          "city": "Ronaldview",
+          "count": 1
+        },
+        {
+          "state": "Texas",
+          "city": "East Jenniferfort",
+          "count": 1
+        },
+        {
+          "state": "Arkansas",
+          "city": "East Amanda",
+          "count": 1
+        },
+        {
+          "state": "Missouri",
+          "city": "Lake Deniseville",
+          "count": 1
+        },
+        {
+          "state": "Wisconsin",
+          "city": "Thomasberg",
+          "count": 1
+        },
+        {
+          "state": "Ohio",
+          "city": "South Jeffrey",
+          "count": 1
+        },
+        {
+          "state": "Arizona",
+          "city": "Kyleborough",
+          "count": 1
+        },
+        {
+          "state": "Minnesota",
+          "city": "Lake Nancyview",
+          "count": 1
+        },
+        {
+          "state": "Nebraska",
+          "city": "Barkerfurt",
+          "count": 1
+        },
+        {
+          "state": "Kansas",
+          "city": "Burchborough",
+          "count": 1
+        },
+        {
+          "state": "Indiana",
+          "city": "North Donnaport",
+          "count": 1
+        }
+      ],
+      "collaborator_distribution": [
+        {
+          "category": "collaborator",
+          "count": 21
+        },
+        {
+          "category": "non_collaborator",
+          "count": 19
+        }
+      ],
+      "contributor_distribution": [
+        {
+          "category": "contributor",
+          "count": 19
+        },
+        {
+          "category": "non_contributor",
+          "count": 21
+        }
+      ]
+    },
+    "filters_applied": {
+      "time_filter": "ALL",
+      "start_date": null,
+      "end_date": null,
+      "org_type": null,
+      "org_size": null,
+      "state_id": null,
+      "city_name": null,
+      "org_rating": null,
+      "is_collaborator": null,
+      "is_contributor": null,
+      "group_by": "monthly"
+    }
+  }
+}

--- a/data-analytics/lambda_functions/organization_analytics_samples/sample_response_performance_ALL.json
+++ b/data-analytics/lambda_functions/organization_analytics_samples/sample_response_performance_ALL.json
@@ -1,0 +1,362 @@
+{
+  "request": {
+    "dashboard_type": "performance",
+    "time_filter": "ALL"
+  },
+  "statusCode": 200,
+  "response": {
+    "organization_performance": {
+      "summary": {
+        "average_rating": 3.23,
+        "rated_organizations": 40,
+        "unrated_organizations": 0,
+        "five_star_organizations": 12
+      },
+      "rating_distribution": [
+        {
+          "rating": 1,
+          "count": 5
+        },
+        {
+          "rating": 2,
+          "count": 9
+        },
+        {
+          "rating": 3,
+          "count": 10
+        },
+        {
+          "rating": 4,
+          "count": 4
+        },
+        {
+          "rating": 5,
+          "count": 12
+        }
+      ],
+      "top_rated_organizations": [
+        {
+          "org_id": "ORG-00-000-000-419",
+          "org_name": "Cedar Valley Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "California",
+          "city": "New Susanville"
+        },
+        {
+          "org_id": "ORG-00-000-000-436",
+          "org_name": "Golden Gate Education Fund",
+          "org_type": "non_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Arizona",
+          "city": "Kyleborough"
+        },
+        {
+          "org_id": "ORG-00-000-000-404",
+          "org_name": "Harbor Family Services",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Minnesota",
+          "city": "Lake Nancyview"
+        },
+        {
+          "org_id": "ORG-00-000-000-401",
+          "org_name": "Harbor Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Alaska",
+          "city": "North Judithbury"
+        },
+        {
+          "org_id": "ORG-00-000-000-411",
+          "org_name": "Hopewell Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "medium",
+          "org_rating": 5,
+          "state": "Rhode Island",
+          "city": "South Rachelborough"
+        },
+        {
+          "org_id": "ORG-00-000-000-409",
+          "org_name": "Lakeside Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Montana",
+          "city": "Williamview"
+        },
+        {
+          "org_id": "ORG-00-000-000-431",
+          "org_name": "Maplewood Housing Trust",
+          "org_type": "for_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Virginia",
+          "city": "Sandrastad"
+        },
+        {
+          "org_id": "ORG-00-000-000-422",
+          "org_name": "Meadowbrook Housing Trust",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Nevada",
+          "city": "Leehaven"
+        },
+        {
+          "org_id": "ORG-00-000-000-434",
+          "org_name": "Northgate Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Michigan",
+          "city": "West Williamport"
+        },
+        {
+          "org_id": "ORG-00-000-000-408",
+          "org_name": "Riverside Environmental Coalition",
+          "org_type": "for_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Iowa",
+          "city": "Lake Debbie"
+        }
+      ],
+      "top_collaborator_organizations": [
+        {
+          "org_id": "ORG-00-000-000-419",
+          "org_name": "Cedar Valley Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "California",
+          "city": "New Susanville"
+        },
+        {
+          "org_id": "ORG-00-000-000-436",
+          "org_name": "Golden Gate Education Fund",
+          "org_type": "non_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Arizona",
+          "city": "Kyleborough"
+        },
+        {
+          "org_id": "ORG-00-000-000-404",
+          "org_name": "Harbor Family Services",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Minnesota",
+          "city": "Lake Nancyview"
+        },
+        {
+          "org_id": "ORG-00-000-000-411",
+          "org_name": "Hopewell Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "medium",
+          "org_rating": 5,
+          "state": "Rhode Island",
+          "city": "South Rachelborough"
+        },
+        {
+          "org_id": "ORG-00-000-000-431",
+          "org_name": "Maplewood Housing Trust",
+          "org_type": "for_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Virginia",
+          "city": "Sandrastad"
+        },
+        {
+          "org_id": "ORG-00-000-000-422",
+          "org_name": "Meadowbrook Housing Trust",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Nevada",
+          "city": "Leehaven"
+        },
+        {
+          "org_id": "ORG-00-000-000-408",
+          "org_name": "Riverside Environmental Coalition",
+          "org_type": "for_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Iowa",
+          "city": "Lake Debbie"
+        },
+        {
+          "org_id": "ORG-00-000-000-427",
+          "org_name": "Silverline Senior Care Network",
+          "org_type": "for_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Montana",
+          "city": "Wendyville"
+        },
+        {
+          "org_id": "ORG-00-000-000-420",
+          "org_name": "Lakeside Legal Aid Society",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Nebraska",
+          "city": "Barkerfurt"
+        },
+        {
+          "org_id": "ORG-00-000-000-423",
+          "org_name": "Maplewood Veterans Support",
+          "org_type": "for_profit",
+          "org_size": "medium",
+          "org_rating": 4,
+          "state": "Alabama",
+          "city": "Smithberg"
+        }
+      ],
+      "top_contributor_organizations": [
+        {
+          "org_id": "ORG-00-000-000-401",
+          "org_name": "Harbor Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Alaska",
+          "city": "North Judithbury"
+        },
+        {
+          "org_id": "ORG-00-000-000-409",
+          "org_name": "Lakeside Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "small",
+          "org_rating": 5,
+          "state": "Montana",
+          "city": "Williamview"
+        },
+        {
+          "org_id": "ORG-00-000-000-434",
+          "org_name": "Northgate Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Michigan",
+          "city": "West Williamport"
+        },
+        {
+          "org_id": "ORG-00-000-000-429",
+          "org_name": "Unity Youth Alliance",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "New Jersey",
+          "city": "South Williamton"
+        },
+        {
+          "org_id": "ORG-00-000-000-435",
+          "org_name": "Summit Relief Network",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Vermont",
+          "city": "Ortizmouth"
+        },
+        {
+          "org_id": "ORG-00-000-000-415",
+          "org_name": "Unity Senior Care Network",
+          "org_type": "for_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Kansas",
+          "city": "Port Andrew"
+        },
+        {
+          "org_id": "ORG-00-000-000-406",
+          "org_name": "Harbor Senior Care Network",
+          "org_type": "for_profit",
+          "org_size": "medium",
+          "org_rating": 3,
+          "state": "Missouri",
+          "city": "Lake Deniseville"
+        },
+        {
+          "org_id": "ORG-00-000-000-424",
+          "org_name": "Liberty Senior Care Network",
+          "org_type": "for_profit",
+          "org_size": "large",
+          "org_rating": 3,
+          "state": "Arkansas",
+          "city": "East Amanda"
+        },
+        {
+          "org_id": "ORG-00-000-000-425",
+          "org_name": "Maplewood Animal Rescue",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 3,
+          "state": "Texas",
+          "city": "Victoriaport"
+        },
+        {
+          "org_id": "ORG-00-000-000-403",
+          "org_name": "Northgate Education Fund",
+          "org_type": "non_profit",
+          "org_size": "medium",
+          "org_rating": 3,
+          "state": "Wisconsin",
+          "city": "Thomasberg"
+        }
+      ],
+      "ratings_by_organization_type": [
+        {
+          "type": "non_profit",
+          "average_rating": 3.62,
+          "rated_organizations": 21,
+          "five_star_organizations": 9
+        },
+        {
+          "type": "for_profit",
+          "average_rating": 2.79,
+          "rated_organizations": 19,
+          "five_star_organizations": 3
+        }
+      ],
+      "ratings_by_organization_size": [
+        {
+          "size": "small",
+          "average_rating": 3.5,
+          "rated_organizations": 10,
+          "five_star_organizations": 5
+        },
+        {
+          "size": "large",
+          "average_rating": 3.24,
+          "rated_organizations": 21,
+          "five_star_organizations": 6
+        },
+        {
+          "size": "medium",
+          "average_rating": 2.89,
+          "rated_organizations": 9,
+          "five_star_organizations": 1
+        }
+      ]
+    },
+    "filters_applied": {
+      "time_filter": "ALL",
+      "start_date": null,
+      "end_date": null,
+      "org_type": null,
+      "org_size": null,
+      "state_id": null,
+      "city_name": null,
+      "org_rating": null,
+      "is_collaborator": null,
+      "is_contributor": null,
+      "group_by": "daily"
+    }
+  }
+}

--- a/data-analytics/lambda_functions/organization_analytics_samples/sample_response_performance_filtered_nonprofit_large.json
+++ b/data-analytics/lambda_functions/organization_analytics_samples/sample_response_performance_filtered_nonprofit_large.json
@@ -1,0 +1,265 @@
+{
+  "request": {
+    "dashboard_type": "performance",
+    "time_filter": "ALL",
+    "org_type": "Non-Profit",
+    "org_size": "Large"
+  },
+  "statusCode": 200,
+  "response": {
+    "organization_performance": {
+      "summary": {
+        "average_rating": 3.73,
+        "rated_organizations": 11,
+        "unrated_organizations": 0,
+        "five_star_organizations": 5
+      },
+      "rating_distribution": [
+        {
+          "rating": 1,
+          "count": 1
+        },
+        {
+          "rating": 2,
+          "count": 2
+        },
+        {
+          "rating": 3,
+          "count": 1
+        },
+        {
+          "rating": 4,
+          "count": 2
+        },
+        {
+          "rating": 5,
+          "count": 5
+        }
+      ],
+      "top_rated_organizations": [
+        {
+          "org_id": "ORG-00-000-000-419",
+          "org_name": "Cedar Valley Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "California",
+          "city": "New Susanville"
+        },
+        {
+          "org_id": "ORG-00-000-000-404",
+          "org_name": "Harbor Family Services",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Minnesota",
+          "city": "Lake Nancyview"
+        },
+        {
+          "org_id": "ORG-00-000-000-422",
+          "org_name": "Meadowbrook Housing Trust",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Nevada",
+          "city": "Leehaven"
+        },
+        {
+          "org_id": "ORG-00-000-000-434",
+          "org_name": "Northgate Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Michigan",
+          "city": "West Williamport"
+        },
+        {
+          "org_id": "ORG-00-000-000-429",
+          "org_name": "Unity Youth Alliance",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "New Jersey",
+          "city": "South Williamton"
+        },
+        {
+          "org_id": "ORG-00-000-000-420",
+          "org_name": "Lakeside Legal Aid Society",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Nebraska",
+          "city": "Barkerfurt"
+        },
+        {
+          "org_id": "ORG-00-000-000-435",
+          "org_name": "Summit Relief Network",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Vermont",
+          "city": "Ortizmouth"
+        },
+        {
+          "org_id": "ORG-00-000-000-425",
+          "org_name": "Maplewood Animal Rescue",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 3,
+          "state": "Texas",
+          "city": "Victoriaport"
+        },
+        {
+          "org_id": "ORG-00-000-000-421",
+          "org_name": "Harbor Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 2,
+          "state": "Arkansas",
+          "city": "Robertfort"
+        },
+        {
+          "org_id": "ORG-00-000-000-416",
+          "org_name": "Meadowbrook Legal Aid Society",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 2,
+          "state": "Florida",
+          "city": "West Amandastad"
+        }
+      ],
+      "top_collaborator_organizations": [
+        {
+          "org_id": "ORG-00-000-000-419",
+          "org_name": "Cedar Valley Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "California",
+          "city": "New Susanville"
+        },
+        {
+          "org_id": "ORG-00-000-000-404",
+          "org_name": "Harbor Family Services",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Minnesota",
+          "city": "Lake Nancyview"
+        },
+        {
+          "org_id": "ORG-00-000-000-422",
+          "org_name": "Meadowbrook Housing Trust",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Nevada",
+          "city": "Leehaven"
+        },
+        {
+          "org_id": "ORG-00-000-000-420",
+          "org_name": "Lakeside Legal Aid Society",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Nebraska",
+          "city": "Barkerfurt"
+        },
+        {
+          "org_id": "ORG-00-000-000-421",
+          "org_name": "Harbor Veterans Support",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 2,
+          "state": "Arkansas",
+          "city": "Robertfort"
+        },
+        {
+          "org_id": "ORG-00-000-000-416",
+          "org_name": "Meadowbrook Legal Aid Society",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 2,
+          "state": "Florida",
+          "city": "West Amandastad"
+        }
+      ],
+      "top_contributor_organizations": [
+        {
+          "org_id": "ORG-00-000-000-434",
+          "org_name": "Northgate Community Foundation",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "Michigan",
+          "city": "West Williamport"
+        },
+        {
+          "org_id": "ORG-00-000-000-429",
+          "org_name": "Unity Youth Alliance",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 5,
+          "state": "New Jersey",
+          "city": "South Williamton"
+        },
+        {
+          "org_id": "ORG-00-000-000-435",
+          "org_name": "Summit Relief Network",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 4,
+          "state": "Vermont",
+          "city": "Ortizmouth"
+        },
+        {
+          "org_id": "ORG-00-000-000-425",
+          "org_name": "Maplewood Animal Rescue",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 3,
+          "state": "Texas",
+          "city": "Victoriaport"
+        },
+        {
+          "org_id": "ORG-00-000-000-426",
+          "org_name": "Lakeside Food Bank",
+          "org_type": "non_profit",
+          "org_size": "large",
+          "org_rating": 1,
+          "state": "North Carolina",
+          "city": "Robinfort"
+        }
+      ],
+      "ratings_by_organization_type": [
+        {
+          "type": "non_profit",
+          "average_rating": 3.73,
+          "rated_organizations": 11,
+          "five_star_organizations": 5
+        }
+      ],
+      "ratings_by_organization_size": [
+        {
+          "size": "large",
+          "average_rating": 3.73,
+          "rated_organizations": 11,
+          "five_star_organizations": 5
+        }
+      ]
+    },
+    "filters_applied": {
+      "time_filter": "ALL",
+      "start_date": null,
+      "end_date": null,
+      "org_type": "Non-Profit",
+      "org_size": "Large",
+      "state_id": null,
+      "city_name": null,
+      "org_rating": null,
+      "is_collaborator": null,
+      "is_contributor": null,
+      "group_by": "daily"
+    }
+  }
+}

--- a/data-analytics/lambda_functions/organization_analytics_seed_data.py
+++ b/data-analytics/lambda_functions/organization_analytics_seed_data.py
@@ -1,0 +1,77 @@
+"""Seed mock organizations data for local testing of the Organization Analytics API."""
+import random
+import psycopg2
+from datetime import datetime, timedelta
+
+random.seed(42)
+
+DB = dict(host="localhost", database="saayam_local", user="saayam",
+          password="saayam_local", port=5432)
+SCHEMA = "virginia_dev_saayam_rdbms"
+
+# state_id values follow state.csv (two-letter ids), not a synthetic prefix.
+STATES = [
+    ("VA", 1, "Virginia", "US-VA"), ("NY", 1, "New York", "US-NY"),
+    ("CA", 1, "California", "US-CA"), ("TX", 1, "Texas", "US-TX"),
+    ("WA", 1, "Washington", "US-WA"), ("NJ", 1, "New Jersey", "US-NJ"),
+]
+CITIES = {
+    "VA": ["Richmond", "Arlington", "Norfolk"],
+    "NY": ["Buffalo", "New York City", "Albany"],
+    "CA": ["San Jose", "Los Angeles", "Sacramento"],
+    "TX": ["Austin", "Dallas", "Houston"],
+    "WA": ["Seattle", "Tacoma"],
+    "NJ": ["Newark", "Jersey City"],
+}
+ORG_WORDS = ["Hope", "Bridge", "Unity", "Care", "Rise", "Nova", "Summit",
+             "Beacon", "Anchor", "Harvest", "Lumen", "Pioneer"]
+ORG_SUFFIX = ["Foundation", "Alliance", "Collective", "Labs", "Partners",
+              "Network", "Trust", "Works", "Group", "Initiative"]
+
+def main():
+    conn = psycopg2.connect(**DB)
+    cur = conn.cursor()
+    cur.execute(f"SET search_path TO {SCHEMA}")
+
+    cur.execute("INSERT INTO country (country_id, country_name) VALUES (1, 'United States') ON CONFLICT DO NOTHING")
+    for s in STATES:
+        cur.execute("INSERT INTO state (state_id, country_id, state_name, state_code) "
+                    "VALUES (%s, %s, %s, %s) ON CONFLICT DO NOTHING", s)
+
+    now = datetime.utcnow()
+    n = 120
+    for i in range(n):
+        name = f"{random.choice(ORG_WORDS)} {random.choice(ORG_SUFFIX)} {i+1}"
+        state_id = random.choice(STATES)[0]
+        city = random.choice(CITIES[state_id])
+        org_type = random.choices(["non_profit", "for_profit"], weights=[0.7, 0.3])[0]
+        org_size = random.choices(["small", "medium", "large"], weights=[0.5, 0.3, 0.2])[0]
+        # ~20% unrated
+        rating = None if random.random() < 0.2 else random.choices([1, 2, 3, 4, 5],
+                 weights=[0.05, 0.10, 0.20, 0.35, 0.30])[0]
+        is_collab = random.random() < 0.35
+        is_contrib = random.random() < 0.55
+        # registrations spread over the last 2 years, denser recently
+        days_ago = int(random.betavariate(1.2, 3.0) * 730)
+        created = now - timedelta(days=days_ago,
+                                  hours=random.randint(0, 23),
+                                  minutes=random.randint(0, 59))
+        cur.execute(
+            """INSERT INTO organizations
+               (org_name, street, city_name, state_id, zip_code, mission, web_url,
+                phone, email, org_type, org_size, org_rating, is_collaborator,
+                is_contributor, created_at, last_updated_at)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+            (name, f"{random.randint(10,999)} Main St", city, state_id,
+             f"{random.randint(10000,99999)}", "Serving the community.",
+             "https://example.org", f"+1716555{random.randint(1000,9999)}",
+             f"contact{i}@example.org", org_type, org_size, rating,
+             is_collab, is_contrib, created, created))
+
+    conn.commit()
+    cur.execute("SELECT COUNT(*) FROM organizations")
+    print(f"Seeded {cur.fetchone()[0]} organizations.")
+    cur.close(); conn.close()
+
+if __name__ == "__main__":
+    main()

--- a/data-analytics/lambda_functions/test_organization_analytics_local.py
+++ b/data-analytics/lambda_functions/test_organization_analytics_local.py
@@ -1,0 +1,296 @@
+"""Local test harness for organization_analytics.py.
+
+Runs against local PostgreSQL (LOCAL_DB=true). Validates status codes,
+response structure, filter behavior, and cross-metric consistency.
+"""
+import json
+import os
+import re
+
+os.environ["LOCAL_DB"] = "true"
+
+import organization_analytics as oa
+
+PASS, FAIL = 0, 0
+RESULTS = []
+
+
+def check(name, condition, detail=""):
+    global PASS, FAIL
+    status = "PASS" if condition else "FAIL"
+    if condition:
+        PASS += 1
+    else:
+        FAIL += 1
+    RESULTS.append(f"[{status}] {name}" + (f" — {detail}" if detail else ""))
+
+
+def call(payload):
+    resp = oa.lambda_handler(payload, None)
+    return resp["statusCode"], json.loads(resp["body"])
+
+
+def probe_dataset():
+    """Pick filter values that exist in whatever dataset is loaded locally.
+
+    Keeps the suite valid against both the synthetic seed and the real
+    organizations.csv / state.csv extracts.
+    """
+    conn = oa.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(f"""
+        SELECT o.state_id, o.city_name, s.state_name,
+               REPLACE(LOWER(o.org_size::text), '-', '_'), o.org_rating
+        FROM {oa.SCHEMA_NAME}.organizations o
+        JOIN {oa.SCHEMA_NAME}.state s ON o.state_id = s.state_id
+        WHERE o.city_name IS NOT NULL
+          AND o.org_size IS NOT NULL
+          AND o.org_rating IS NOT NULL
+        ORDER BY o.org_id
+        LIMIT 1;
+    """)
+    row = cur.fetchone()
+    cur.close()
+    conn.close()
+    if row is None:
+        raise SystemExit("No usable rows in the local organizations table — load data first.")
+    return row
+
+
+def main():
+    (sample_state_id, sample_city, sample_state_name,
+     sample_size, sample_rating) = probe_dataset()
+    print(f"Dataset probe: state_id={sample_state_id} ({sample_state_name}), "
+          f"city={sample_city}, size={sample_size}, rating={sample_rating}\n")
+
+    # 1. Overview — no filters
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL"})
+    ov = body["organization_overview"]
+    s = ov["summary"]
+    check("overview: 200 OK", code == 200)
+    check("overview: total = non_profit + for_profit + untyped",
+          s["total_organizations"] >= s["non_profit_organizations"] + s["for_profit_organizations"])
+    check("overview: collab + non_collab = total",
+          s["collaborator_organizations"] + s["non_collaborator_organizations"] == s["total_organizations"])
+    check("overview: contrib + non_contrib = total",
+          s["contributor_organizations"] + s["non_contributor_organizations"] == s["total_organizations"])
+    check("overview: trend cumulative total matches summary",
+          ov["organization_activity_trend"][-1]["total_organizations"] == s["total_organizations"])
+    check("overview: type distribution sums to total",
+          sum(r["count"] for r in ov["organizations_by_type"]) == s["total_organizations"])
+    check("overview: size distribution sums to total",
+          sum(r["count"] for r in ov["organizations_by_size"]) == s["total_organizations"])
+    check("overview: location distribution sums to total",
+          sum(r["count"] for r in ov["organizations_by_location"]) == s["total_organizations"])
+    check("overview: collaborator_distribution sums to total",
+          sum(r["count"] for r in ov["collaborator_distribution"]) == s["total_organizations"])
+    check("overview: contributor_distribution sums to total",
+          sum(r["count"] for r in ov["contributor_distribution"]) == s["total_organizations"])
+
+    # 2. Performance — no filters
+    code, body = call({"dashboard_type": "performance", "time_filter": "ALL"})
+    pf = body["organization_performance"]
+    ps = pf["summary"]
+    check("performance: 200 OK", code == 200)
+    check("performance: rated + unrated = overview total",
+          ps["rated_organizations"] + ps["unrated_organizations"] == s["total_organizations"])
+    check("performance: rating distribution sums to rated",
+          sum(r["count"] for r in pf["rating_distribution"]) == ps["rated_organizations"])
+    check("performance: rating distribution always has buckets 1-5",
+          [r["rating"] for r in pf["rating_distribution"]] == [1, 2, 3, 4, 5])
+    check("performance: 1 <= avg rating <= 5",
+          1 <= ps["average_rating"] <= 5)
+    five_star_in_dist = next((r["count"] for r in pf["rating_distribution"] if r["rating"] == 5), 0)
+    check("performance: five_star matches distribution",
+          ps["five_star_organizations"] == five_star_in_dist)
+    check("performance: top_rated <= 10 and sorted desc",
+          len(pf["top_rated_organizations"]) <= 10 and
+          all(pf["top_rated_organizations"][i]["org_rating"] >= pf["top_rated_organizations"][i + 1]["org_rating"]
+              for i in range(len(pf["top_rated_organizations"]) - 1)))
+    check("performance: top collaborators all flagged",
+          len(pf["top_collaborator_organizations"]) <= 10)
+    check("performance: ratings_by_type nonempty",
+          len(pf["ratings_by_organization_type"]) >= 1)
+    check("performance: ratings_by_size nonempty",
+          len(pf["ratings_by_organization_size"]) >= 1)
+
+    # 3. Time filters
+    totals = {}
+    for tf in ["7D", "30D", "1Y", "ALL"]:
+        code, body = call({"dashboard_type": "overview", "time_filter": tf})
+        totals[tf] = body["organization_overview"]["summary"]["total_organizations"]
+        check(f"time_filter {tf}: 200 OK", code == 200, f"total={totals[tf]}")
+    check("time filters monotonic: 7D <= 30D <= 1Y <= ALL",
+          totals["7D"] <= totals["30D"] <= totals["1Y"] <= totals["ALL"])
+
+    # 4. CUSTOM date range
+    code, body = call({"dashboard_type": "overview", "time_filter": "CUSTOM",
+                       "start_date": "2025-01-01", "end_date": "2025-12-31"})
+    check("CUSTOM range: 200 OK", code == 200,
+          f"total={body['organization_overview']['summary']['total_organizations']}")
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "CUSTOM",
+                       "start_date": "2025-01-01"})
+    check("CUSTOM without end_date: 400", code == 400)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "CUSTOM",
+                       "start_date": "01-01-2025", "end_date": "2025-12-31"})
+    check("CUSTOM with non-ISO date: 400", code == 400)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "CUSTOM",
+                       "start_date": "2025-12-31", "end_date": "2025-01-01"})
+    check("CUSTOM with start_date after end_date: 400", code == 400)
+
+    # 5. Dimension filters
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL", "org_type": "non_profit"})
+    s2 = body["organization_overview"]["summary"]
+    check("filter org_type=non_profit: for_profit count is 0",
+          s2["for_profit_organizations"] == 0 and s2["total_organizations"] == s2["non_profit_organizations"])
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL",
+                       "org_type": "Non-Profit"})
+    s2_label = body["organization_overview"]["summary"]
+    check("filter accepts the CSV display label 'Non-Profit'",
+          s2_label == s2)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL", "org_size": sample_size})
+    sizes = body["organization_overview"]["organizations_by_size"]
+    check(f"filter org_size={sample_size}: only that bucket returned",
+          len(sizes) == 1 and sizes[0]["size"] == sample_size)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL",
+                       "org_size": sample_size.upper()})
+    check(f"filter org_size={sample_size.upper()} (case-insensitive) matches",
+          body["organization_overview"]["organizations_by_size"] == sizes)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL", "state_id": sample_state_id})
+    locs = body["organization_overview"]["organizations_by_location"]
+    check(f"filter state_id={sample_state_id}: all locations in {sample_state_name}",
+          all(l["state"] == sample_state_name for l in locs) and len(locs) > 0)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL",
+                       "city_name": sample_city.lower()})
+    locs = body["organization_overview"]["organizations_by_location"]
+    check(f"filter city_name (case-insensitive): only {sample_city}",
+          all(l["city"] == sample_city for l in locs) and len(locs) > 0)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL", "is_collaborator": True})
+    s3 = body["organization_overview"]["summary"]
+    check("filter is_collaborator=true: non_collaborator count is 0",
+          s3["non_collaborator_organizations"] == 0)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "ALL", "is_contributor": False})
+    s4 = body["organization_overview"]["summary"]
+    check("filter is_contributor=false: contributor count is 0",
+          s4["contributor_organizations"] == 0)
+
+    code, body = call({"dashboard_type": "performance", "time_filter": "ALL",
+                       "org_rating": sample_rating})
+    pf2 = body["organization_performance"]
+    check(f"filter org_rating={sample_rating}: only that bucket non-zero, rest zero-filled",
+          [r["rating"] for r in pf2["rating_distribution"]] == [1, 2, 3, 4, 5] and
+          all(r["count"] == 0 for r in pf2["rating_distribution"] if r["rating"] != sample_rating) and
+          next(r["count"] for r in pf2["rating_distribution"] if r["rating"] == sample_rating) > 0)
+
+    # 6. group_by variants
+    for gb in ["daily", "weekly", "monthly", "yearly"]:
+        code, body = call({"dashboard_type": "overview", "time_filter": "1Y", "group_by": gb})
+        trend = body["organization_overview"]["organization_activity_trend"]
+        check(f"group_by {gb}: 200 OK with trend rows", code == 200 and len(trend) >= 1,
+              f"buckets={len(trend)}")
+
+    # 7. Invalid inputs
+    code, body = call({"dashboard_type": "bogus"})
+    check("invalid dashboard_type: 400", code == 400)
+
+    code, body = call({"dashboard_type": "overview", "time_filter": "INVALID",
+                       "group_by": "hourly", "org_rating": 99})
+    check("invalid filter values sanitized to defaults: 200", code == 200)
+
+    # 8. API-Gateway-style event (stringified body)
+    code, body = call({"body": json.dumps({"dashboard_type": "performance", "time_filter": "30D"})})
+    check("API Gateway string body parsed: 200", code == 200)
+
+    # 9. Credentials come from configuration, never a hard-coded Parameter Store path
+    # Pattern-matched rather than spelled out, so no Parameter Store path
+    # literal exists anywhere in the repository, not even as an assertion.
+    source = open(oa.__file__, encoding="utf-8").read()
+    absolute_path_literals = re.findall(r"""['"]/[a-z0-9_\-/]*saayam[a-z0-9_\-/]*['"]""",
+                                        source, re.IGNORECASE)
+    check("no Parameter Store path hard-coded in source",
+          absolute_path_literals == [], f"found {absolute_path_literals}")
+
+    os.environ["LOCAL_DB"] = "false"
+    os.environ.pop("DB_CREDENTIALS_PARAMETER", None)
+    try:
+        oa.get_db_connection()
+        check("missing DB_CREDENTIALS_PARAMETER raises a clear error", False)
+    except RuntimeError as error:
+        check("missing DB_CREDENTIALS_PARAMETER raises a clear error",
+              "DB_CREDENTIALS_PARAMETER" in str(error))
+    except Exception as error:
+        check("missing DB_CREDENTIALS_PARAMETER raises a clear error", False,
+              f"got {type(error).__name__}")
+    finally:
+        os.environ["LOCAL_DB"] = "true"
+
+    # 10. A failing metric must not cascade into the metrics that follow it
+    def failing_fetch(cursor, *_args):
+        cursor.execute("SELECT 1 / 0")
+        return []
+
+    original_by_type = oa.fetch_organizations_by_type
+    oa.fetch_organizations_by_type = failing_fetch
+    try:
+        code, body = call({"dashboard_type": "overview", "time_filter": "ALL"})
+        ov_err = body["organization_overview"]
+        check("failing metric: request still 200", code == 200)
+        check("failing metric: its own section falls back to the safe default",
+              ov_err["organizations_by_type"] == [])
+        check("failing metric: later queries on the same connection still succeed",
+              ov_err["summary"]["total_organizations"] == s["total_organizations"] and
+              sum(r["count"] for r in ov_err["organizations_by_size"]) == s["total_organizations"] and
+              len(ov_err["organization_activity_trend"]) > 0)
+    finally:
+        oa.fetch_organizations_by_type = original_by_type
+
+    # 11. Graceful degradation when the organizations table has no is_contributor column
+    original_detector = oa.has_contributor_column
+    oa.has_contributor_column = lambda cursor: False
+    try:
+        code, body = call({"dashboard_type": "overview", "time_filter": "ALL"})
+        ov_nc = body["organization_overview"]
+        s_nc = ov_nc["summary"]
+        check("no is_contributor column: overview still 200", code == 200)
+        check("no is_contributor column: non-contributor metrics unaffected",
+              s_nc["total_organizations"] == s["total_organizations"] and
+              s_nc["collaborator_organizations"] == s["collaborator_organizations"])
+        check("no is_contributor column: contributor metrics zero/empty",
+              s_nc["contributor_organizations"] == 0 and
+              s_nc["non_contributor_organizations"] == 0 and
+              ov_nc["contributor_distribution"] == [])
+        check("no is_contributor column: schema note returned",
+              any("is_contributor" in note for note in body.get("schema_notes", [])))
+
+        code, body = call({"dashboard_type": "overview", "time_filter": "ALL",
+                           "is_contributor": True})
+        check("no is_contributor column: is_contributor filter ignored, not fatal",
+              code == 200 and
+              body["organization_overview"]["summary"]["total_organizations"] == s["total_organizations"])
+
+        code, body = call({"dashboard_type": "performance", "time_filter": "ALL"})
+        pf_nc = body["organization_performance"]
+        check("no is_contributor column: performance still 200 with ratings intact",
+              code == 200 and pf_nc["summary"]["rated_organizations"] == ps["rated_organizations"])
+        check("no is_contributor column: top contributors empty",
+              pf_nc["top_contributor_organizations"] == [])
+    finally:
+        oa.has_contributor_column = original_detector
+
+    print("\n".join(RESULTS))
+    print(f"\n{PASS} passed, {FAIL} failed out of {PASS + FAIL} checks.")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the Organization Analytics API requested in #228 using the `virginia_dev_saayam_rdbms.organizations` table.

## Changes

- Added Organization Overview dashboard metrics
- Added Organization Performance dashboard metrics
- Added all required time and organization filters
- Added daily, weekly, monthly, and yearly registration trends
- Added organization type, size, location, collaborator, contributor, and rating analytics
- Added safe handling when `is_contributor` is unavailable
- Added local PostgreSQL setup, source CSV loader, seed data, and test utilities
- Added sample responses for both dashboards
- No AWS Parameter Store path is hard-coded

## Testing

- Tested locally using PostgreSQL
- Tested using the 40-row `organizations.csv` source extract
- All 57 checks passed
- Verified API Gateway-style request bodies and invalid-input handling
- Verified one failed metric does not affect later dashboard metrics

Closes #228