### PR TITLE
#228: Add Organization Analytics API for the Organization Dashboard

### DIFF
--- a/data-analytics/lambda_functions/ORGANIZATION_ANALYTICS_TEST_RESULTS.md
+++ b/data-analytics/lambda_functions/ORGANIZATION_ANALYTICS_TEST_RESULTS.md
@@ -1,0 +1,67 @@
+# Organization Analytics API - Local Test Results
+
+Test date: August 9, 2026
+
+## Environment
+
+- Python: 3.12.13
+- PostgreSQL: 17.10, portable local server
+- Database: `saayam_local` on localhost only
+- Source data: `data-analytics/sql/organizations.csv` and
+  `data-analytics/sql/state.csv`
+- Rows loaded: 40 organizations and 51 states
+- AWS deployment: not performed
+- GitHub changes: not performed
+
+## Results
+
+```text
+Ran 20 tests in 3.243s
+
+OK
+```
+
+All 20 tests passed:
+
+- 10 request parsing, validation, SQL parameterization, and configuration tests
+- 10 local PostgreSQL integration tests
+- Both overview and performance dashboard response structures
+- All common dimension filters
+- `7D`, `30D`, `1Y`, `ALL`, and `CUSTOM` time-filter behavior
+- Daily, weekly, monthly, and yearly trend grouping
+- API Gateway stringified request-body handling
+- Contributor analytics when `is_contributor` is present
+- Safe fallback and filter rejection when `is_contributor` is absent
+- Per-metric failure isolation
+- No hard-coded AWS Parameter Store path or client in the API source
+
+## Verified source metrics
+
+```text
+total_organizations: 40
+non_profit_organizations: 21
+for_profit_organizations: 19
+collaborator_organizations: 21
+non_collaborator_organizations: 19
+contributor_organizations: 19
+non_contributor_organizations: 21
+average_rating: 3.23
+rated_organizations: 40
+unrated_organizations: 0
+five_star_organizations: 12
+rating_distribution: 1=5, 2=9, 3=10, 4=4, 5=12
+```
+
+## Additional checks
+
+```text
+Python AST parse: passed for all four Python implementation/support files
+Python line-length check: 0 lines over 99 characters
+Git whitespace check: passed
+```
+
+The intentional metric-failure test logs two stack traces while forcing the
+type and size queries to fail. The test passes because the summary and later
+location metrics still return correct data, proving one failed metric does not
+blank the dashboard.
+

