### PR TITLE
feat: add organization analytics dashboards (#228)

### DIFF
--- a/data-analytics/docs/organization-analytics-api.md
+++ b/data-analytics/docs/organization-analytics-api.md
@@ -1,0 +1,121 @@
+# Organization Analytics API
+
+`organization_analytics.lambda_handler` provides both organization dashboards
+through one POST handler. Set `dashboard_type` to `overview` or `performance`.
+
+## Local configuration
+
+The API uses PostgreSQL environment variables and does not read AWS Parameter
+Store:
+
+| Variable | Default |
+| --- | --- |
+| `DB_HOST` | `localhost` |
+| `DB_PORT` | `5432` |
+| `DB_NAME` | `saayam_db` |
+| `DB_USER` | `postgres` |
+| `DB_PASSWORD` | `postgres` |
+| `DB_SCHEMA` | `virginia_dev_saayam_rdbms` |
+| `DB_CONNECT_TIMEOUT` | `10` |
+
+The PostgreSQL schema is expected to contain `organizations` and `state`, using
+the columns in `sql/organizations.csv` and `sql/state.csv`. The API detects
+whether `organizations.is_contributor` exists. Until that migration is applied,
+all organizations are reported as non-contributors, top contributors is empty,
+and filtering for contributors returns an empty result.
+
+## Request
+
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "30D",
+  "start_date": null,
+  "end_date": null,
+  "org_type": null,
+  "org_size": null,
+  "state_id": null,
+  "city_name": null,
+  "org_rating": null,
+  "is_collaborator": null,
+  "is_contributor": null,
+  "group_by": "daily"
+}
+```
+
+Supported time filters are `7D`, `30D`, `1Y`, `ALL`, and `CUSTOM`. `CUSTOM`
+requires inclusive `start_date` and `end_date` values in `YYYY-MM-DD` format.
+Supported trend groupings are `daily`, `weekly`, `monthly`, and `yearly`.
+
+## Sample responses
+
+The following summaries were produced locally from the 40 rows in
+`sql/organizations.csv` with `time_filter: "ALL"`.
+
+Overview:
+
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 40,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 19,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 19,
+      "contributor_organizations": 19,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [],
+    "organizations_by_type": [],
+    "organizations_by_size": [],
+    "organizations_by_location": [],
+    "collaborator_distribution": [],
+    "contributor_distribution": []
+  }
+}
+```
+
+Performance:
+
+```json
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.23,
+      "rated_organizations": 40,
+      "unrated_organizations": 0,
+      "five_star_organizations": 12
+    },
+    "rating_distribution": [
+      {"rating": 1, "count": 5},
+      {"rating": 2, "count": 9},
+      {"rating": 3, "count": 10},
+      {"rating": 4, "count": 4},
+      {"rating": 5, "count": 12}
+    ],
+    "top_rated_organizations": [],
+    "top_collaborator_organizations": [],
+    "top_contributor_organizations": [],
+    "ratings_by_organization_type": [],
+    "ratings_by_organization_size": []
+  }
+}
+```
+
+Arrays are abbreviated above; live responses include their complete contents.
+
+## Tests
+
+From the repository root, with `psycopg2-binary` installed:
+
+```bash
+python3 -m unittest discover \
+  -s data-analytics/lambda_functions \
+  -p 'test_organization_analytics.py' \
+  -v
+```
+
+Local PostgreSQL integration verification was performed twice: first with both
+CSV files loaded exactly as supplied, then after dropping `is_contributor` to
+verify compatibility with the current database schema.

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,473 @@
+"""Organization analytics dashboards backed by PostgreSQL.
+
+The Lambda accepts either a direct payload or an API Gateway event. Database
+credentials are read from environment variables so the same code can run
+against a local PostgreSQL instance or a configured Lambda environment.
+"""
+
+import json
+import logging
+import os
+import re
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+DEFAULT_SCHEMA = "virginia_dev_saayam_rdbms"
+TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+GROUPINGS = {
+    "daily": ("day", "YYYY-MM-DD"),
+    "weekly": ("week", "IYYY-IW"),
+    "monthly": ("month", "YYYY-MM"),
+    "yearly": ("year", "YYYY"),
+}
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+}
+
+
+class RequestValidationError(ValueError):
+    """Raised when an analytics request contains invalid filters."""
+
+
+def get_schema_name():
+    """Return a SQL-safe configured schema name."""
+    schema = os.environ.get("DB_SCHEMA", DEFAULT_SCHEMA)
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", schema):
+        raise ValueError("DB_SCHEMA must be a valid PostgreSQL identifier")
+    return schema
+
+
+def get_db_connection():
+    """Create a PostgreSQL connection using local/environment configuration."""
+    return psycopg2.connect(
+        host=os.environ.get("DB_HOST", "localhost"),
+        dbname=os.environ.get("DB_NAME", "saayam_db"),
+        user=os.environ.get("DB_USER", "postgres"),
+        password=os.environ.get("DB_PASSWORD", "postgres"),
+        port=int(os.environ.get("DB_PORT", "5432")),
+        connect_timeout=int(os.environ.get("DB_CONNECT_TIMEOUT", "10")),
+    )
+
+
+def parse_payload(event):
+    """Parse direct invocation and API Gateway request formats."""
+    if not isinstance(event, dict):
+        raise RequestValidationError("Request must be a JSON object")
+
+    body = event.get("body")
+    if body is None:
+        return event
+    if isinstance(body, dict):
+        return body
+    if isinstance(body, str):
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RequestValidationError("Request body must contain valid JSON") from exc
+        if not isinstance(payload, dict):
+            raise RequestValidationError("Request body must be a JSON object")
+        return payload
+    raise RequestValidationError("Request body must be a JSON object")
+
+
+def _parse_date(value, field_name):
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise RequestValidationError(f"{field_name} must use YYYY-MM-DD format") from exc
+
+
+def _parse_boolean(value, field_name):
+    if value is None or isinstance(value, bool):
+        return value
+    raise RequestValidationError(f"{field_name} must be true, false, or null")
+
+
+def validate_filters(payload):
+    """Normalize and validate all common dashboard filters."""
+    dashboard_type = str(payload.get("dashboard_type", "overview")).lower()
+    if dashboard_type not in {"overview", "performance"}:
+        raise RequestValidationError(
+            "dashboard_type must be 'overview' or 'performance'"
+        )
+
+    time_filter = str(payload.get("time_filter", "30D")).upper()
+    if time_filter not in TIME_FILTERS:
+        raise RequestValidationError("time_filter must be 7D, 30D, 1Y, ALL, or CUSTOM")
+
+    group_by = str(payload.get("group_by", "daily")).lower()
+    if group_by not in GROUPINGS:
+        raise RequestValidationError("group_by must be daily, weekly, monthly, or yearly")
+
+    start_date = _parse_date(payload.get("start_date"), "start_date")
+    end_date = _parse_date(payload.get("end_date"), "end_date")
+    if time_filter == "CUSTOM" and (start_date is None or end_date is None):
+        raise RequestValidationError("CUSTOM time_filter requires start_date and end_date")
+    if start_date and end_date and start_date > end_date:
+        raise RequestValidationError("start_date cannot be after end_date")
+
+    org_rating = payload.get("org_rating")
+    if org_rating is not None:
+        if isinstance(org_rating, bool):
+            raise RequestValidationError("org_rating must be a number from 1 to 5")
+        try:
+            org_rating = float(org_rating)
+        except (TypeError, ValueError) as exc:
+            raise RequestValidationError("org_rating must be a number from 1 to 5") from exc
+        if not 1 <= org_rating <= 5:
+            raise RequestValidationError("org_rating must be a number from 1 to 5")
+
+    return {
+        "dashboard_type": dashboard_type,
+        "time_filter": time_filter,
+        "start_date": start_date,
+        "end_date": end_date,
+        "org_type": payload.get("org_type"),
+        "org_size": payload.get("org_size"),
+        "state_id": payload.get("state_id"),
+        "city_name": payload.get("city_name"),
+        "org_rating": org_rating,
+        "is_collaborator": _parse_boolean(payload.get("is_collaborator"), "is_collaborator"),
+        "is_contributor": _parse_boolean(payload.get("is_contributor"), "is_contributor"),
+        "group_by": group_by,
+    }
+
+
+def contributor_column_exists(cursor, schema):
+    """Detect the in-progress is_contributor database migration."""
+    cursor.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = %s
+              AND table_name = 'organizations'
+              AND column_name = 'is_contributor'
+        ) AS exists
+        """,
+        (schema,),
+    )
+    row = cursor.fetchone()
+    return bool(row and row["exists"])
+
+
+def build_where_clause(filters, has_contributor):
+    """Build a parameterized WHERE clause shared by all dashboard queries."""
+    conditions = []
+    params = {}
+    time_filter = filters["time_filter"]
+
+    if time_filter == "7D":
+        conditions.append("o.created_at >= CURRENT_DATE - INTERVAL '7 days'")
+    elif time_filter == "30D":
+        conditions.append("o.created_at >= CURRENT_DATE - INTERVAL '30 days'")
+    elif time_filter == "1Y":
+        conditions.append("o.created_at >= CURRENT_DATE - INTERVAL '1 year'")
+    elif time_filter == "CUSTOM":
+        conditions.append(
+            "o.created_at >= %(start_date)s AND o.created_at < %(end_exclusive)s"
+        )
+        params.update(
+            start_date=filters["start_date"],
+            end_exclusive=filters["end_date"] + timedelta(days=1),
+        )
+
+    column_filters = {
+        "org_type": "o.org_type",
+        "org_size": "o.org_size",
+        "state_id": "o.state_id",
+        "city_name": "o.city_name",
+        "org_rating": "o.org_rating",
+        "is_collaborator": "o.is_collaborator",
+    }
+    for name, column in column_filters.items():
+        if filters[name] is not None:
+            conditions.append(f"{column} = %({name})s")
+            params[name] = filters[name]
+
+    contributor_filter = filters["is_contributor"]
+    if contributor_filter is not None:
+        if has_contributor:
+            conditions.append("o.is_contributor = %(is_contributor)s")
+            params["is_contributor"] = contributor_filter
+        elif contributor_filter:
+            conditions.append("FALSE")
+
+    return ("WHERE " + " AND ".join(conditions)) if conditions else "", params
+
+
+def _with_condition(where_sql, condition):
+    if where_sql:
+        return f"{where_sql} AND {condition}"
+    return f"WHERE {condition}"
+
+
+def _fetch_all(cursor, query, params):
+    cursor.execute(query, params)
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def fetch_overview_dashboard(cursor, schema, where_sql, params, group_by, has_contributor):
+    contributor_true = "o.is_contributor IS TRUE" if has_contributor else "FALSE"
+    contributor_false = "o.is_contributor IS NOT TRUE" if has_contributor else "TRUE"
+    cursor.execute(
+        f"""
+        SELECT COUNT(*) AS total_organizations,
+               COUNT(*) FILTER (WHERE LOWER(o.org_type) IN ('non-profit', 'nonprofit')) AS non_profit_organizations,
+               COUNT(*) FILTER (WHERE LOWER(o.org_type) IN ('for-profit', 'for profit')) AS for_profit_organizations,
+               COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborator_organizations,
+               COUNT(*) FILTER (WHERE o.is_collaborator IS NOT TRUE) AS non_collaborator_organizations,
+               COUNT(*) FILTER (WHERE {contributor_true}) AS contributor_organizations,
+               COUNT(*) FILTER (WHERE {contributor_false}) AS non_contributor_organizations
+        FROM {schema}.organizations o
+        {where_sql}
+        """,
+        params,
+    )
+    summary = dict(cursor.fetchone())
+    trunc_unit, output_format = GROUPINGS[group_by]
+
+    trend = _fetch_all(
+        cursor,
+        f"""
+        SELECT TO_CHAR(DATE_TRUNC('{trunc_unit}', o.created_at), '{output_format}') AS period,
+               COUNT(*) AS count
+        FROM {schema}.organizations o
+        {where_sql}
+        GROUP BY DATE_TRUNC('{trunc_unit}', o.created_at)
+        ORDER BY DATE_TRUNC('{trunc_unit}', o.created_at)
+        """,
+        params,
+    )
+    by_type = _fetch_all(
+        cursor,
+        f"""
+        SELECT COALESCE(o.org_type, 'Unknown') AS type, COUNT(*) AS count
+        FROM {schema}.organizations o
+        {where_sql}
+        GROUP BY o.org_type
+        ORDER BY count DESC, type
+        """,
+        params,
+    )
+    by_size = _fetch_all(
+        cursor,
+        f"""
+        SELECT COALESCE(o.org_size, 'Unknown') AS size, COUNT(*) AS count
+        FROM {schema}.organizations o
+        {where_sql}
+        GROUP BY o.org_size
+        ORDER BY count DESC, size
+        """,
+        params,
+    )
+    by_location = _fetch_all(
+        cursor,
+        f"""
+        SELECT o.state_id, COALESCE(s.state_name, 'Unknown') AS state,
+               COALESCE(o.city_name, 'Unknown') AS city, COUNT(*) AS count
+        FROM {schema}.organizations o
+        LEFT JOIN {schema}.state s ON o.state_id = s.state_id
+        {where_sql}
+        GROUP BY o.state_id, s.state_name, o.city_name
+        ORDER BY count DESC, state, city
+        """,
+        params,
+    )
+    collaborators = [
+        {"status": "collaborator", "count": summary["collaborator_organizations"]},
+        {
+            "status": "non_collaborator",
+            "count": summary["non_collaborator_organizations"],
+        },
+    ]
+    contributors = [
+        {"status": "contributor", "count": summary["contributor_organizations"]},
+        {
+            "status": "non_contributor",
+            "count": summary["non_contributor_organizations"],
+        },
+    ]
+
+    return {"organization_overview": {
+        "summary": summary,
+        "organization_activity_trend": trend,
+        "organizations_by_type": by_type,
+        "organizations_by_size": by_size,
+        "organizations_by_location": by_location,
+        "collaborator_distribution": collaborators,
+        "contributor_distribution": contributors,
+    }}
+
+
+def fetch_performance_dashboard(cursor, schema, where_sql, params, has_contributor):
+    contributor_true = "o.is_contributor IS TRUE" if has_contributor else "FALSE"
+    cursor.execute(
+        f"""
+        SELECT COALESCE(ROUND(AVG(o.org_rating)::numeric, 2), 0) AS average_rating,
+               COUNT(*) FILTER (WHERE o.org_rating IS NOT NULL) AS rated_organizations,
+               COUNT(*) FILTER (WHERE o.org_rating IS NULL) AS unrated_organizations,
+               COUNT(*) FILTER (WHERE o.org_rating = 5) AS five_star_organizations
+        FROM {schema}.organizations o
+        {where_sql}
+        """,
+        params,
+    )
+    summary = dict(cursor.fetchone())
+    rated_where = _with_condition(where_sql, "o.org_rating IS NOT NULL")
+
+    rating_rows = _fetch_all(
+        cursor,
+        f"""
+        SELECT o.org_rating AS rating, COUNT(*) AS count
+        FROM {schema}.organizations o
+        {rated_where}
+        GROUP BY o.org_rating
+        ORDER BY o.org_rating
+        """,
+        params,
+    )
+    counts = {int(row["rating"]): int(row["count"]) for row in rating_rows}
+    rating_distribution = [
+        {"rating": rating, "count": counts.get(rating, 0)}
+        for rating in range(1, 6)
+    ]
+    organization_fields = """
+        o.org_id, o.org_name, o.org_rating, o.org_type, o.org_size,
+        o.state_id, o.city_name
+    """
+    top_rated = _fetch_all(
+        cursor,
+        f"""
+        SELECT {organization_fields}
+        FROM {schema}.organizations o
+        {rated_where}
+        ORDER BY o.org_rating DESC, o.org_name
+        LIMIT 10
+        """,
+        params,
+    )
+    top_collaborators = _fetch_all(
+        cursor,
+        f"""
+        SELECT {organization_fields}
+        FROM {schema}.organizations o
+        {_with_condition(where_sql, 'o.is_collaborator IS TRUE')}
+        ORDER BY o.org_rating DESC NULLS LAST, o.org_name
+        LIMIT 10
+        """,
+        params,
+    )
+    top_contributors = _fetch_all(
+        cursor,
+        f"""
+        SELECT {organization_fields}
+        FROM {schema}.organizations o
+        {_with_condition(where_sql, contributor_true)}
+        ORDER BY o.org_rating DESC NULLS LAST, o.org_name
+        LIMIT 10
+        """,
+        params,
+    )
+    by_type = _fetch_all(
+        cursor,
+        f"""
+        SELECT COALESCE(o.org_type, 'Unknown') AS type,
+               ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+               COUNT(*) AS rated_organizations
+        FROM {schema}.organizations o
+        {rated_where}
+        GROUP BY o.org_type
+        ORDER BY average_rating DESC, type
+        """,
+        params,
+    )
+    by_size = _fetch_all(
+        cursor,
+        f"""
+        SELECT COALESCE(o.org_size, 'Unknown') AS size,
+               ROUND(AVG(o.org_rating)::numeric, 2) AS average_rating,
+               COUNT(*) AS rated_organizations
+        FROM {schema}.organizations o
+        {rated_where}
+        GROUP BY o.org_size
+        ORDER BY average_rating DESC, size
+        """,
+        params,
+    )
+
+    return {"organization_performance": {
+        "summary": summary,
+        "rating_distribution": rating_distribution,
+        "top_rated_organizations": top_rated,
+        "top_collaborator_organizations": top_collaborators,
+        "top_contributor_organizations": top_contributors,
+        "ratings_by_organization_type": by_type,
+        "ratings_by_organization_size": by_size,
+    }}
+
+
+def _json_default(value):
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": CORS_HEADERS,
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def lambda_handler(event, context):
+    """Serve overview or performance organization analytics."""
+    conn = None
+    cursor = None
+    try:
+        if isinstance(event, dict) and event.get("httpMethod") == "OPTIONS":
+            return build_response(200, {})
+        filters = validate_filters(parse_payload(event))
+        schema = get_schema_name()
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        has_contributor = contributor_column_exists(cursor, schema)
+        where_sql, params = build_where_clause(filters, has_contributor)
+
+        if filters["dashboard_type"] == "overview":
+            result = fetch_overview_dashboard(cursor, schema, where_sql, params, filters["group_by"], has_contributor)
+        else:
+            result = fetch_performance_dashboard(cursor, schema, where_sql, params, has_contributor)
+        return build_response(200, result)
+    except RequestValidationError as exc:
+        return build_response(400, {"error_code": "DE 1002", "message": str(exc)})
+    except psycopg2.Error:
+        LOGGER.exception("Organization analytics database query failed")
+        return build_response(500, {"error_code": "DE 1001", "message": "Database query failed."})
+    except Exception:
+        LOGGER.exception("Organization analytics request failed")
+        return build_response(500, {"error_code": "DE 1000", "message": "Internal server execution error."})
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            conn.close()
+
+
+if __name__ == "__main__":
+    print(json.dumps(lambda_handler({"dashboard_type": "overview"}, None), indent=2))

--- a/data-analytics/lambda_functions/test_organization_analytics.py
+++ b/data-analytics/lambda_functions/test_organization_analytics.py
@@ -1,0 +1,143 @@
+import json
+import os
+import sys
+import unittest
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+
+sys.path.insert(0, os.path.dirname(__file__))
+import organization_analytics as analytics  # noqa: E402
+
+
+class FilterValidationTests(unittest.TestCase):
+    def test_defaults(self):
+        filters = analytics.validate_filters({})
+        self.assertEqual(filters["dashboard_type"], "overview")
+        self.assertEqual(filters["time_filter"], "30D")
+        self.assertEqual(filters["group_by"], "daily")
+
+    def test_custom_dates_are_parsed(self):
+        filters = analytics.validate_filters({
+            "time_filter": "CUSTOM", "start_date": "2025-01-01", "end_date": "2025-01-31"
+        })
+        self.assertEqual(filters["start_date"], date(2025, 1, 1))
+
+    def test_custom_requires_dates(self):
+        with self.assertRaisesRegex(analytics.RequestValidationError, "requires"):
+            analytics.validate_filters({"time_filter": "CUSTOM"})
+
+    def test_boolean_filter_is_strict(self):
+        with self.assertRaisesRegex(analytics.RequestValidationError, "true, false"):
+            analytics.validate_filters({"is_collaborator": "true"})
+
+    def test_invalid_schema_is_rejected(self):
+        with patch.dict(os.environ, {"DB_SCHEMA": "public; DROP TABLE organizations"}):
+            with self.assertRaises(ValueError):
+                analytics.get_schema_name()
+
+
+class QueryBuilderTests(unittest.TestCase):
+    def test_all_common_filters_are_parameterized(self):
+        filters = analytics.validate_filters({
+            "time_filter": "ALL", "org_type": "Non-Profit", "org_size": "Small",
+            "state_id": "VA", "city_name": "Richmond", "org_rating": 5,
+            "is_collaborator": True, "is_contributor": False,
+        })
+        where_sql, params = analytics.build_where_clause(filters, True)
+        self.assertIn("o.org_rating = %(org_rating)s", where_sql)
+        self.assertIn("o.is_contributor = %(is_contributor)s", where_sql)
+        self.assertEqual(params["city_name"], "Richmond")
+
+    def test_missing_contributor_column_true_filter_returns_no_rows(self):
+        filters = analytics.validate_filters({"is_contributor": True})
+        where_sql, params = analytics.build_where_clause(filters, False)
+        self.assertIn("FALSE", where_sql)
+        self.assertNotIn("is_contributor", params)
+
+    def test_missing_contributor_column_false_filter_treats_all_as_noncontributors(self):
+        filters = analytics.validate_filters({"is_contributor": False})
+        where_sql, _ = analytics.build_where_clause(filters, False)
+        self.assertNotIn("FALSE", where_sql)
+
+    def test_custom_date_filter_is_inclusive_and_index_friendly(self):
+        filters = analytics.validate_filters({
+            "time_filter": "CUSTOM",
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-31",
+        })
+        where_sql, params = analytics.build_where_clause(filters, True)
+        self.assertNotIn("created_at::date", where_sql)
+        self.assertEqual(params["end_exclusive"], date(2025, 2, 1))
+
+    def test_extra_condition_works_with_and_without_where(self):
+        self.assertEqual(analytics._with_condition("", "o.org_rating IS NOT NULL"), "WHERE o.org_rating IS NOT NULL")
+        self.assertEqual(analytics._with_condition("WHERE FALSE", "o.org_rating IS NOT NULL"), "WHERE FALSE AND o.org_rating IS NOT NULL")
+
+
+class HandlerTests(unittest.TestCase):
+    @patch("organization_analytics.get_db_connection")
+    def test_overview_response_and_cleanup(self, get_connection):
+        connection = MagicMock()
+        cursor = MagicMock()
+        get_connection.return_value = connection
+        connection.cursor.return_value = cursor
+        cursor.fetchone.side_effect = [
+            {"exists": False},
+            {"total_organizations": 2, "non_profit_organizations": 1,
+             "for_profit_organizations": 1, "collaborator_organizations": 1,
+             "non_collaborator_organizations": 1, "contributor_organizations": 0,
+             "non_contributor_organizations": 2},
+        ]
+        cursor.fetchall.side_effect = [[], [], [], []]
+
+        response = analytics.lambda_handler({"body": json.dumps({"dashboard_type": "overview", "time_filter": "ALL"})}, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        body = json.loads(response["body"])
+        self.assertEqual(body["organization_overview"]["summary"]["total_organizations"], 2)
+        dashboard_queries = " ".join(
+            call.args[0] for call in cursor.execute.call_args_list[1:]
+        )
+        self.assertNotIn("o.is_contributor", dashboard_queries)
+        self.assertEqual(cursor.execute.call_count, 6)
+        cursor.close.assert_called_once()
+        connection.close.assert_called_once()
+
+    @patch("organization_analytics.get_db_connection")
+    def test_performance_returns_complete_rating_scale(self, get_connection):
+        connection = MagicMock()
+        cursor = MagicMock()
+        get_connection.return_value = connection
+        connection.cursor.return_value = cursor
+        cursor.fetchone.side_effect = [
+            {"exists": True},
+            {"average_rating": 5, "rated_organizations": 2, "unrated_organizations": 0, "five_star_organizations": 2},
+        ]
+        cursor.fetchall.side_effect = [
+            [{"rating": 5, "count": 2}], [], [], [], [], []
+        ]
+
+        response = analytics.lambda_handler({"dashboard_type": "performance", "time_filter": "ALL"}, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        distribution = json.loads(response["body"])["organization_performance"]["rating_distribution"]
+        self.assertEqual(distribution, [
+            {"rating": 1, "count": 0}, {"rating": 2, "count": 0},
+            {"rating": 3, "count": 0}, {"rating": 4, "count": 0},
+            {"rating": 5, "count": 2},
+        ])
+
+    def test_bad_dashboard_returns_400_without_database_call(self):
+        with patch("organization_analytics.get_db_connection") as get_connection:
+            response = analytics.lambda_handler({"dashboard_type": "unknown"}, None)
+        self.assertEqual(response["statusCode"], 400)
+        get_connection.assert_not_called()
+
+    def test_options_request(self):
+        response = analytics.lambda_handler({"httpMethod": "OPTIONS"}, None)
+        self.assertEqual(response["statusCode"], 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the Organization Overview and Organization Performance dashboards through `organization_analytics.lambda_handler`
- support all issue filters, time windows, and daily/weekly/monthly/yearly registration trends
- use environment-based PostgreSQL configuration with no AWS Parameter Store dependency
- detect the pending `is_contributor` column and return safe results when it is not yet available
- add API documentation, local configuration, and sample responses

Closes #228

## Local test results

- 14/14 unit tests passed
- 32/32 dashboard/time/group PostgreSQL integration combinations passed
- `CUSTOM` date range passed
- all 7 individual attribute filters passed
- invalid request validation passed (6/6 returned HTTP 400)
- full CSV schema passed with 40 organizations and 51 states
- current-schema compatibility passed after dropping `is_contributor`
- Python compilation and `git diff --check` passed
- confirmed no `boto3`, SSM call, or AWS Parameter Store path in the new API

## Sample API results

### Overview (`ALL`)

```json
{
  "total_organizations": 40,
  "non_profit_organizations": 21,
  "for_profit_organizations": 19,
  "collaborator_organizations": 21,
  "non_collaborator_organizations": 19,
  "contributor_organizations": 19,
  "non_contributor_organizations": 21
}
```

### Performance (`ALL`)

```json
{
  "average_rating": 3.23,
  "rated_organizations": 40,
  "unrated_organizations": 0,
  "five_star_organizations": 12
}
```

Rating distribution: `1: 5`, `2: 9`, `3: 10`, `4: 4`, `5: 12`.

### Current database compatibility

Without `is_contributor`, the API returns HTTP 200, reports 0 contributors and 40 non-contributors, returns an empty top-contributor list, and safely returns zero rows for `is_contributor: true`.

## Deployment

Not deployed to AWS, per issue requirements.