### PR TITLE
Add Organization Analytics API for Organization Dashboard

### DIFF
--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,505 @@
+"""
+Organization Analytics API
+Issue: https://github.com/saayam-for-all/data/issues/228
+
+POST /analytics/organizations
+
+Populates all three tabs of the Organization Dashboard:
+    Tab 1 - Growth & Location   (growth_trend, organizations_by_location)
+    Tab 2 - Size & Contribution (organizations_by_size, collaborator_vs_contributor)
+    Tab 3 - Ratings & Type      (rating_distribution, organization_type_distribution)
+
+Follows the same structure/conventions as kpi_api_analytics.py and
+volunteer_application_analytics.py:
+    - psycopg2 + RealDictCursor
+    - build_response() / build_date_filter() helper pattern
+    - common filters: time_filter, region, organization_type
+    - NULL-safe aggregation
+    - local Postgres connection via environment variables
+
+NOTE: Per issue #228, AWS Parameter Store is intentionally NOT used here.
+Local/dev credentials are read from environment variables instead.
+"""
+
+import json
+import os
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+SCHEMA_NAME = "virginia_dev_saayam_rdbms"
+TABLE_ORGANIZATIONS = f"{SCHEMA_NAME}.organizations"
+TABLE_STATE = f"{SCHEMA_NAME}.state"
+
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+VALID_GROUP_BY = {"daily", "weekly", "monthly", "yearly"}
+
+
+# ---------------------------------------------------------------------------
+# Response helpers
+# ---------------------------------------------------------------------------
+def get_default_response():
+    """Empty-but-valid response shape, returned on failure so the dashboard
+    never breaks on a 500."""
+    return {
+        "summary": {
+            "total_organizations": 0,
+            "total_collaborators": 0,
+            "total_contributors": 0,
+            "average_org_rating": 0,
+        },
+        "growth_trend": [],
+        "organizations_by_location": {"by_state": [], "by_city": []},
+        "organizations_by_size": [],
+        "collaborator_vs_contributor": [],
+        "rating_distribution": [],
+        "organization_type_distribution": [],
+    }
+
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "Content-Type,Authorization",
+            "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+        },
+        "body": json.dumps(body, default=str),
+    }
+
+
+def parse_event_body(event):
+    if not event:
+        return {}
+    body = event.get("body")
+    if body is None:
+        return event
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+    if isinstance(body, dict):
+        return body
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# DB connection (local Postgres only - no AWS Parameter Store, per issue)
+# ---------------------------------------------------------------------------
+def get_db_connection():
+    return psycopg2.connect(
+        host=os.environ.get("DB_HOST", "localhost"),
+        port=os.environ.get("DB_PORT", "5432"),
+        dbname=os.environ.get("DB_NAME", "saayam_dev"),
+        user=os.environ.get("DB_USER", "postgres"),
+        password=os.environ.get("DB_PASSWORD", ""),
+        sslmode=os.environ.get("DB_SSLMODE", "prefer"),
+    )
+
+
+def column_exists(cursor, schema, table, column):
+    """Guards against is_contributor not yet existing in the dev DB
+    (see 'Database Note' in issue #228)."""
+    query = """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = %s AND table_name = %s AND column_name = %s
+        LIMIT 1;
+    """
+    cursor.execute(query, (schema, table, column))
+    return cursor.fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# Common filters
+# ---------------------------------------------------------------------------
+def get_grouping(group_by):
+    mapping = {
+        "daily": ("day", "YYYY-MM-DD"),
+        "weekly": ("week", 'IYYY-"W"IW'),
+        "monthly": ("month", "YYYY-MM"),
+        "yearly": ("year", "YYYY"),
+    }
+    if group_by not in mapping:
+        raise ValueError(
+            "Invalid group_by. Must be one of: 'daily', 'weekly', 'monthly', 'yearly'."
+        )
+    return mapping[group_by]
+
+
+def build_date_filter(time_filter, start_date=None, end_date=None):
+    """Returns (sql_condition, params) filtering on o.created_at."""
+    if time_filter == "CUSTOM":
+        if not start_date or not end_date:
+            raise ValueError("CUSTOM time_filter requires both start_date and end_date.")
+        return "o.created_at::date BETWEEN %s AND %s", (start_date, end_date)
+    if time_filter == "7D":
+        return "o.created_at >= CURRENT_DATE - INTERVAL '7 days'", ()
+    if time_filter == "30D":
+        return "o.created_at >= CURRENT_DATE - INTERVAL '30 days'", ()
+    if time_filter == "1Y":
+        return "o.created_at >= CURRENT_DATE - INTERVAL '1 year'", ()
+    if time_filter == "ALL":
+        return "", ()
+    raise ValueError("Invalid time_filter. Must be one of: 7D, 30D, 1Y, ALL, CUSTOM.")
+
+
+def build_common_where(time_filter, start_date, end_date, region, organization_type,
+                        include_state_join=False):
+    """
+    Builds the shared WHERE clause (date range + region + organization_type)
+    used by every query in this API, so all six charts respect the same
+    common filters as the Request/Volunteer/Beneficiary/KPI dashboards.
+    """
+    conditions = []
+    params = []
+
+    date_condition, date_params = build_date_filter(time_filter, start_date, end_date)
+    if date_condition:
+        conditions.append(date_condition)
+        params.extend(date_params)
+
+    if region and region != "ALL":
+        if include_state_join:
+            conditions.append("UPPER(s.state_name) = UPPER(%s)")
+        else:
+            conditions.append(
+                f"UPPER(o.state_id) IN (SELECT state_id FROM {TABLE_STATE} "
+                f"WHERE UPPER(state_name) = UPPER(%s))"
+            )
+        params.append(region)
+
+    if organization_type and organization_type != "ALL":
+        conditions.append("LOWER(REPLACE(o.org_type, '-', '_')) = LOWER(%s)")
+        params.append(organization_type)
+
+    where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    return where_clause, params
+
+
+# ---------------------------------------------------------------------------
+# 1. Summary KPI cards
+# ---------------------------------------------------------------------------
+def fetch_summary(cursor, has_contributor_col, time_filter, start_date, end_date,
+                   region, organization_type):
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type
+    )
+
+    contributor_expr = "o.is_contributor" if has_contributor_col else "FALSE"
+
+    query = f"""
+        SELECT
+            COUNT(*) AS total_organizations,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS total_collaborators,
+            COUNT(*) FILTER (WHERE {contributor_expr} IS TRUE) AS total_contributors,
+            ROUND(AVG(o.org_rating)::numeric, 2) AS average_org_rating
+        FROM {TABLE_ORGANIZATIONS} o
+        {where_clause};
+    """
+    cursor.execute(query, params)
+    row = cursor.fetchone()
+    if not row:
+        return {
+            "total_organizations": 0,
+            "total_collaborators": 0,
+            "total_contributors": 0,
+            "average_org_rating": 0,
+        }
+    return {
+        "total_organizations": int(row["total_organizations"] or 0),
+        "total_collaborators": int(row["total_collaborators"] or 0),
+        "total_contributors": int(row["total_contributors"] or 0),
+        "average_org_rating": float(row["average_org_rating"]) if row["average_org_rating"] is not None else 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. Growth trend (Tab 1)
+# ---------------------------------------------------------------------------
+def fetch_growth_trend(cursor, group_by, time_filter, start_date, end_date,
+                        region, organization_type):
+    period, date_string = get_grouping(group_by)
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type
+    )
+
+    # Aggregate per period first, then run a cumulative window sum (mirrors
+    # the rolling-total pattern used in volunteer_application_analytics.py).
+    query = f"""
+        SELECT period, SUM(org_count) OVER (ORDER BY period) AS total_organizations,
+               SUM(collab_count) OVER (ORDER BY period) AS total_collaborators
+        FROM (
+            SELECT
+                TO_CHAR(DATE_TRUNC('{period}', o.created_at), '{date_string}') AS period,
+                COUNT(*) AS org_count,
+                COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collab_count
+            FROM {TABLE_ORGANIZATIONS} o
+            {where_clause}
+            GROUP BY 1
+        ) sub
+        ORDER BY period;
+    """
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    return [
+        {
+            "period": row["period"],
+            "total_organizations": int(row["total_organizations"] or 0),
+            "total_collaborators": int(row["total_collaborators"] or 0),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 3. Organizations by location (Tab 1)
+# ---------------------------------------------------------------------------
+def fetch_organizations_by_location(cursor, time_filter, start_date, end_date,
+                                     region, organization_type):
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type,
+        include_state_join=True,
+    )
+
+    state_query = f"""
+        SELECT
+            o.state_id,
+            COALESCE(s.state_name, 'Unknown') AS state_name,
+            COUNT(*) AS organization_count,
+            ROUND(100.0 * COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0), 1) AS percentage
+        FROM {TABLE_ORGANIZATIONS} o
+        LEFT JOIN {TABLE_STATE} s ON o.state_id = s.state_id
+        {where_clause}
+        GROUP BY o.state_id, s.state_name
+        ORDER BY organization_count DESC;
+    """
+    cursor.execute(state_query, params)
+    by_state = [
+        {
+            "state_id": row["state_id"],
+            "state_name": row["state_name"],
+            "organization_count": int(row["organization_count"] or 0),
+            "percentage": float(row["percentage"]) if row["percentage"] is not None else 0,
+        }
+        for row in cursor.fetchall()
+    ]
+
+    city_query = f"""
+        SELECT
+            COALESCE(o.city_name, 'Unknown') AS city_name,
+            COUNT(*) AS organization_count,
+            ROUND(100.0 * COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0), 1) AS percentage
+        FROM {TABLE_ORGANIZATIONS} o
+        LEFT JOIN {TABLE_STATE} s ON o.state_id = s.state_id
+        {where_clause}
+        GROUP BY o.city_name
+        ORDER BY organization_count DESC;
+    """
+    cursor.execute(city_query, params)
+    by_city = [
+        {
+            "city_name": row["city_name"],
+            "organization_count": int(row["organization_count"] or 0),
+            "percentage": float(row["percentage"]) if row["percentage"] is not None else 0,
+        }
+        for row in cursor.fetchall()
+    ]
+
+    return {"by_state": by_state, "by_city": by_city}
+
+
+# ---------------------------------------------------------------------------
+# 4. Organizations by size (Tab 2)
+# ---------------------------------------------------------------------------
+def fetch_organizations_by_size(cursor, time_filter, start_date, end_date,
+                                 region, organization_type):
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type
+    )
+    query = f"""
+        SELECT LOWER(COALESCE(o.org_size, 'unknown')) AS org_size, COUNT(*) AS organization_count
+        FROM {TABLE_ORGANIZATIONS} o
+        {where_clause}
+        GROUP BY 1
+        ORDER BY CASE LOWER(COALESCE(o.org_size, 'unknown'))
+                    WHEN 'small' THEN 1 WHEN 'medium' THEN 2 WHEN 'large' THEN 3 ELSE 4 END;
+    """
+    cursor.execute(query, params)
+    return [
+        {"org_size": row["org_size"], "organization_count": int(row["organization_count"] or 0)}
+        for row in cursor.fetchall()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 5. Collaborator vs Contributor (Tab 2)
+# ---------------------------------------------------------------------------
+def fetch_collaborator_vs_contributor(cursor, has_contributor_col, time_filter, start_date,
+                                       end_date, region, organization_type):
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type
+    )
+    contributor_expr = "o.is_contributor" if has_contributor_col else "FALSE"
+
+    query = f"""
+        SELECT
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborator_count,
+            COUNT(*) FILTER (WHERE {contributor_expr} IS TRUE) AS contributor_count
+        FROM {TABLE_ORGANIZATIONS} o
+        {where_clause};
+    """
+    cursor.execute(query, params)
+    row = cursor.fetchone() or {}
+    collaborator_count = int(row.get("collaborator_count") or 0)
+    contributor_count = int(row.get("contributor_count") or 0)
+    total = collaborator_count + contributor_count
+
+    def pct(count):
+        return round(100.0 * count / total, 1) if total else 0
+
+    return [
+        {"type": "collaborator", "organization_count": collaborator_count, "percentage": pct(collaborator_count)},
+        {"type": "contributor", "organization_count": contributor_count, "percentage": pct(contributor_count)},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 6. Rating distribution (Tab 3) - NULLs handled safely
+# ---------------------------------------------------------------------------
+def fetch_rating_distribution(cursor, time_filter, start_date, end_date,
+                               region, organization_type):
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type
+    )
+    # Exclude NULL ratings from the 1-5 buckets instead of letting them break the query.
+    null_guard = "o.org_rating IS NOT NULL"
+    where_clause = f"{where_clause} AND {null_guard}" if where_clause else f"WHERE {null_guard}"
+
+    query = f"""
+        SELECT o.org_rating AS rating, COUNT(*) AS organization_count
+        FROM {TABLE_ORGANIZATIONS} o
+        {where_clause}
+        GROUP BY o.org_rating
+        ORDER BY o.org_rating;
+    """
+    cursor.execute(query, params)
+    rows = {int(row["rating"]): int(row["organization_count"]) for row in cursor.fetchall()}
+    # Always return all 5 buckets, even if a rating has zero organizations.
+    return [{"rating": r, "organization_count": rows.get(r, 0)} for r in range(1, 6)]
+
+
+# ---------------------------------------------------------------------------
+# 7. For-Profit vs Non-Profit trend (Tab 3)
+# ---------------------------------------------------------------------------
+def fetch_organization_type_distribution(cursor, group_by, time_filter, start_date, end_date,
+                                          region, organization_type):
+    period, date_string = get_grouping(group_by)
+    where_clause, params = build_common_where(
+        time_filter, start_date, end_date, region, organization_type
+    )
+    query = f"""
+        SELECT
+            TO_CHAR(DATE_TRUNC('{period}', o.created_at), '{date_string}') AS period,
+            COUNT(*) FILTER (WHERE LOWER(REPLACE(o.org_type, '-', '_')) = 'for_profit') AS for_profit,
+            COUNT(*) FILTER (WHERE LOWER(REPLACE(o.org_type, '-', '_')) = 'non_profit') AS non_profit,
+            COUNT(*) AS total
+        FROM {TABLE_ORGANIZATIONS} o
+        {where_clause}
+        GROUP BY 1
+        ORDER BY 1;
+    """
+    cursor.execute(query, params)
+    return [
+        {
+            "period": row["period"],
+            "for_profit": int(row["for_profit"] or 0),
+            "non_profit": int(row["non_profit"] or 0),
+            "total": int(row["total"] or 0),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Lambda entrypoint
+# ---------------------------------------------------------------------------
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+    response_body = get_default_response()
+
+    request_body = parse_event_body(event)
+
+    time_filter = request_body.get("time_filter", "ALL")
+    start_date = request_body.get("start_date")
+    end_date = request_body.get("end_date")
+    group_by = request_body.get("group_by", "monthly")
+    region = request_body.get("region", "ALL")
+    organization_type = request_body.get("organization_type", "ALL")
+
+    # --- Validate filters up front (mirrors "Test invalid filters" requirement) ---
+    if time_filter not in VALID_TIME_FILTERS:
+        return build_response(400, {"error": f"Invalid time_filter: {time_filter}"})
+    if time_filter == "CUSTOM" and (not start_date or not end_date):
+        return build_response(400, {"error": "CUSTOM time_filter requires start_date and end_date."})
+    if group_by not in VALID_GROUP_BY:
+        return build_response(400, {"error": f"Invalid group_by: {group_by}"})
+
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+        has_contributor_col = column_exists(
+            cursor, SCHEMA_NAME, "organizations", "is_contributor"
+        )
+
+        response_body["summary"] = fetch_summary(
+            cursor, has_contributor_col, time_filter, start_date, end_date, region, organization_type
+        )
+        response_body["growth_trend"] = fetch_growth_trend(
+            cursor, group_by, time_filter, start_date, end_date, region, organization_type
+        )
+        response_body["organizations_by_location"] = fetch_organizations_by_location(
+            cursor, time_filter, start_date, end_date, region, organization_type
+        )
+        response_body["organizations_by_size"] = fetch_organizations_by_size(
+            cursor, time_filter, start_date, end_date, region, organization_type
+        )
+        response_body["collaborator_vs_contributor"] = fetch_collaborator_vs_contributor(
+            cursor, has_contributor_col, time_filter, start_date, end_date, region, organization_type
+        )
+        response_body["rating_distribution"] = fetch_rating_distribution(
+            cursor, time_filter, start_date, end_date, region, organization_type
+        )
+        response_body["organization_type_distribution"] = fetch_organization_type_distribution(
+            cursor, group_by, time_filter, start_date, end_date, region, organization_type
+        )
+
+        return build_response(200, response_body)
+
+    except ValueError as e:
+        return build_response(400, {"error": str(e)})
+    except Exception as e:
+        print("ERROR:", str(e))
+        return build_response(500, response_body)
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+
+if __name__ == "__main__":
+    test_event = {
+        "time_filter": "30D",
+        "start_date": None,
+        "end_date": None,
+        "group_by": "daily",
+        "region": "ALL",
+        "organization_type": "ALL",
+    }
+    print(json.dumps(lambda_handler(test_event, None), indent=2))

--- a/data-analytics/tests/test_organization_analytics.py
+++ b/data-analytics/tests/test_organization_analytics.py
@@ -1,0 +1,291 @@
+"""
+Unit tests for organization_analytics.py (issue #228).
+
+Uses unittest.mock to fake psycopg2 connections/cursors, so these run
+without a real database - mirrors the "cursor-based/mock database unit
+tests" requirement in the issue.
+
+Run with:
+    python -m unittest test_organization_analytics.py -v
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import organization_analytics as api
+
+
+def make_mock_cursor(fetchone_results=None, fetchall_results=None, column_exists=True):
+    """
+    fetchone_results: list of dict rows returned in order across successive
+                       fetchone() calls.
+    fetchall_results:  list of list-of-dict rows returned in order across
+                       successive fetchall() calls.
+    """
+    cursor = MagicMock()
+    fetchone_results = list(fetchone_results or [])
+    fetchall_results = list(fetchall_results or [])
+
+    def fetchone_side_effect(*args, **kwargs):
+        return fetchone_results.pop(0) if fetchone_results else None
+
+    def fetchall_side_effect(*args, **kwargs):
+        return fetchall_results.pop(0) if fetchall_results else []
+
+    cursor.fetchone.side_effect = fetchone_side_effect
+    cursor.fetchall.side_effect = fetchall_side_effect
+    return cursor
+
+
+class TestFilters(unittest.TestCase):
+    def test_build_date_filter_valid_ranges(self):
+        for tf in ["7D", "30D", "1Y", "ALL"]:
+            condition, params = api.build_date_filter(tf)
+            self.assertIsInstance(condition, str)
+            self.assertEqual(params, ())
+
+    def test_build_date_filter_custom_requires_dates(self):
+        with self.assertRaises(ValueError):
+            api.build_date_filter("CUSTOM", None, None)
+
+    def test_build_date_filter_custom_with_dates(self):
+        condition, params = api.build_date_filter("CUSTOM", "2026-01-01", "2026-06-30")
+        self.assertIn("BETWEEN", condition)
+        self.assertEqual(params, ("2026-01-01", "2026-06-30"))
+
+    def test_build_date_filter_invalid(self):
+        with self.assertRaises(ValueError):
+            api.build_date_filter("INVALID")
+
+    def test_get_grouping_valid(self):
+        for g in ["daily", "weekly", "monthly", "yearly"]:
+            period, date_string = api.get_grouping(g)
+            self.assertTrue(period)
+            self.assertTrue(date_string)
+
+    def test_get_grouping_invalid(self):
+        with self.assertRaises(ValueError):
+            api.get_grouping("hourly")
+
+    def test_build_common_where_no_filters(self):
+        where_clause, params = api.build_common_where("ALL", None, None, "ALL", "ALL")
+        self.assertEqual(where_clause, "")
+        self.assertEqual(params, [])
+
+    def test_build_common_where_region_and_type(self):
+        where_clause, params = api.build_common_where(
+            "ALL", None, None, "California", "non_profit"
+        )
+        self.assertIn("WHERE", where_clause)
+        self.assertIn("California", params)
+        self.assertIn("non_profit", params)
+
+
+class TestFetchFunctions(unittest.TestCase):
+    def test_fetch_summary_with_data(self):
+        cursor = make_mock_cursor(
+            fetchone_results=[
+                {
+                    "total_organizations": 126,
+                    "total_collaborators": 42,
+                    "total_contributors": 84,
+                    "average_org_rating": 4.2,
+                }
+            ]
+        )
+        result = api.fetch_summary(cursor, True, "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(result["total_organizations"], 126)
+        self.assertEqual(result["average_org_rating"], 4.2)
+
+    def test_fetch_summary_empty_result_set(self):
+        cursor = make_mock_cursor(fetchone_results=[None])
+        result = api.fetch_summary(cursor, True, "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(
+            result,
+            {
+                "total_organizations": 0,
+                "total_collaborators": 0,
+                "total_contributors": 0,
+                "average_org_rating": 0,
+            },
+        )
+
+    def test_fetch_rating_distribution_fills_missing_buckets(self):
+        # Only ratings 4 and 5 present in DB; 1-3 should still show as 0.
+        cursor = make_mock_cursor(
+            fetchall_results=[[{"rating": 4, "organization_count": 46}, {"rating": 5, "organization_count": 64}]]
+        )
+        result = api.fetch_rating_distribution(cursor, "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(len(result), 5)
+        ratings = {row["rating"]: row["organization_count"] for row in result}
+        self.assertEqual(ratings[1], 0)
+        self.assertEqual(ratings[4], 46)
+        self.assertEqual(ratings[5], 64)
+
+    def test_fetch_rating_distribution_handles_null_ratings_safely(self):
+        # NULL ratings must not raise; query excludes them via NOT NULL guard.
+        cursor = make_mock_cursor(fetchall_results=[[]])
+        result = api.fetch_rating_distribution(cursor, "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(sum(r["organization_count"] for r in result), 0)
+
+    def test_fetch_collaborator_vs_contributor_percentages(self):
+        cursor = make_mock_cursor(
+            fetchone_results=[{"collaborator_count": 42, "contributor_count": 84}]
+        )
+        result = api.fetch_collaborator_vs_contributor(cursor, True, "ALL", None, None, "ALL", "ALL")
+        collab = next(r for r in result if r["type"] == "collaborator")
+        contrib = next(r for r in result if r["type"] == "contributor")
+        self.assertEqual(collab["organization_count"], 42)
+        self.assertEqual(contrib["organization_count"], 84)
+        self.assertAlmostEqual(collab["percentage"], 33.3, places=1)
+        self.assertAlmostEqual(contrib["percentage"], 66.7, places=1)
+
+    def test_fetch_collaborator_vs_contributor_zero_total(self):
+        cursor = make_mock_cursor(
+            fetchone_results=[{"collaborator_count": 0, "contributor_count": 0}]
+        )
+        result = api.fetch_collaborator_vs_contributor(cursor, True, "ALL", None, None, "ALL", "ALL")
+        for row in result:
+            self.assertEqual(row["percentage"], 0)
+
+    def test_fetch_collaborator_vs_contributor_missing_is_contributor_column(self):
+        # Simulates dev DB where is_contributor doesn't exist yet.
+        cursor = make_mock_cursor(
+            fetchone_results=[{"collaborator_count": 42, "contributor_count": 0}]
+        )
+        result = api.fetch_collaborator_vs_contributor(cursor, False, "ALL", None, None, "ALL", "ALL")
+        contrib = next(r for r in result if r["type"] == "contributor")
+        self.assertEqual(contrib["organization_count"], 0)
+
+    def test_fetch_organizations_by_size_empty_result_set(self):
+        cursor = make_mock_cursor(fetchall_results=[[]])
+        result = api.fetch_organizations_by_size(cursor, "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(result, [])
+
+    def test_fetch_growth_trend_returns_periods(self):
+        cursor = make_mock_cursor(
+            fetchall_results=[
+                [
+                    {"period": "2026-01", "total_organizations": 100, "total_collaborators": 34},
+                    {"period": "2026-02", "total_organizations": 108, "total_collaborators": 36},
+                ]
+            ]
+        )
+        result = api.fetch_growth_trend(cursor, "monthly", "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[1]["total_organizations"], 108)
+
+    def test_fetch_organization_type_distribution(self):
+        cursor = make_mock_cursor(
+            fetchall_results=[
+                [{"period": "2026-01", "for_profit": 41, "non_profit": 68, "total": 109}]
+            ]
+        )
+        result = api.fetch_organization_type_distribution(
+            cursor, "monthly", "ALL", None, None, "ALL", "ALL"
+        )
+        self.assertEqual(result[0]["total"], 109)
+
+    def test_fetch_organizations_by_location_state_and_city(self):
+        cursor = make_mock_cursor(
+            fetchall_results=[
+                [{"state_id": "CA", "state_name": "California", "organization_count": 32, "percentage": 25.4}],
+                [{"city_name": "Springfield", "organization_count": 5, "percentage": 4.0}],
+            ]
+        )
+        result = api.fetch_organizations_by_location(cursor, "ALL", None, None, "ALL", "ALL")
+        self.assertEqual(result["by_state"][0]["state_name"], "California")
+        self.assertEqual(result["by_city"][0]["city_name"], "Springfield")
+
+
+class TestLambdaHandler(unittest.TestCase):
+    def _mock_conn_cursor(self, cursor):
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        return conn
+
+    @patch("organization_analytics.column_exists", return_value=True)
+    @patch("organization_analytics.get_db_connection")
+    def test_lambda_handler_valid_filters_returns_200(self, mock_get_conn, mock_col_exists):
+        cursor = make_mock_cursor(
+            fetchone_results=[
+                {
+                    "total_organizations": 10,
+                    "total_collaborators": 4,
+                    "total_contributors": 6,
+                    "average_org_rating": 4.0,
+                },
+                {"collaborator_count": 4, "contributor_count": 6},
+            ],
+            fetchall_results=[[], [], [], [], []],
+        )
+        mock_get_conn.return_value = self._mock_conn_cursor(cursor)
+
+        event = {
+            "time_filter": "30D",
+            "start_date": None,
+            "end_date": None,
+            "group_by": "daily",
+            "region": "ALL",
+            "organization_type": "ALL",
+        }
+        response = api.lambda_handler(event, None)
+        self.assertEqual(response["statusCode"], 200)
+        body = json.loads(response["body"])
+        self.assertEqual(body["summary"]["total_organizations"], 10)
+
+    def test_lambda_handler_invalid_time_filter(self):
+        event = {"time_filter": "NOT_REAL", "group_by": "monthly"}
+        response = api.lambda_handler(event, None)
+        self.assertEqual(response["statusCode"], 400)
+
+    def test_lambda_handler_custom_missing_dates(self):
+        event = {"time_filter": "CUSTOM", "group_by": "monthly"}
+        response = api.lambda_handler(event, None)
+        self.assertEqual(response["statusCode"], 400)
+
+    def test_lambda_handler_invalid_group_by(self):
+        event = {"time_filter": "ALL", "group_by": "hourly"}
+        response = api.lambda_handler(event, None)
+        self.assertEqual(response["statusCode"], 400)
+
+    def test_lambda_handler_custom_valid_range(self):
+        with patch("organization_analytics.column_exists", return_value=True), \
+             patch("organization_analytics.get_db_connection") as mock_get_conn:
+            cursor = make_mock_cursor(
+                fetchone_results=[
+                    {
+                        "total_organizations": 5,
+                        "total_collaborators": 2,
+                        "total_contributors": 3,
+                        "average_org_rating": 3.5,
+                    },
+                    {"collaborator_count": 2, "contributor_count": 3},
+                ],
+                fetchall_results=[[], [], [], [], []],
+            )
+            mock_get_conn.return_value = self._mock_conn_cursor(cursor)
+            event = {
+                "time_filter": "CUSTOM",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "group_by": "monthly",
+                "region": "ALL",
+                "organization_type": "ALL",
+            }
+            response = api.lambda_handler(event, None)
+            self.assertEqual(response["statusCode"], 200)
+
+    @patch("organization_analytics.get_db_connection", side_effect=Exception("connection refused"))
+    def test_lambda_handler_db_exception_returns_500_with_safe_body(self, mock_get_conn):
+        event = {"time_filter": "ALL", "group_by": "monthly"}
+        response = api.lambda_handler(event, None)
+        self.assertEqual(response["statusCode"], 500)
+        body = json.loads(response["body"])
+        self.assertEqual(body["summary"]["total_organizations"], 0)
+        self.assertEqual(body["growth_trend"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #228

Implements the Organization Analytics API for the Organization Dashboard, 
following the common filter pattern used in the Request/Volunteer/Beneficiary/KPI 
dashboards.

Includes:
- Summary KPIs (total organizations, collaborators, contributors, avg rating)
- Growth trend (organizations + collaborators over time)
- Organizations by location (state + city)
- Organizations by size (small/medium/large)
- Collaborator vs contributor breakdown
- Rating distribution (NULL-safe, always returns all 5 buckets)
- For-profit vs non-profit trend

## Local test results
25/25 tests passing:

Ran 25 tests in 0.082s
OK

## Sample request
{
  "time_filter": "30D",
  "start_date": null,
  "end_date": null,
  "group_by": "daily",
  "region": "ALL",
  "organization_type": "ALL"
}