--- a/data-analytics/lambda_functions/README_organization_analytics.md
+++ b/data-analytics/lambda_functions/README_organization_analytics.md
@@ -1,0 +1,106 @@
+# Organization Analytics API
+
+Implements issue #228 over
+`virginia_dev_saayam_rdbms.organizations` and
+`virginia_dev_saayam_rdbms.state`. It follows the existing analytics Lambda
+pattern: API Gateway-compatible responses, `psycopg2`/`RealDictCursor`, one
+query helper per metric, parameterized filters, and per-metric failure
+isolation.
+
+## Endpoints
+
+The main Lambda supports the single-endpoint design:
+
+```text
+POST /analytics/organizations
+```
+
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "30D",
+  "group_by": "daily"
+}
+```
+
+`overview_handler` and `performance_handler` are also exported for deployments
+that use these separate routes:
+
+```text
+POST /analytics/organizations/overview
+POST /analytics/organizations/performance
+```
+
+## Filters
+
+Both dashboards accept:
+
+- `time_filter`: `7D`, `30D`, `1Y`, `ALL`, or `CUSTOM`
+- `start_date` and `end_date`: required for `CUSTOM`, in `YYYY-MM-DD` format
+- `org_type`: `non_profit` or `for_profit` (display labels are normalized)
+- `org_size`: `small`, `medium`, or `large`
+- `state_id`, `city_name`, `org_rating`
+- `is_collaborator`, `is_contributor`
+- `group_by`: `daily`, `weekly`, `monthly`, or `yearly`
+
+The API returns HTTP 400 for invalid filters. Every user-supplied value is sent
+to PostgreSQL as a query parameter.
+
+## Database configuration
+
+The implementation does not contain or retrieve an AWS Parameter Store path.
+Set either `DATABASE_URL` or these environment variables:
+
+```text
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=saayam_local
+DB_USER=postgres
+DB_PASSWORD=<local password>
+DB_SSLMODE=<optional>
+```
+
+## `is_contributor` compatibility
+
+The current shared database may not yet contain `is_contributor`. The API checks
+`information_schema.columns` at runtime:
+
+- when present, contributor summaries, distribution, leaderboard, and filter
+  work normally;
+- when absent, contributor counts are `null`, contributor arrays are empty, and
+  `schema_notes.is_contributor` explains the limitation;
+- a requested `is_contributor` filter returns HTTP 400 when the column is absent,
+  because silently ignoring a filter would return misleading analytics.
+
+## Local PostgreSQL setup and tests
+
+The commands below are PowerShell examples. Use a disposable local database;
+nothing in this workflow deploys to AWS.
+
+```powershell
+cd data-analytics/lambda_functions
+python -m pip install -r requirements.txt
+
+$env:DB_HOST = "localhost"
+$env:DB_PORT = "5432"
+$env:DB_NAME = "saayam_local"
+$env:DB_USER = "postgres"
+$env:DB_PASSWORD = "<local password>"
+$env:ORG_ANALYTICS_LOCAL_TEST = "true"
+
+psql -d saayam_local -f organization_analytics_local_setup.sql
+python organization_analytics_load_csv.py
+
+python -m unittest -v test_organization_analytics.py
+$env:ORG_ANALYTICS_RUN_INTEGRATION_TESTS = "true"
+python -m unittest -v test_organization_analytics.py
+
+python organization_analytics_generate_samples.py
+```
+
+The integration suite verifies both dashboards, every common filter, all four
+trend groupings, API Gateway request parsing, response consistency, missing
+`is_contributor` behavior, SQL parameterization, and per-metric failure
+isolation. Generated sample bodies are stored in
+`organization_analytics_samples/`.
+

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,856 @@
+"""Organization analytics API for the Saayam dashboard.
+
+The Lambda exposes a single handler selected by ``dashboard_type`` and thin
+wrappers for deployments that prefer separate overview/performance routes.
+Database settings come from environment variables; no AWS Parameter Store path
+is embedded in this module.
+"""
+
+import json
+import logging
+import os
+from datetime import date
+from decimal import Decimal
+
+
+LOGGER = logging.getLogger(__name__)
+
+SCHEMA_NAME = "virginia_dev_saayam_rdbms"
+ORGANIZATIONS_TABLE = f"{SCHEMA_NAME}.organizations"
+STATE_TABLE = f"{SCHEMA_NAME}.state"
+
+VALID_DASHBOARDS = {"overview", "performance"}
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+VALID_GROUP_BY = {
+    "daily": "day",
+    "weekly": "week",
+    "monthly": "month",
+    "yearly": "year",
+}
+VALID_ORG_TYPES = {"non_profit", "for_profit"}
+VALID_ORG_SIZES = {"small", "medium", "large"}
+TOP_ORGANIZATION_LIMIT = 10
+
+NORMALIZED_ORG_TYPE = (
+    "REPLACE(REPLACE(LOWER(o.org_type::text), '-', '_'), ' ', '_')"
+)
+NORMALIZED_ORG_SIZE = (
+    "REPLACE(REPLACE(LOWER(o.org_size::text), '-', '_'), ' ', '_')"
+)
+
+
+class RequestValidationError(ValueError):
+    """Raised when an API request contains unsupported filter values."""
+
+
+def normalize_label(value):
+    """Normalize display labels such as ``Non-Profit`` to ``non_profit``."""
+    if value is None:
+        return None
+    return str(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def parse_boolean(value, field_name):
+    """Parse a JSON boolean or a common string representation."""
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise RequestValidationError(f"{field_name} must be true, false, or null.")
+
+
+def parse_event_body(event):
+    """Return a request dictionary for direct or API Gateway proxy invocation."""
+    if event is None:
+        return {}
+    if not isinstance(event, dict):
+        raise RequestValidationError("The request payload must be a JSON object.")
+
+    body = event.get("body")
+    if body is None:
+        return event
+    if isinstance(body, dict):
+        return body
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as error:
+            raise RequestValidationError("The request body is not valid JSON.") from error
+        if not isinstance(parsed, dict):
+            raise RequestValidationError("The request body must be a JSON object.")
+        return parsed
+    raise RequestValidationError("The request body must be a JSON object.")
+
+
+def parse_filters(request_body):
+    """Validate and normalize the filters shared by both dashboards."""
+    time_filter = str(request_body.get("time_filter", "30D")).upper()
+    if time_filter not in VALID_TIME_FILTERS:
+        allowed = ", ".join(sorted(VALID_TIME_FILTERS))
+        raise RequestValidationError(f"time_filter must be one of: {allowed}.")
+
+    group_by = str(request_body.get("group_by", "daily")).lower()
+    if group_by not in VALID_GROUP_BY:
+        allowed = ", ".join(VALID_GROUP_BY)
+        raise RequestValidationError(f"group_by must be one of: {allowed}.")
+
+    start_date = request_body.get("start_date")
+    end_date = request_body.get("end_date")
+    if time_filter == "CUSTOM":
+        if not start_date or not end_date:
+            raise RequestValidationError(
+                "CUSTOM time_filter requires start_date and end_date."
+            )
+        try:
+            parsed_start = date.fromisoformat(str(start_date))
+            parsed_end = date.fromisoformat(str(end_date))
+        except ValueError as error:
+            raise RequestValidationError(
+                "start_date and end_date must use YYYY-MM-DD format."
+            ) from error
+        if parsed_start > parsed_end:
+            raise RequestValidationError("start_date cannot be after end_date.")
+        start_date = parsed_start.isoformat()
+        end_date = parsed_end.isoformat()
+
+    org_type = normalize_label(request_body.get("org_type"))
+    if org_type is not None and org_type not in VALID_ORG_TYPES:
+        raise RequestValidationError("org_type must be non_profit or for_profit.")
+
+    org_size = normalize_label(request_body.get("org_size"))
+    if org_size is not None and org_size not in VALID_ORG_SIZES:
+        raise RequestValidationError("org_size must be small, medium, or large.")
+
+    org_rating = request_body.get("org_rating")
+    if org_rating is not None:
+        try:
+            org_rating = int(org_rating)
+        except (TypeError, ValueError) as error:
+            raise RequestValidationError("org_rating must be an integer from 1 to 5.") from error
+        if org_rating < 1 or org_rating > 5:
+            raise RequestValidationError("org_rating must be an integer from 1 to 5.")
+
+    state_id = request_body.get("state_id")
+    if state_id is not None:
+        state_id = str(state_id).strip().upper()
+    city_name = request_body.get("city_name")
+    if city_name is not None:
+        city_name = str(city_name).strip()
+
+    return {
+        "time_filter": time_filter,
+        "start_date": start_date,
+        "end_date": end_date,
+        "org_type": org_type,
+        "org_size": org_size,
+        "state_id": state_id,
+        "city_name": city_name,
+        "org_rating": org_rating,
+        "is_collaborator": parse_boolean(
+            request_body.get("is_collaborator"), "is_collaborator"
+        ),
+        "is_contributor": parse_boolean(
+            request_body.get("is_contributor"), "is_contributor"
+        ),
+        "group_by": group_by,
+    }
+
+
+def build_response(status_code, body):
+    """Build an API Gateway proxy response with standard CORS headers."""
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "Content-Type,Authorization",
+            "Access-Control-Allow-Methods": "POST,OPTIONS",
+        },
+        "body": json.dumps(body, default=str),
+    }
+
+
+def get_db_connection():
+    """Create a PostgreSQL connection using only environment configuration.
+
+    ``DATABASE_URL`` takes precedence. Otherwise ``DB_HOST``, ``DB_PORT``,
+    ``DB_NAME``, ``DB_USER``, ``DB_PASSWORD`` and optional ``DB_SSLMODE`` are
+    used. Local-friendly defaults are supplied for host, port, database, and
+    user; a password is not hard-coded.
+    """
+    try:
+        import psycopg2
+    except ImportError as error:
+        raise RuntimeError(
+            "psycopg2 is required. Install data-analytics/lambda_functions/"
+            "requirements.txt before running the API."
+        ) from error
+
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url:
+        connection = psycopg2.connect(database_url)
+    else:
+        connection_options = {
+            "host": os.environ.get("DB_HOST", "localhost"),
+            "port": os.environ.get("DB_PORT", "5432"),
+            "dbname": os.environ.get("DB_NAME", "saayam_local"),
+            "user": os.environ.get("DB_USER", "postgres"),
+        }
+        password = os.environ.get("DB_PASSWORD")
+        sslmode = os.environ.get("DB_SSLMODE")
+        if password is not None:
+            connection_options["password"] = password
+        if sslmode:
+            connection_options["sslmode"] = sslmode
+        connection = psycopg2.connect(**connection_options)
+
+    # Each dashboard metric is read-only and independent. Autocommit prevents a
+    # single failed metric from aborting every subsequent query on the connection.
+    connection.autocommit = True
+    return connection
+
+
+def get_default_overview_response():
+    """Return the complete safe shape for the overview dashboard."""
+    return {
+        "organization_overview": {
+            "summary": {
+                "total_organizations": 0,
+                "non_profit_organizations": 0,
+                "for_profit_organizations": 0,
+                "collaborator_organizations": 0,
+                "non_collaborator_organizations": 0,
+                "contributor_organizations": None,
+                "non_contributor_organizations": None,
+            },
+            "organization_activity_trend": [],
+            "organizations_by_type": [],
+            "organizations_by_size": [],
+            "organizations_by_location": {"by_state": [], "by_city": []},
+            "collaborator_distribution": [],
+            "contributor_distribution": [],
+        }
+    }
+
+
+def get_default_performance_response():
+    """Return the complete safe shape for the performance dashboard."""
+    return {
+        "organization_performance": {
+            "summary": {
+                "average_rating": 0.0,
+                "rated_organizations": 0,
+                "unrated_organizations": 0,
+                "five_star_organizations": 0,
+            },
+            "rating_distribution": [],
+            "top_rated_organizations": [],
+            "top_collaborator_organizations": [],
+            "top_contributor_organizations": [],
+            "ratings_by_organization_type": [],
+            "ratings_by_organization_size": [],
+        }
+    }
+
+
+def has_contributor_column(cursor):
+    """Return whether the not-yet-universal ``is_contributor`` column exists."""
+    cursor.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = %s
+              AND table_name = 'organizations'
+              AND column_name = 'is_contributor'
+        ) AS available;
+        """,
+        (SCHEMA_NAME,),
+    )
+    row = cursor.fetchone()
+    return bool(row and row["available"])
+
+
+def build_conditions(filters, contributor_available):
+    """Build parameterized SQL conditions referencing organization alias ``o``."""
+    conditions = []
+    params = []
+    time_filter = filters["time_filter"]
+
+    if time_filter == "7D":
+        conditions.append("o.created_at >= CURRENT_DATE - INTERVAL '7 days'")
+    elif time_filter == "30D":
+        conditions.append("o.created_at >= CURRENT_DATE - INTERVAL '30 days'")
+    elif time_filter == "1Y":
+        conditions.append("o.created_at >= CURRENT_DATE - INTERVAL '1 year'")
+    elif time_filter == "CUSTOM":
+        conditions.append("o.created_at >= %s::date")
+        conditions.append("o.created_at < %s::date + INTERVAL '1 day'")
+        params.extend([filters["start_date"], filters["end_date"]])
+
+    if filters["org_type"] is not None:
+        conditions.append(f"{NORMALIZED_ORG_TYPE} = %s")
+        params.append(filters["org_type"])
+    if filters["org_size"] is not None:
+        conditions.append(f"{NORMALIZED_ORG_SIZE} = %s")
+        params.append(filters["org_size"])
+    if filters["state_id"]:
+        conditions.append("UPPER(o.state_id::text) = %s")
+        params.append(filters["state_id"])
+    if filters["city_name"]:
+        conditions.append("LOWER(o.city_name) = LOWER(%s)")
+        params.append(filters["city_name"])
+    if filters["org_rating"] is not None:
+        conditions.append("o.org_rating = %s")
+        params.append(filters["org_rating"])
+    if filters["is_collaborator"] is not None:
+        conditions.append("o.is_collaborator IS NOT DISTINCT FROM %s")
+        params.append(filters["is_collaborator"])
+    if filters["is_contributor"] is not None:
+        if not contributor_available:
+            raise RequestValidationError(
+                "is_contributor cannot be filtered because the column is not "
+                "available in the current database schema."
+            )
+        conditions.append("o.is_contributor IS NOT DISTINCT FROM %s")
+        params.append(filters["is_contributor"])
+
+    return conditions, params
+
+
+def where_clause(conditions):
+    """Render a WHERE clause from trusted, internally generated conditions."""
+    return f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+
+def where_with_extra(conditions, extra_condition):
+    """Render a WHERE clause plus one trusted metric-specific condition."""
+    all_conditions = [*conditions, extra_condition]
+    return where_clause(all_conditions)
+
+
+def to_number(value):
+    """Convert PostgreSQL numeric values to JSON-friendly int/float values."""
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        value = float(value)
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def fetch_overview_summary(cursor, conditions, params, contributor_available):
+    """Fetch all overview summary cards in one aggregate query."""
+    if contributor_available:
+        contributor_columns = """
+            COUNT(*) FILTER (WHERE o.is_contributor IS TRUE)
+                AS contributor_organizations,
+            COUNT(*) FILTER (WHERE o.is_contributor IS NOT TRUE)
+                AS non_contributor_organizations
+        """
+    else:
+        contributor_columns = """
+            NULL::bigint AS contributor_organizations,
+            NULL::bigint AS non_contributor_organizations
+        """
+
+    cursor.execute(
+        f"""
+        SELECT
+            COUNT(*) AS total_organizations,
+            COUNT(*) FILTER (WHERE {NORMALIZED_ORG_TYPE} = 'non_profit')
+                AS non_profit_organizations,
+            COUNT(*) FILTER (WHERE {NORMALIZED_ORG_TYPE} = 'for_profit')
+                AS for_profit_organizations,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE)
+                AS collaborator_organizations,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS NOT TRUE)
+                AS non_collaborator_organizations,
+            {contributor_columns}
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)};
+        """,
+        params,
+    )
+    row = cursor.fetchone()
+    return {
+        "total_organizations": int(row["total_organizations"] or 0),
+        "non_profit_organizations": int(row["non_profit_organizations"] or 0),
+        "for_profit_organizations": int(row["for_profit_organizations"] or 0),
+        "collaborator_organizations": int(row["collaborator_organizations"] or 0),
+        "non_collaborator_organizations": int(
+            row["non_collaborator_organizations"] or 0
+        ),
+        "contributor_organizations": (
+            int(row["contributor_organizations"] or 0)
+            if contributor_available
+            else None
+        ),
+        "non_contributor_organizations": (
+            int(row["non_contributor_organizations"] or 0)
+            if contributor_available
+            else None
+        ),
+    }
+
+
+def fetch_registration_trend(cursor, conditions, params, group_by):
+    """Fetch new organization registrations grouped by the requested period."""
+    period = VALID_GROUP_BY[group_by]
+    cursor.execute(
+        f"""
+        SELECT DATE_TRUNC('{period}', o.created_at)::date AS period,
+               COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_with_extra(conditions, 'o.created_at IS NOT NULL')}
+        GROUP BY 1
+        ORDER BY 1;
+        """,
+        params,
+    )
+    return [
+        {"period": row["period"].isoformat(), "count": int(row["count"])}
+        for row in cursor.fetchall()
+    ]
+
+
+def fetch_group_distribution(cursor, conditions, params, dimension):
+    """Fetch normalized counts for organization type or size."""
+    if dimension == "org_type":
+        expression = NORMALIZED_ORG_TYPE
+    elif dimension == "org_size":
+        expression = NORMALIZED_ORG_SIZE
+    else:
+        raise ValueError("Unsupported organization dimension.")
+
+    cursor.execute(
+        f"""
+        SELECT {expression} AS label, COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY 1
+        ORDER BY count DESC, label;
+        """,
+        params,
+    )
+    return [
+        {dimension: row["label"], "count": int(row["count"])}
+        for row in cursor.fetchall()
+    ]
+
+
+def fetch_organizations_by_location(cursor, conditions, params):
+    """Fetch state and city distributions for the same filtered population."""
+    cursor.execute(
+        f"""
+        SELECT o.state_id, COALESCE(s.state_name, o.state_id::text) AS state_name,
+               COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        LEFT JOIN {STATE_TABLE} s ON s.state_id = o.state_id
+        {where_clause(conditions)}
+        GROUP BY o.state_id, s.state_name
+        ORDER BY count DESC, state_name;
+        """,
+        params,
+    )
+    by_state = [
+        {
+            "state_id": row["state_id"],
+            "state_name": row["state_name"],
+            "count": int(row["count"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+    cursor.execute(
+        f"""
+        SELECT o.city_name, COUNT(*) AS count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY o.city_name
+        ORDER BY count DESC, o.city_name;
+        """,
+        params,
+    )
+    by_city = [
+        {"city_name": row["city_name"], "count": int(row["count"])}
+        for row in cursor.fetchall()
+    ]
+    return {"by_state": by_state, "by_city": by_city}
+
+
+def fetch_boolean_distribution(cursor, conditions, params, column_name):
+    """Fetch true/false counts for an allow-listed organization flag."""
+    if column_name not in {"is_collaborator", "is_contributor"}:
+        raise ValueError("Unsupported boolean distribution.")
+    cursor.execute(
+        f"""
+        SELECT
+            COUNT(*) FILTER (WHERE o.{column_name} IS TRUE) AS true_count,
+            COUNT(*) FILTER (WHERE o.{column_name} IS NOT TRUE) AS false_count
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)};
+        """,
+        params,
+    )
+    row = cursor.fetchone()
+    return [
+        {column_name: True, "count": int(row["true_count"] or 0)},
+        {column_name: False, "count": int(row["false_count"] or 0)},
+    ]
+
+
+def fetch_performance_summary(cursor, conditions, params):
+    """Fetch the performance summary cards."""
+    cursor.execute(
+        f"""
+        SELECT
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+            COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL)
+                AS rated_organizations,
+            COUNT(*) FILTER (WHERE o.org_rating IS NULL)
+                AS unrated_organizations,
+            COUNT(*) FILTER (WHERE o.org_rating = 5)
+                AS five_star_organizations
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)};
+        """,
+        params,
+    )
+    row = cursor.fetchone()
+    return {
+        "average_rating": float(row["average_rating"] or 0),
+        "rated_organizations": int(row["rated_organizations"] or 0),
+        "unrated_organizations": int(row["unrated_organizations"] or 0),
+        "five_star_organizations": int(row["five_star_organizations"] or 0),
+    }
+
+
+def fetch_rating_distribution(cursor, conditions, params):
+    """Return all rating buckets from one to five, including zero-count buckets."""
+    cursor.execute(
+        f"""
+        SELECT ratings.rating, COUNT(filtered.org_rating) AS count
+        FROM GENERATE_SERIES(1, 5) AS ratings(rating)
+        LEFT JOIN (
+            SELECT o.org_rating
+            FROM {ORGANIZATIONS_TABLE} o
+            {where_with_extra(conditions, 'o.org_rating IS NOT NULL')}
+        ) AS filtered ON filtered.org_rating::int = ratings.rating
+        GROUP BY ratings.rating
+        ORDER BY ratings.rating;
+        """,
+        params,
+    )
+    return [
+        {"rating": int(row["rating"]), "count": int(row["count"])}
+        for row in cursor.fetchall()
+    ]
+
+
+def fetch_top_organizations(cursor, conditions, params, flag_column=None):
+    """Fetch the ten highest-rated organizations, optionally restricted by flag."""
+    extra_conditions = ["o.org_rating IS NOT NULL"]
+    if flag_column is not None:
+        if flag_column not in {"is_collaborator", "is_contributor"}:
+            raise ValueError("Unsupported top-organization flag.")
+        extra_conditions.append(f"o.{flag_column} IS TRUE")
+
+    cursor.execute(
+        f"""
+        SELECT o.org_id, o.org_name, o.org_rating,
+               {NORMALIZED_ORG_TYPE} AS org_type,
+               {NORMALIZED_ORG_SIZE} AS org_size,
+               o.state_id, o.city_name
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause([*conditions, *extra_conditions])}
+        ORDER BY o.org_rating DESC, o.org_name
+        LIMIT %s;
+        """,
+        [*params, TOP_ORGANIZATION_LIMIT],
+    )
+    return [
+        {
+            "org_id": row["org_id"],
+            "org_name": row["org_name"],
+            "org_rating": to_number(row["org_rating"]),
+            "org_type": row["org_type"],
+            "org_size": row["org_size"],
+            "state_id": row["state_id"],
+            "city_name": row["city_name"],
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def fetch_ratings_by_dimension(cursor, conditions, params, dimension):
+    """Fetch average ratings by normalized organization type or size."""
+    if dimension == "org_type":
+        expression = NORMALIZED_ORG_TYPE
+    elif dimension == "org_size":
+        expression = NORMALIZED_ORG_SIZE
+    else:
+        raise ValueError("Unsupported rating dimension.")
+
+    cursor.execute(
+        f"""
+        SELECT {expression} AS label,
+               ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+               COUNT(*) AS total_organizations,
+               COUNT(o.org_rating) AS rated_organizations
+        FROM {ORGANIZATIONS_TABLE} o
+        {where_clause(conditions)}
+        GROUP BY 1
+        ORDER BY average_rating DESC NULLS LAST, label;
+        """,
+        params,
+    )
+    return [
+        {
+            dimension: row["label"],
+            "average_rating": float(row["average_rating"] or 0),
+            "total_organizations": int(row["total_organizations"]),
+            "rated_organizations": int(row["rated_organizations"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def run_metric(connection, label, default, callback):
+    """Run one metric without allowing its failure to blank the dashboard."""
+    try:
+        return callback()
+    except Exception:
+        LOGGER.exception("Organization analytics metric failed: %s", label)
+        try:
+            connection.rollback()
+        except Exception:
+            LOGGER.exception("Database rollback failed after metric: %s", label)
+        return default
+
+
+def build_overview(connection, cursor, filters, contributor_available):
+    """Build the Organization Overview dashboard response."""
+    response = get_default_overview_response()
+    dashboard = response["organization_overview"]
+    conditions, params = build_conditions(filters, contributor_available)
+
+    dashboard["summary"] = run_metric(
+        connection,
+        "overview.summary",
+        dashboard["summary"],
+        lambda: fetch_overview_summary(
+            cursor, conditions, params, contributor_available
+        ),
+    )
+    dashboard["organization_activity_trend"] = run_metric(
+        connection,
+        "overview.organization_activity_trend",
+        [],
+        lambda: fetch_registration_trend(
+            cursor, conditions, params, filters["group_by"]
+        ),
+    )
+    dashboard["organizations_by_type"] = run_metric(
+        connection,
+        "overview.organizations_by_type",
+        [],
+        lambda: fetch_group_distribution(
+            cursor, conditions, params, "org_type"
+        ),
+    )
+    dashboard["organizations_by_size"] = run_metric(
+        connection,
+        "overview.organizations_by_size",
+        [],
+        lambda: fetch_group_distribution(
+            cursor, conditions, params, "org_size"
+        ),
+    )
+    dashboard["organizations_by_location"] = run_metric(
+        connection,
+        "overview.organizations_by_location",
+        {"by_state": [], "by_city": []},
+        lambda: fetch_organizations_by_location(cursor, conditions, params),
+    )
+    dashboard["collaborator_distribution"] = run_metric(
+        connection,
+        "overview.collaborator_distribution",
+        [],
+        lambda: fetch_boolean_distribution(
+            cursor, conditions, params, "is_collaborator"
+        ),
+    )
+    if contributor_available:
+        dashboard["contributor_distribution"] = run_metric(
+            connection,
+            "overview.contributor_distribution",
+            [],
+            lambda: fetch_boolean_distribution(
+                cursor, conditions, params, "is_contributor"
+            ),
+        )
+    else:
+        dashboard["schema_notes"] = {
+            "is_contributor": (
+                "Contributor metrics are unavailable until is_contributor is "
+                "added to the organizations table."
+            )
+        }
+    return response
+
+
+def build_performance(connection, cursor, filters, contributor_available):
+    """Build the Organization Performance dashboard response."""
+    response = get_default_performance_response()
+    dashboard = response["organization_performance"]
+    conditions, params = build_conditions(filters, contributor_available)
+
+    dashboard["summary"] = run_metric(
+        connection,
+        "performance.summary",
+        dashboard["summary"],
+        lambda: fetch_performance_summary(cursor, conditions, params),
+    )
+    dashboard["rating_distribution"] = run_metric(
+        connection,
+        "performance.rating_distribution",
+        [],
+        lambda: fetch_rating_distribution(cursor, conditions, params),
+    )
+    dashboard["top_rated_organizations"] = run_metric(
+        connection,
+        "performance.top_rated_organizations",
+        [],
+        lambda: fetch_top_organizations(cursor, conditions, params),
+    )
+    dashboard["top_collaborator_organizations"] = run_metric(
+        connection,
+        "performance.top_collaborator_organizations",
+        [],
+        lambda: fetch_top_organizations(
+            cursor, conditions, params, "is_collaborator"
+        ),
+    )
+    if contributor_available:
+        dashboard["top_contributor_organizations"] = run_metric(
+            connection,
+            "performance.top_contributor_organizations",
+            [],
+            lambda: fetch_top_organizations(
+                cursor, conditions, params, "is_contributor"
+            ),
+        )
+    else:
+        dashboard["schema_notes"] = {
+            "is_contributor": (
+                "Top contributor organizations are unavailable until "
+                "is_contributor is added to the organizations table."
+            )
+        }
+    dashboard["ratings_by_organization_type"] = run_metric(
+        connection,
+        "performance.ratings_by_organization_type",
+        [],
+        lambda: fetch_ratings_by_dimension(
+            cursor, conditions, params, "org_type"
+        ),
+    )
+    dashboard["ratings_by_organization_size"] = run_metric(
+        connection,
+        "performance.ratings_by_organization_size",
+        [],
+        lambda: fetch_ratings_by_dimension(
+            cursor, conditions, params, "org_size"
+        ),
+    )
+    return response
+
+
+def handle_dashboard(dashboard_type, request_body):
+    """Validate, connect, and execute one dashboard request."""
+    connection = None
+    cursor = None
+    fallback = (
+        get_default_overview_response()
+        if dashboard_type == "overview"
+        else get_default_performance_response()
+    )
+
+    try:
+        filters = parse_filters(request_body)
+        connection = get_db_connection()
+        from psycopg2.extras import RealDictCursor
+
+        cursor = connection.cursor(cursor_factory=RealDictCursor)
+        contributor_available = has_contributor_column(cursor)
+        if dashboard_type == "overview":
+            body = build_overview(
+                connection, cursor, filters, contributor_available
+            )
+        else:
+            body = build_performance(
+                connection, cursor, filters, contributor_available
+            )
+        return build_response(200, body)
+    except RequestValidationError as error:
+        return build_response(400, {"error": str(error)})
+    except Exception:
+        LOGGER.exception("Organization analytics request failed")
+        fallback["error"] = "Unable to query organization analytics."
+        return build_response(500, fallback)
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if connection is not None:
+            connection.close()
+
+
+def lambda_handler(event, context):
+    """Serve ``POST /analytics/organizations`` using ``dashboard_type``."""
+    try:
+        request_body = parse_event_body(event)
+        dashboard_type = str(
+            request_body.get("dashboard_type", "overview")
+        ).lower()
+        if dashboard_type not in VALID_DASHBOARDS:
+            raise RequestValidationError(
+                "dashboard_type must be overview or performance."
+            )
+        return handle_dashboard(dashboard_type, request_body)
+    except RequestValidationError as error:
+        return build_response(400, {"error": str(error)})
+
+
+def overview_handler(event, context):
+    """Serve ``POST /analytics/organizations/overview``."""
+    try:
+        return handle_dashboard("overview", parse_event_body(event))
+    except RequestValidationError as error:
+        return build_response(400, {"error": str(error)})
+
+
+def performance_handler(event, context):
+    """Serve ``POST /analytics/organizations/performance``."""
+    try:
+        return handle_dashboard("performance", parse_event_body(event))
+    except RequestValidationError as error:
+        return build_response(400, {"error": str(error)})
+
+
+if __name__ == "__main__":
+    for selected_dashboard in ("overview", "performance"):
+        result = lambda_handler(
+            {
+                "dashboard_type": selected_dashboard,
+                "time_filter": "ALL",
+                "group_by": "monthly",
+            },
+            None,
+        )
+        print(json.dumps(result, indent=2))

--- a/data-analytics/lambda_functions/organization_analytics_generate_samples.py
+++ b/data-analytics/lambda_functions/organization_analytics_generate_samples.py
@@ -1,0 +1,54 @@
+"""Generate committed sample responses from the configured local database."""
+
+import json
+import os
+from pathlib import Path
+
+from organization_analytics import lambda_handler
+
+
+SAMPLE_DIRECTORY = Path(__file__).resolve().parent / "organization_analytics_samples"
+REQUESTS = {
+    "sample_response_overview_ALL_monthly.json": {
+        "dashboard_type": "overview",
+        "time_filter": "ALL",
+        "group_by": "monthly",
+    },
+    "sample_response_performance_ALL.json": {
+        "dashboard_type": "performance",
+        "time_filter": "ALL",
+    },
+}
+
+
+def require_local_test_mode():
+    """Prevent sample generation without an explicit local opt-in."""
+    enabled = os.environ.get("ORG_ANALYTICS_LOCAL_TEST", "").lower()
+    if enabled not in {"1", "true", "yes"}:
+        raise RuntimeError(
+            "Set ORG_ANALYTICS_LOCAL_TEST=true before generating samples."
+        )
+
+
+def main():
+    """Call both dashboards and save their decoded response bodies."""
+    require_local_test_mode()
+    SAMPLE_DIRECTORY.mkdir(exist_ok=True)
+    for file_name, request in REQUESTS.items():
+        response = lambda_handler(request, None)
+        if response["statusCode"] != 200:
+            raise RuntimeError(
+                f"{file_name} failed with HTTP {response['statusCode']}: "
+                f"{response['body']}"
+            )
+        output_path = SAMPLE_DIRECTORY / file_name
+        output_path.write_text(
+            json.dumps(json.loads(response["body"]), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/data-analytics/lambda_functions/organization_analytics_load_csv.py
+++ b/data-analytics/lambda_functions/organization_analytics_load_csv.py
@@ -1,0 +1,144 @@
+"""Load the checked-in state and organization extracts into local PostgreSQL."""
+
+import csv
+import os
+from pathlib import Path
+
+from organization_analytics import get_db_connection
+
+
+DATA_DIRECTORY = Path(__file__).resolve().parents[1] / "sql"
+STATE_CSV = DATA_DIRECTORY / "state.csv"
+ORGANIZATIONS_CSV = DATA_DIRECTORY / "organizations.csv"
+
+
+def parse_boolean(value):
+    """Convert a CSV boolean value to a Python boolean or None."""
+    if value is None or not value.strip():
+        return None
+    return value.strip().lower() == "true"
+
+
+def empty_to_none(value):
+    """Convert empty CSV cells to None."""
+    return value if value not in (None, "") else None
+
+
+def require_local_test_mode():
+    """Prevent this data loader from running without an explicit local opt-in."""
+    enabled = os.environ.get("ORG_ANALYTICS_LOCAL_TEST", "").lower()
+    if enabled not in {"1", "true", "yes"}:
+        raise RuntimeError(
+            "Set ORG_ANALYTICS_LOCAL_TEST=true before loading local test data."
+        )
+
+
+def load_states(cursor):
+    """Upsert all rows from state.csv and return the number processed."""
+    with STATE_CSV.open(encoding="utf-8-sig", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    cursor.executemany(
+        """
+        INSERT INTO virginia_dev_saayam_rdbms.state (
+            state_id, country_id, state_name, state_code, last_update_date
+        ) VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT (state_id) DO UPDATE SET
+            country_id = EXCLUDED.country_id,
+            state_name = EXCLUDED.state_name,
+            state_code = EXCLUDED.state_code,
+            last_update_date = EXCLUDED.last_update_date;
+        """,
+        [
+            (
+                row["state_id"],
+                empty_to_none(row["country_id"]),
+                row["state_name"],
+                empty_to_none(row["state_code"]),
+                empty_to_none(row["last_update_date"]),
+            )
+            for row in rows
+        ],
+    )
+    return len(rows)
+
+
+def load_organizations(cursor):
+    """Upsert all rows from organizations.csv and return the number processed."""
+    with ORGANIZATIONS_CSV.open(encoding="utf-8-sig", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    cursor.executemany(
+        """
+        INSERT INTO virginia_dev_saayam_rdbms.organizations (
+            org_id, org_name, street, city_name, state_id, zip_code, mission,
+            web_url, phone, email, org_type, org_size, org_rating,
+            is_collaborator, is_contributor, created_at, last_updated_at
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s
+        )
+        ON CONFLICT (org_id) DO UPDATE SET
+            org_name = EXCLUDED.org_name,
+            street = EXCLUDED.street,
+            city_name = EXCLUDED.city_name,
+            state_id = EXCLUDED.state_id,
+            zip_code = EXCLUDED.zip_code,
+            mission = EXCLUDED.mission,
+            web_url = EXCLUDED.web_url,
+            phone = EXCLUDED.phone,
+            email = EXCLUDED.email,
+            org_type = EXCLUDED.org_type,
+            org_size = EXCLUDED.org_size,
+            org_rating = EXCLUDED.org_rating,
+            is_collaborator = EXCLUDED.is_collaborator,
+            is_contributor = EXCLUDED.is_contributor,
+            created_at = EXCLUDED.created_at,
+            last_updated_at = EXCLUDED.last_updated_at;
+        """,
+        [
+            (
+                row["org_id"],
+                row["org_name"],
+                empty_to_none(row["street"]),
+                empty_to_none(row["city_name"]),
+                empty_to_none(row["state_id"]),
+                empty_to_none(row["zip_code"]),
+                empty_to_none(row["mission"]),
+                empty_to_none(row["web_url"]),
+                empty_to_none(row["phone"]),
+                empty_to_none(row["email"]),
+                empty_to_none(row["org_type"]),
+                empty_to_none(row["org_size"]),
+                empty_to_none(row["org_rating"]),
+                parse_boolean(row["is_collaborator"]),
+                parse_boolean(row["is_contributor"]),
+                empty_to_none(row["created_at"]),
+                empty_to_none(row["last_updated_at"]),
+            )
+            for row in rows
+        ],
+    )
+    return len(rows)
+
+
+def main():
+    """Load both source extracts in one local transaction."""
+    require_local_test_mode()
+    connection = get_db_connection()
+    connection.autocommit = False
+    try:
+        with connection.cursor() as cursor:
+            state_count = load_states(cursor)
+            organization_count = load_organizations(cursor)
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+    print(f"Loaded {state_count} states and {organization_count} organizations.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/data-analytics/lambda_functions/organization_analytics_local_setup.sql
+++ b/data-analytics/lambda_functions/organization_analytics_local_setup.sql
@@ -1,0 +1,41 @@
+-- Local PostgreSQL setup for Organization Analytics API development only.
+-- Run this against a disposable local database, never an AWS environment.
+
+CREATE SCHEMA IF NOT EXISTS virginia_dev_saayam_rdbms;
+
+CREATE TABLE IF NOT EXISTS virginia_dev_saayam_rdbms.state (
+    state_id VARCHAR(16) PRIMARY KEY,
+    country_id INTEGER,
+    state_name VARCHAR(150) NOT NULL,
+    state_code VARCHAR(32),
+    last_update_date TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS virginia_dev_saayam_rdbms.organizations (
+    org_id VARCHAR(64) PRIMARY KEY,
+    org_name VARCHAR(255) NOT NULL,
+    street VARCHAR(255),
+    city_name VARCHAR(150),
+    state_id VARCHAR(16),
+    zip_code VARCHAR(32),
+    mission TEXT,
+    web_url TEXT,
+    phone VARCHAR(64),
+    email VARCHAR(255),
+    org_type VARCHAR(64),
+    org_size VARCHAR(64),
+    org_rating NUMERIC(3, 2),
+    is_collaborator BOOLEAN,
+    is_contributor BOOLEAN,
+    created_at TIMESTAMP,
+    last_updated_at TIMESTAMP,
+    CONSTRAINT organizations_state_fk
+        FOREIGN KEY (state_id)
+        REFERENCES virginia_dev_saayam_rdbms.state (state_id)
+);
+
+-- The production column is not available in every environment yet. This is
+-- intentionally part of local setup so contributor behavior can be verified.
+ALTER TABLE virginia_dev_saayam_rdbms.organizations
+    ADD COLUMN IF NOT EXISTS is_contributor BOOLEAN;
+

--- a/data-analytics/lambda_functions/organization_analytics_samples/sample_response_overview_ALL_monthly.json
+++ b/data-analytics/lambda_functions/organization_analytics_samples/sample_response_overview_ALL_monthly.json
@@ -1,0 +1,450 @@
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 40,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 19,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 19,
+      "contributor_organizations": 19,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09-01",
+        "count": 2
+      },
+      {
+        "period": "2023-11-01",
+        "count": 1
+      },
+      {
+        "period": "2023-12-01",
+        "count": 2
+      },
+      {
+        "period": "2024-02-01",
+        "count": 2
+      },
+      {
+        "period": "2024-04-01",
+        "count": 2
+      },
+      {
+        "period": "2024-06-01",
+        "count": 1
+      },
+      {
+        "period": "2024-07-01",
+        "count": 2
+      },
+      {
+        "period": "2024-08-01",
+        "count": 2
+      },
+      {
+        "period": "2024-09-01",
+        "count": 3
+      },
+      {
+        "period": "2024-11-01",
+        "count": 2
+      },
+      {
+        "period": "2024-12-01",
+        "count": 1
+      },
+      {
+        "period": "2025-01-01",
+        "count": 3
+      },
+      {
+        "period": "2025-04-01",
+        "count": 1
+      },
+      {
+        "period": "2025-06-01",
+        "count": 1
+      },
+      {
+        "period": "2025-08-01",
+        "count": 4
+      },
+      {
+        "period": "2025-09-01",
+        "count": 3
+      },
+      {
+        "period": "2025-10-01",
+        "count": 1
+      },
+      {
+        "period": "2025-11-01",
+        "count": 3
+      },
+      {
+        "period": "2025-12-01",
+        "count": 3
+      },
+      {
+        "period": "2026-01-01",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "non_profit",
+        "count": 21
+      },
+      {
+        "org_type": "for_profit",
+        "count": 19
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "large",
+        "count": 21
+      },
+      {
+        "org_size": "small",
+        "count": 10
+      },
+      {
+        "org_size": "medium",
+        "count": 9
+      }
+    ],
+    "organizations_by_location": {
+      "by_state": [
+        {
+          "state_id": "TX",
+          "state_name": "Texas",
+          "count": 3
+        },
+        {
+          "state_id": "AR",
+          "state_name": "Arkansas",
+          "count": 2
+        },
+        {
+          "state_id": "FL",
+          "state_name": "Florida",
+          "count": 2
+        },
+        {
+          "state_id": "IN",
+          "state_name": "Indiana",
+          "count": 2
+        },
+        {
+          "state_id": "IA",
+          "state_name": "Iowa",
+          "count": 2
+        },
+        {
+          "state_id": "KS",
+          "state_name": "Kansas",
+          "count": 2
+        },
+        {
+          "state_id": "MN",
+          "state_name": "Minnesota",
+          "count": 2
+        },
+        {
+          "state_id": "MT",
+          "state_name": "Montana",
+          "count": 2
+        },
+        {
+          "state_id": "NC",
+          "state_name": "North Carolina",
+          "count": 2
+        },
+        {
+          "state_id": "RI",
+          "state_name": "Rhode Island",
+          "count": 2
+        },
+        {
+          "state_id": "AL",
+          "state_name": "Alabama",
+          "count": 1
+        },
+        {
+          "state_id": "AK",
+          "state_name": "Alaska",
+          "count": 1
+        },
+        {
+          "state_id": "AZ",
+          "state_name": "Arizona",
+          "count": 1
+        },
+        {
+          "state_id": "CA",
+          "state_name": "California",
+          "count": 1
+        },
+        {
+          "state_id": "ME",
+          "state_name": "Maine",
+          "count": 1
+        },
+        {
+          "state_id": "MI",
+          "state_name": "Michigan",
+          "count": 1
+        },
+        {
+          "state_id": "MO",
+          "state_name": "Missouri",
+          "count": 1
+        },
+        {
+          "state_id": "NE",
+          "state_name": "Nebraska",
+          "count": 1
+        },
+        {
+          "state_id": "NV",
+          "state_name": "Nevada",
+          "count": 1
+        },
+        {
+          "state_id": "NJ",
+          "state_name": "New Jersey",
+          "count": 1
+        },
+        {
+          "state_id": "OH",
+          "state_name": "Ohio",
+          "count": 1
+        },
+        {
+          "state_id": "OK",
+          "state_name": "Oklahoma",
+          "count": 1
+        },
+        {
+          "state_id": "OR",
+          "state_name": "Oregon",
+          "count": 1
+        },
+        {
+          "state_id": "UT",
+          "state_name": "Utah",
+          "count": 1
+        },
+        {
+          "state_id": "VT",
+          "state_name": "Vermont",
+          "count": 1
+        },
+        {
+          "state_id": "VA",
+          "state_name": "Virginia",
+          "count": 1
+        },
+        {
+          "state_id": "WA",
+          "state_name": "Washington",
+          "count": 1
+        },
+        {
+          "state_id": "WI",
+          "state_name": "Wisconsin",
+          "count": 1
+        },
+        {
+          "state_id": "WY",
+          "state_name": "Wyoming",
+          "count": 1
+        }
+      ],
+      "by_city": [
+        {
+          "city_name": "Barkerfurt",
+          "count": 1
+        },
+        {
+          "city_name": "Burchborough",
+          "count": 1
+        },
+        {
+          "city_name": "East Amanda",
+          "count": 1
+        },
+        {
+          "city_name": "East Jenniferfort",
+          "count": 1
+        },
+        {
+          "city_name": "Hortonberg",
+          "count": 1
+        },
+        {
+          "city_name": "Jeremyburgh",
+          "count": 1
+        },
+        {
+          "city_name": "Johnberg",
+          "count": 1
+        },
+        {
+          "city_name": "Kingborough",
+          "count": 1
+        },
+        {
+          "city_name": "Kyleborough",
+          "count": 1
+        },
+        {
+          "city_name": "Lake Debbie",
+          "count": 1
+        },
+        {
+          "city_name": "Lake Deniseville",
+          "count": 1
+        },
+        {
+          "city_name": "Lake Nancyview",
+          "count": 1
+        },
+        {
+          "city_name": "Leehaven",
+          "count": 1
+        },
+        {
+          "city_name": "Martinezbury",
+          "count": 1
+        },
+        {
+          "city_name": "Mitchellside",
+          "count": 1
+        },
+        {
+          "city_name": "New Amyhaven",
+          "count": 1
+        },
+        {
+          "city_name": "New Susanville",
+          "count": 1
+        },
+        {
+          "city_name": "New Thomas",
+          "count": 1
+        },
+        {
+          "city_name": "North Donnaport",
+          "count": 1
+        },
+        {
+          "city_name": "North Jamesborough",
+          "count": 1
+        },
+        {
+          "city_name": "North Judithbury",
+          "count": 1
+        },
+        {
+          "city_name": "Ortizmouth",
+          "count": 1
+        },
+        {
+          "city_name": "Port Andrew",
+          "count": 1
+        },
+        {
+          "city_name": "Robertfort",
+          "count": 1
+        },
+        {
+          "city_name": "Robinfort",
+          "count": 1
+        },
+        {
+          "city_name": "Ronaldview",
+          "count": 1
+        },
+        {
+          "city_name": "Sandrastad",
+          "count": 1
+        },
+        {
+          "city_name": "Smithberg",
+          "count": 1
+        },
+        {
+          "city_name": "South Jeffrey",
+          "count": 1
+        },
+        {
+          "city_name": "South Monicamouth",
+          "count": 1
+        },
+        {
+          "city_name": "South Rachelborough",
+          "count": 1
+        },
+        {
+          "city_name": "South Williamton",
+          "count": 1
+        },
+        {
+          "city_name": "Stephaniemouth",
+          "count": 1
+        },
+        {
+          "city_name": "Thomasberg",
+          "count": 1
+        },
+        {
+          "city_name": "Victoriaport",
+          "count": 1
+        },
+        {
+          "city_name": "Wendyville",
+          "count": 1
+        },
+        {
+          "city_name": "West Amandastad",
+          "count": 1
+        },
+        {
+          "city_name": "West Erik",
+          "count": 1
+        },
+        {
+          "city_name": "West Williamport",
+          "count": 1
+        },
+        {
+          "city_name": "Williamview",
+          "count": 1
+        }
+      ]
+    },
+    "collaborator_distribution": [
+      {
+        "is_collaborator": true,
+        "count": 21
+      },
+      {
+        "is_collaborator": false,
+        "count": 19
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "is_contributor": true,
+        "count": 19
+      },
+      {
+        "is_contributor": false,
+        "count": 21
+      }
+    ]
+  }
+}

--- a/data-analytics/lambda_functions/organization_analytics_samples/sample_response_performance_ALL.json
+++ b/data-analytics/lambda_functions/organization_analytics_samples/sample_response_performance_ALL.json
@@ -1,0 +1,342 @@
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.23,
+      "rated_organizations": 40,
+      "unrated_organizations": 0,
+      "five_star_organizations": 12
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 5
+      },
+      {
+        "rating": 2,
+        "count": 9
+      },
+      {
+        "rating": 3,
+        "count": 10
+      },
+      {
+        "rating": 4,
+        "count": 4
+      },
+      {
+        "rating": 5,
+        "count": 12
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "CA",
+        "city_name": "New Susanville"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "small",
+        "state_id": "AZ",
+        "city_name": "Kyleborough"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "MN",
+        "city_name": "Lake Nancyview"
+      },
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "small",
+        "state_id": "AK",
+        "city_name": "North Judithbury"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "medium",
+        "state_id": "RI",
+        "city_name": "South Rachelborough"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "small",
+        "state_id": "MT",
+        "city_name": "Williamview"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_rating": 5,
+        "org_type": "for_profit",
+        "org_size": "small",
+        "state_id": "VA",
+        "city_name": "Sandrastad"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "NV",
+        "city_name": "Leehaven"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "MI",
+        "city_name": "West Williamport"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_rating": 5,
+        "org_type": "for_profit",
+        "org_size": "large",
+        "state_id": "IA",
+        "city_name": "Lake Debbie"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "CA",
+        "city_name": "New Susanville"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "small",
+        "state_id": "AZ",
+        "city_name": "Kyleborough"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "MN",
+        "city_name": "Lake Nancyview"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "medium",
+        "state_id": "RI",
+        "city_name": "South Rachelborough"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_rating": 5,
+        "org_type": "for_profit",
+        "org_size": "small",
+        "state_id": "VA",
+        "city_name": "Sandrastad"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "NV",
+        "city_name": "Leehaven"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_rating": 5,
+        "org_type": "for_profit",
+        "org_size": "large",
+        "state_id": "IA",
+        "city_name": "Lake Debbie"
+      },
+      {
+        "org_id": "ORG00027",
+        "org_name": "Silverline Senior Care Network",
+        "org_rating": 5,
+        "org_type": "for_profit",
+        "org_size": "small",
+        "state_id": "MT",
+        "city_name": "Wendyville"
+      },
+      {
+        "org_id": "ORG00020",
+        "org_name": "Lakeside Legal Aid Society",
+        "org_rating": 4,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "NE",
+        "city_name": "Barkerfurt"
+      },
+      {
+        "org_id": "ORG00023",
+        "org_name": "Maplewood Veterans Support",
+        "org_rating": 4,
+        "org_type": "for_profit",
+        "org_size": "medium",
+        "state_id": "AL",
+        "city_name": "Smithberg"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "small",
+        "state_id": "AK",
+        "city_name": "North Judithbury"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "small",
+        "state_id": "MT",
+        "city_name": "Williamview"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "MI",
+        "city_name": "West Williamport"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_rating": 5,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "NJ",
+        "city_name": "South Williamton"
+      },
+      {
+        "org_id": "ORG00035",
+        "org_name": "Summit Relief Network",
+        "org_rating": 4,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "VT",
+        "city_name": "Ortizmouth"
+      },
+      {
+        "org_id": "ORG00015",
+        "org_name": "Unity Senior Care Network",
+        "org_rating": 4,
+        "org_type": "for_profit",
+        "org_size": "large",
+        "state_id": "KS",
+        "city_name": "Port Andrew"
+      },
+      {
+        "org_id": "ORG00006",
+        "org_name": "Harbor Senior Care Network",
+        "org_rating": 3,
+        "org_type": "for_profit",
+        "org_size": "medium",
+        "state_id": "MO",
+        "city_name": "Lake Deniseville"
+      },
+      {
+        "org_id": "ORG00024",
+        "org_name": "Liberty Senior Care Network",
+        "org_rating": 3,
+        "org_type": "for_profit",
+        "org_size": "large",
+        "state_id": "AR",
+        "city_name": "East Amanda"
+      },
+      {
+        "org_id": "ORG00025",
+        "org_name": "Maplewood Animal Rescue",
+        "org_rating": 3,
+        "org_type": "non_profit",
+        "org_size": "large",
+        "state_id": "TX",
+        "city_name": "Victoriaport"
+      },
+      {
+        "org_id": "ORG00003",
+        "org_name": "Northgate Education Fund",
+        "org_rating": 3,
+        "org_type": "non_profit",
+        "org_size": "medium",
+        "state_id": "WI",
+        "city_name": "Thomasberg"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "org_type": "non_profit",
+        "average_rating": 3.62,
+        "total_organizations": 21,
+        "rated_organizations": 21
+      },
+      {
+        "org_type": "for_profit",
+        "average_rating": 2.79,
+        "total_organizations": 19,
+        "rated_organizations": 19
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "org_size": "small",
+        "average_rating": 3.5,
+        "total_organizations": 10,
+        "rated_organizations": 10
+      },
+      {
+        "org_size": "large",
+        "average_rating": 3.24,
+        "total_organizations": 21,
+        "rated_organizations": 21
+      },
+      {
+        "org_size": "medium",
+        "average_rating": 2.89,
+        "total_organizations": 9,
+        "rated_organizations": 9
+      }
+    ]
+  }
+}

--- a/data-analytics/lambda_functions/requirements.txt
+++ b/data-analytics/lambda_functions/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2-binary==2.9.10
+

--- a/data-analytics/lambda_functions/test_organization_analytics.py
+++ b/data-analytics/lambda_functions/test_organization_analytics.py
@@ -1,0 +1,304 @@
+"""Unit and local PostgreSQL tests for the Organization Analytics API."""
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import organization_analytics as analytics
+
+
+class OrganizationAnalyticsUnitTests(unittest.TestCase):
+    """Validate request parsing and safe SQL filter construction without a DB."""
+
+    def test_parses_api_gateway_body(self):
+        payload = {"dashboard_type": "performance", "time_filter": "ALL"}
+        self.assertEqual(
+            analytics.parse_event_body({"body": json.dumps(payload)}), payload
+        )
+
+    def test_default_filters_match_api_contract(self):
+        filters = analytics.parse_filters({})
+        self.assertEqual(filters["time_filter"], "30D")
+        self.assertEqual(filters["group_by"], "daily")
+
+    def test_display_labels_are_normalized(self):
+        filters = analytics.parse_filters(
+            {"org_type": "Non-Profit", "org_size": "LARGE"}
+        )
+        self.assertEqual(filters["org_type"], "non_profit")
+        self.assertEqual(filters["org_size"], "large")
+
+    def test_string_booleans_are_supported(self):
+        filters = analytics.parse_filters(
+            {"is_collaborator": "false", "is_contributor": "true"}
+        )
+        self.assertIs(filters["is_collaborator"], False)
+        self.assertIs(filters["is_contributor"], True)
+
+    def test_custom_filter_is_inclusive_of_end_date(self):
+        filters = analytics.parse_filters(
+            {
+                "time_filter": "CUSTOM",
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-31",
+            }
+        )
+        conditions, params = analytics.build_conditions(filters, True)
+        self.assertIn("o.created_at >= %s::date", conditions)
+        self.assertIn("o.created_at < %s::date + INTERVAL '1 day'", conditions)
+        self.assertEqual(params[:2], ["2025-01-01", "2025-01-31"])
+
+    def test_filter_values_are_parameterized(self):
+        filters = analytics.parse_filters(
+            {"city_name": "Richmond' OR TRUE --", "time_filter": "ALL"}
+        )
+        conditions, params = analytics.build_conditions(filters, True)
+        self.assertNotIn("Richmond", " ".join(conditions))
+        self.assertEqual(params, ["Richmond' OR TRUE --"])
+
+    def test_contributor_filter_is_rejected_when_column_is_missing(self):
+        filters = analytics.parse_filters(
+            {"time_filter": "ALL", "is_contributor": True}
+        )
+        with self.assertRaises(analytics.RequestValidationError):
+            analytics.build_conditions(filters, False)
+
+    def test_invalid_filters_are_rejected(self):
+        invalid_payloads = [
+            {"time_filter": "90D"},
+            {"group_by": "hourly"},
+            {"org_rating": 6},
+            {"is_collaborator": "sometimes"},
+            {"org_type": "government"},
+            {"org_size": "extra-large"},
+            {"time_filter": "CUSTOM", "start_date": "2025-01-01"},
+            {
+                "time_filter": "CUSTOM",
+                "start_date": "2025-02-01",
+                "end_date": "2025-01-01",
+            },
+        ]
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(analytics.RequestValidationError):
+                    analytics.parse_filters(payload)
+
+    def test_handler_rejects_invalid_dashboard_before_database_access(self):
+        response = analytics.lambda_handler({"dashboard_type": "unknown"}, None)
+        self.assertEqual(response["statusCode"], 400)
+        self.assertIn("dashboard_type", json.loads(response["body"])["error"])
+
+    def test_source_contains_no_parameter_store_path_or_client(self):
+        source = Path(analytics.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("/dev/saayam/db", source)
+        self.assertNotIn("boto3", source)
+        self.assertNotIn("get_parameter", source)
+
+
+@unittest.skipUnless(
+    os.environ.get("ORG_ANALYTICS_RUN_INTEGRATION_TESTS", "").lower()
+    in {"1", "true", "yes"},
+    "Set ORG_ANALYTICS_RUN_INTEGRATION_TESTS=true for local PostgreSQL tests.",
+)
+class OrganizationAnalyticsPostgresTests(unittest.TestCase):
+    """Exercise both dashboard handlers against the loaded source CSV data."""
+
+    @staticmethod
+    def request(payload):
+        response = analytics.lambda_handler(payload, None)
+        return response, json.loads(response["body"])
+
+    def test_overview_all_metrics_match_source_extract(self):
+        response, body = self.request(
+            {
+                "dashboard_type": "overview",
+                "time_filter": "ALL",
+                "group_by": "monthly",
+            }
+        )
+        self.assertEqual(response["statusCode"], 200)
+        overview = body["organization_overview"]
+        self.assertEqual(
+            overview["summary"],
+            {
+                "total_organizations": 40,
+                "non_profit_organizations": 21,
+                "for_profit_organizations": 19,
+                "collaborator_organizations": 21,
+                "non_collaborator_organizations": 19,
+                "contributor_organizations": 19,
+                "non_contributor_organizations": 21,
+            },
+        )
+        self.assertTrue(overview["organization_activity_trend"])
+        self.assertTrue(overview["organizations_by_location"]["by_state"])
+        self.assertTrue(overview["organizations_by_location"]["by_city"])
+
+    def test_overview_distributions_are_consistent(self):
+        _, body = self.request(
+            {"dashboard_type": "overview", "time_filter": "ALL"}
+        )
+        overview = body["organization_overview"]
+        total = overview["summary"]["total_organizations"]
+        self.assertEqual(
+            sum(item["count"] for item in overview["organizations_by_type"]),
+            total,
+        )
+        self.assertEqual(
+            sum(item["count"] for item in overview["organizations_by_size"]),
+            total,
+        )
+        self.assertEqual(
+            sum(item["count"] for item in overview["collaborator_distribution"]),
+            total,
+        )
+        self.assertEqual(
+            sum(item["count"] for item in overview["contributor_distribution"]),
+            total,
+        )
+
+    def test_performance_all_metrics_match_source_extract(self):
+        response, body = self.request(
+            {"dashboard_type": "performance", "time_filter": "ALL"}
+        )
+        self.assertEqual(response["statusCode"], 200)
+        performance = body["organization_performance"]
+        self.assertEqual(
+            performance["summary"],
+            {
+                "average_rating": 3.23,
+                "rated_organizations": 40,
+                "unrated_organizations": 0,
+                "five_star_organizations": 12,
+            },
+        )
+        expected_distribution = {1: 5, 2: 9, 3: 10, 4: 4, 5: 12}
+        self.assertEqual(
+            {
+                item["rating"]: item["count"]
+                for item in performance["rating_distribution"]
+            },
+            expected_distribution,
+        )
+        self.assertLessEqual(len(performance["top_rated_organizations"]), 10)
+        self.assertLessEqual(
+            len(performance["top_collaborator_organizations"]), 10
+        )
+        self.assertLessEqual(
+            len(performance["top_contributor_organizations"]), 10
+        )
+
+    def test_every_grouping_is_supported(self):
+        for group_by in ("daily", "weekly", "monthly", "yearly"):
+            with self.subTest(group_by=group_by):
+                response, body = self.request(
+                    {
+                        "dashboard_type": "overview",
+                        "time_filter": "ALL",
+                        "group_by": group_by,
+                    }
+                )
+                self.assertEqual(response["statusCode"], 200)
+                self.assertTrue(
+                    body["organization_overview"][
+                        "organization_activity_trend"
+                    ]
+                )
+
+    def test_all_dimension_filters(self):
+        cases = [
+            ("org_type", "Non-Profit"),
+            ("org_size", "Large"),
+            ("state_id", "CA"),
+            ("city_name", "North Judithbury"),
+            ("org_rating", 5),
+            ("is_collaborator", True),
+            ("is_contributor", True),
+        ]
+        for field, value in cases:
+            with self.subTest(field=field):
+                response, body = self.request(
+                    {
+                        "dashboard_type": "overview",
+                        "time_filter": "ALL",
+                        field: value,
+                    }
+                )
+                self.assertEqual(response["statusCode"], 200)
+                self.assertGreater(
+                    body["organization_overview"]["summary"][
+                        "total_organizations"
+                    ],
+                    0,
+                )
+
+    def test_custom_date_range_and_api_gateway_body(self):
+        payload = {
+            "dashboard_type": "performance",
+            "time_filter": "CUSTOM",
+            "start_date": "2020-01-01",
+            "end_date": "2030-12-31",
+        }
+        response = analytics.lambda_handler({"body": json.dumps(payload)}, None)
+        body = json.loads(response["body"])
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(
+            body["organization_performance"]["summary"]["rated_organizations"],
+            40,
+        )
+
+    def test_separate_endpoint_handlers(self):
+        overview = analytics.overview_handler({"time_filter": "ALL"}, None)
+        performance = analytics.performance_handler({"time_filter": "ALL"}, None)
+        self.assertEqual(overview["statusCode"], 200)
+        self.assertEqual(performance["statusCode"], 200)
+        self.assertIn("organization_overview", json.loads(overview["body"]))
+        self.assertIn("organization_performance", json.loads(performance["body"]))
+
+    def test_missing_contributor_column_degrades_gracefully(self):
+        with patch.object(analytics, "has_contributor_column", return_value=False):
+            response, body = self.request(
+                {"dashboard_type": "overview", "time_filter": "ALL"}
+            )
+        self.assertEqual(response["statusCode"], 200)
+        overview = body["organization_overview"]
+        self.assertIsNone(overview["summary"]["contributor_organizations"])
+        self.assertEqual(overview["contributor_distribution"], [])
+        self.assertIn("is_contributor", overview["schema_notes"])
+        self.assertEqual(overview["summary"]["total_organizations"], 40)
+
+    def test_missing_contributor_column_rejects_contributor_filter(self):
+        with patch.object(analytics, "has_contributor_column", return_value=False):
+            response, body = self.request(
+                {
+                    "dashboard_type": "overview",
+                    "time_filter": "ALL",
+                    "is_contributor": True,
+                }
+            )
+        self.assertEqual(response["statusCode"], 400)
+        self.assertIn("is_contributor", body["error"])
+
+    def test_one_metric_failure_does_not_blank_later_metrics(self):
+        with patch.object(
+            analytics,
+            "fetch_group_distribution",
+            side_effect=RuntimeError("forced metric failure"),
+        ):
+            response, body = self.request(
+                {"dashboard_type": "overview", "time_filter": "ALL"}
+            )
+        overview = body["organization_overview"]
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(overview["organizations_by_type"], [])
+        self.assertTrue(overview["organizations_by_location"]["by_state"])
+        self.assertEqual(overview["summary"]["total_organizations"], 40)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Implements the Organization Analytics API requested in #228 using the organizations and state tables.

Closes #228

## Changes

- Added Organization Overview and Performance dashboards
- Added type, size, location, collaborator, contributor, trend, and rating metrics
- Added 7D, 30D, 1Y, ALL, and CUSTOM time filters
- Added daily, weekly, monthly, and yearly grouping
- Added all common organization filters
- Added safe handling when `is_contributor` is unavailable
- Added local PostgreSQL setup, tests, and sample responses

## Database Configuration

Database credentials are read from environment variables or `DATABASE_URL`.

No AWS Parameter Store path, credentials, or deployment code is included.

## Local Testing

- PostgreSQL 17.10
- Loaded 40 organizations and 51 states
- 20/20 automated tests passed
- Both dashboards and all filters verified
- Missing `is_contributor` behavior verified

## Deployment

No AWS deployment was performed.