### PR TITLE
Add Organization Analytics API using mock data (issue #228)

### DIFF
--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,580 @@
+"""
+Organization Analytics API (mock-data version)
+
+Provides the data backing the Saayam "Organization Dashboard":
+  1. Organization Overview Dashboard    -> get_organization_overview()
+  2. Organization Performance Dashboard -> get_organization_performance()
+
+--------------------------------------------------------------------------
+Why this doesn't connect to a database
+--------------------------------------------------------------------------
+Per review feedback on issue #228, this implementation never touches AWS,
+SSM, or the real Postgres database. It loads the sample data provided for
+this task (data-analytics/sql/organizations.csv) and computes every
+metric locally with pandas, reproducing the same filters and response
+shape the real SQL-backed version will eventually produce.
+
+Mock data schema (data-analytics/sql/organizations.csv):
+  org_id, org_name, street, city_name, state_id, zip_code, mission,
+  web_url, phone, email, org_type, org_size, org_rating, is_collaborator,
+  is_contributor, created_at, last_updated_at
+
+Notes on real values seen in the mock file:
+  - org_type:  "Non-Profit" | "For-profit"
+  - org_size:  "Small" | "Medium" | "Large"
+  - org_rating: 1-5 (may be null on the real table; handled defensively)
+  - is_collaborator / is_contributor: TRUE / FALSE
+  - There is no separate state reference table in the current mock data
+    set, so "state" in the location breakdown is simply the org's own
+    state_id (a 2-letter code) rather than a joined state_name.
+"""
+
+import json
+import os
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Paths / constants
+# ---------------------------------------------------------------------------
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+MOCK_DATA_DIR = os.environ.get("MOCK_DATA_DIR", os.path.join(BASE_DIR, "..", "sql"))
+ORGANIZATIONS_CSV = os.path.join(MOCK_DATA_DIR, "organizations.csv")
+
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+GROUP_BY_PANDAS_FREQ = {
+    "daily": "D",
+    "weekly": "W",
+    "monthly": "MS",
+    "yearly": "YS",
+}
+GROUP_BY_FORMAT = {
+    "daily": "%Y-%m-%d",
+    "weekly": "%Y-%m-%d",
+    "monthly": "%Y-%m",
+    "yearly": "%Y",
+}
+
+TOP_N_DEFAULT = 10
+
+
+# ---------------------------------------------------------------------------
+# Response helpers
+# ---------------------------------------------------------------------------
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+        },
+        "body": json.dumps(body, default=str),
+    }
+
+
+def parse_event_body(event):
+    if not event:
+        return {}
+    body = event.get("body")
+    if body is None:
+        return event
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+    if isinstance(body, dict):
+        return body
+    return {}
+
+
+def get_default_overview_response():
+    return {
+        "organization_overview": {
+            "summary": {
+                "total_organizations": 0,
+                "non_profit_organizations": 0,
+                "for_profit_organizations": 0,
+                "collaborator_organizations": 0,
+                "non_collaborator_organizations": 0,
+                "contributor_organizations": 0,
+                "non_contributor_organizations": 0,
+            },
+            "organization_activity_trend": [],
+            "organizations_by_type": [],
+            "organizations_by_size": [],
+            "organizations_by_location": [],
+            "collaborator_distribution": [],
+            "contributor_distribution": [],
+        }
+    }
+
+
+def get_default_performance_response():
+    return {
+        "organization_performance": {
+            "summary": {
+                "average_rating": 0,
+                "rated_organizations": 0,
+                "unrated_organizations": 0,
+                "five_star_organizations": 0,
+            },
+            "rating_distribution": [],
+            "top_rated_organizations": [],
+            "top_collaborator_organizations": [],
+            "top_contributor_organizations": [],
+            "ratings_by_organization_type": [],
+            "ratings_by_organization_size": [],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mock data loading
+# ---------------------------------------------------------------------------
+
+def load_mock_data(organizations_csv=ORGANIZATIONS_CSV):
+    """
+    Loads the mock organizations table from CSV into a DataFrame, doing the
+    light type coercion that would otherwise come "for free" from Postgres
+    column types (created_at -> datetime, org_rating -> nullable numeric,
+    is_collaborator/is_contributor -> bool).
+    """
+    df = pd.read_csv(organizations_csv)
+
+    df["created_at"] = pd.to_datetime(df["created_at"])
+    df["org_rating"] = pd.to_numeric(df["org_rating"], errors="coerce")
+
+    for bool_col in ("is_collaborator", "is_contributor"):
+        if bool_col in df.columns:
+            df[bool_col] = df[bool_col].map(
+                lambda v: v if isinstance(v, bool) else str(v).strip().upper() == "TRUE"
+            )
+        else:
+            # Isolated fallback in case a future/real data source is missing
+            # this column (e.g. is_contributor before its DB migration).
+            df[bool_col] = pd.NA
+
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Filter helpers
+# ---------------------------------------------------------------------------
+
+def apply_date_filter(df, time_filter, start_date=None, end_date=None, column="created_at"):
+    time_filter = (time_filter or "ALL").upper()
+    now = pd.Timestamp.now().normalize() + pd.Timedelta(days=1)  # end of "today"
+
+    if time_filter == "CUSTOM" and start_date and end_date:
+        start = pd.to_datetime(start_date)
+        end = pd.to_datetime(end_date)
+        return df[(df[column] >= start) & (df[column] <= end)]
+    elif time_filter == "7D":
+        return df[df[column] >= now - pd.Timedelta(days=7)]
+    elif time_filter == "30D":
+        return df[df[column] >= now - pd.Timedelta(days=30)]
+    elif time_filter == "1Y":
+        return df[df[column] >= now - pd.DateOffset(years=1)]
+    else:
+        # "ALL" or unrecognized -> no date filter
+        return df
+
+
+def apply_common_filters(df, filters):
+    """
+    org_type, org_size, state_id, city_name, org_rating, is_collaborator,
+    time_filter/start_date/end_date.
+
+    `is_contributor` is intentionally left out here and applied only
+    inside the isolated contributor fetch functions below, so a data
+    source missing that column only degrades the contributor-specific
+    pieces instead of failing every metric.
+    """
+    result = df
+
+    org_type = filters.get("org_type")
+    if org_type:
+        result = result[result["org_type"] == org_type]
+
+    org_size = filters.get("org_size")
+    if org_size:
+        result = result[result["org_size"] == org_size]
+
+    state_id = filters.get("state_id")
+    if state_id:
+        result = result[result["state_id"] == state_id]
+
+    city_name = filters.get("city_name")
+    if city_name:
+        result = result[result["city_name"] == city_name]
+
+    org_rating = filters.get("org_rating")
+    if org_rating is not None:
+        result = result[result["org_rating"] == org_rating]
+
+    is_collaborator = filters.get("is_collaborator")
+    if is_collaborator is not None:
+        result = result[result["is_collaborator"] == bool(is_collaborator)]
+
+    result = apply_date_filter(
+        result,
+        filters.get("time_filter", "ALL"),
+        filters.get("start_date"),
+        filters.get("end_date"),
+    )
+
+    return result
+
+
+def get_group_by_unit(group_by):
+    group_by = (group_by or "daily").lower()
+    if group_by not in GROUP_BY_PANDAS_FREQ:
+        group_by = "daily"
+    return GROUP_BY_PANDAS_FREQ[group_by], GROUP_BY_FORMAT[group_by]
+
+
+# ---------------------------------------------------------------------------
+# Dashboard 1: Organization Overview
+# ---------------------------------------------------------------------------
+
+def fetch_overview_summary(df, filters):
+    filtered = apply_common_filters(df, filters)
+    return {
+        "total_organizations": int(len(filtered)),
+        "non_profit_organizations": int((filtered["org_type"] == "Non-Profit").sum()),
+        "for_profit_organizations": int((filtered["org_type"] == "For-profit").sum()),
+        "collaborator_organizations": int((filtered["is_collaborator"] == True).sum()),  # noqa: E712
+        "non_collaborator_organizations": int((filtered["is_collaborator"] != True).sum()),  # noqa: E712
+    }
+
+
+def fetch_contributor_summary(df, filters):
+    """Isolated so a data source missing is_contributor just zeroes this out."""
+    filtered = apply_common_filters(df, filters)
+    if "is_contributor" not in filtered.columns or filtered["is_contributor"].isna().all():
+        return {"contributor_organizations": 0, "non_contributor_organizations": 0}
+    return {
+        "contributor_organizations": int((filtered["is_contributor"] == True).sum()),  # noqa: E712
+        "non_contributor_organizations": int((filtered["is_contributor"] != True).sum()),  # noqa: E712
+    }
+
+
+def fetch_organization_activity_trend(df, filters):
+    filtered = apply_common_filters(df, filters)
+    freq, fmt = get_group_by_unit(filters.get("group_by"))
+
+    if filtered.empty:
+        return []
+
+    grouped = (
+        filtered.set_index("created_at")
+        .resample(freq)
+        .size()
+        .reset_index(name="count")
+    )
+    grouped = grouped[grouped["count"] > 0]
+    return [
+        {"period": row["created_at"].strftime(fmt), "count": int(row["count"])}
+        for _, row in grouped.iterrows()
+    ]
+
+
+def fetch_organizations_by_type(df, filters):
+    filtered = apply_common_filters(df, filters)
+    counts = filtered["org_type"].fillna("unknown").value_counts()
+    return [
+        {"org_type": org_type, "count": int(count)}
+        for org_type, count in counts.sort_values(ascending=False).items()
+    ]
+
+
+def fetch_organizations_by_size(df, filters):
+    filtered = apply_common_filters(df, filters)
+    counts = filtered["org_size"].fillna("unknown").value_counts()
+    return [
+        {"org_size": org_size, "count": int(count)}
+        for org_size, count in counts.sort_values(ascending=False).items()
+    ]
+
+
+def fetch_organizations_by_location(df, filters):
+    filtered = apply_common_filters(df, filters).copy()
+    filtered["state_id"] = filtered["state_id"].fillna("Unknown")
+    filtered["city_name"] = filtered["city_name"].fillna("Unknown")
+    grouped = (
+        filtered.groupby(["state_id", "city_name"])
+        .size()
+        .reset_index(name="count")
+        .sort_values("count", ascending=False)
+    )
+    return [
+        {"state": row["state_id"], "city": row["city_name"], "count": int(row["count"])}
+        for _, row in grouped.iterrows()
+    ]
+
+
+def fetch_collaborator_distribution(df, filters):
+    filtered = apply_common_filters(df, filters)
+    category = filtered["is_collaborator"].map(
+        lambda v: "collaborator" if v is True else "non_collaborator"
+    )
+    counts = category.value_counts()
+    return [
+        {"category": category, "count": int(count)}
+        for category, count in counts.sort_index().items()
+    ]
+
+
+def fetch_contributor_distribution(df, filters):
+    """Isolated for the same is_contributor reason as fetch_contributor_summary."""
+    filtered = apply_common_filters(df, filters)
+    if "is_contributor" not in filtered.columns or filtered["is_contributor"].isna().all():
+        return []
+    category = filtered["is_contributor"].map(
+        lambda v: "contributor" if v is True else "non_contributor"
+    )
+    counts = category.value_counts()
+    return [
+        {"category": category, "count": int(count)}
+        for category, count in counts.sort_index().items()
+    ]
+
+
+def get_organization_overview(df, filters):
+    response = get_default_overview_response()["organization_overview"]
+
+    try:
+        response["summary"].update(fetch_overview_summary(df, filters))
+    except Exception as error:
+        print(f"[overview] summary computation failed: {error}")
+
+    try:
+        response["summary"].update(fetch_contributor_summary(df, filters))
+    except Exception as error:
+        print(f"[overview] contributor summary computation failed: {error}")
+
+    try:
+        response["organization_activity_trend"] = fetch_organization_activity_trend(df, filters)
+    except Exception as error:
+        print(f"[overview] activity trend computation failed: {error}")
+
+    try:
+        response["organizations_by_type"] = fetch_organizations_by_type(df, filters)
+    except Exception as error:
+        print(f"[overview] organizations_by_type computation failed: {error}")
+
+    try:
+        response["organizations_by_size"] = fetch_organizations_by_size(df, filters)
+    except Exception as error:
+        print(f"[overview] organizations_by_size computation failed: {error}")
+
+    try:
+        response["organizations_by_location"] = fetch_organizations_by_location(df, filters)
+    except Exception as error:
+        print(f"[overview] organizations_by_location computation failed: {error}")
+
+    try:
+        response["collaborator_distribution"] = fetch_collaborator_distribution(df, filters)
+    except Exception as error:
+        print(f"[overview] collaborator_distribution computation failed: {error}")
+
+    try:
+        response["contributor_distribution"] = fetch_contributor_distribution(df, filters)
+    except Exception as error:
+        print(f"[overview] contributor_distribution computation failed: {error}")
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Dashboard 2: Organization Performance
+# ---------------------------------------------------------------------------
+
+def fetch_performance_summary(df, filters):
+    filtered = apply_common_filters(df, filters)
+    rated = filtered["org_rating"].dropna()
+    return {
+        "average_rating": round(float(rated.mean()), 2) if not rated.empty else 0,
+        "rated_organizations": int(rated.shape[0]),
+        "unrated_organizations": int(filtered["org_rating"].isna().sum()),
+        "five_star_organizations": int((filtered["org_rating"] == 5).sum()),
+    }
+
+
+def fetch_rating_distribution(df, filters):
+    filtered = apply_common_filters(df, filters)
+    counts = filtered["org_rating"].value_counts(dropna=False)
+    items = sorted(counts.items(), key=lambda kv: (pd.isna(kv[0]), kv[0]))  # NULLS LAST
+    return [
+        {"rating": (None if pd.isna(rating) else int(rating)), "count": int(count)}
+        for rating, count in items
+    ]
+
+
+def _row_to_org_dict(row):
+    return {
+        "org_id": row["org_id"],
+        "org_name": row["org_name"],
+        "org_type": row["org_type"],
+        "org_size": row["org_size"],
+        "org_rating": (None if pd.isna(row["org_rating"]) else float(row["org_rating"])),
+        "city_name": row["city_name"],
+        "state_id": row["state_id"],
+    }
+
+
+def fetch_top_rated_organizations(df, filters, limit=TOP_N_DEFAULT):
+    filtered = apply_common_filters(df, filters)
+    filtered = filtered[filtered["org_rating"].notna()]
+    filtered = filtered.sort_values(["org_rating", "org_name"], ascending=[False, True])
+    return [_row_to_org_dict(row) for _, row in filtered.head(limit).iterrows()]
+
+
+def fetch_top_collaborator_organizations(df, filters, limit=TOP_N_DEFAULT):
+    filtered = apply_common_filters(df, filters)
+    filtered = filtered[filtered["is_collaborator"] == True]  # noqa: E712
+    filtered = filtered.sort_values(
+        ["org_rating", "org_name"], ascending=[False, True], na_position="last"
+    )
+    return [_row_to_org_dict(row) for _, row in filtered.head(limit).iterrows()]
+
+
+def fetch_top_contributor_organizations(df, filters, limit=TOP_N_DEFAULT):
+    """Isolated: relies on is_contributor, which may not exist on the real table yet."""
+    filtered = apply_common_filters(df, filters)
+    if "is_contributor" not in filtered.columns:
+        return []
+    filtered = filtered[filtered["is_contributor"] == True]  # noqa: E712
+    filtered = filtered.sort_values(
+        ["org_rating", "org_name"], ascending=[False, True], na_position="last"
+    )
+    return [_row_to_org_dict(row) for _, row in filtered.head(limit).iterrows()]
+
+
+def fetch_ratings_by_organization_type(df, filters):
+    filtered = apply_common_filters(df, filters)
+    grouped = filtered.groupby(filtered["org_type"].fillna("unknown")).agg(
+        average_rating=("org_rating", "mean"),
+        rated_count=("org_rating", "count"),
+    )
+    grouped = grouped.sort_values("average_rating", ascending=False, na_position="last")
+    return [
+        {
+            "org_type": org_type,
+            "average_rating": round(float(row["average_rating"]), 2) if pd.notna(row["average_rating"]) else 0,
+            "rated_count": int(row["rated_count"]),
+        }
+        for org_type, row in grouped.iterrows()
+    ]
+
+
+def fetch_ratings_by_organization_size(df, filters):
+    filtered = apply_common_filters(df, filters)
+    grouped = filtered.groupby(filtered["org_size"].fillna("unknown")).agg(
+        average_rating=("org_rating", "mean"),
+        rated_count=("org_rating", "count"),
+    )
+    grouped = grouped.sort_values("average_rating", ascending=False, na_position="last")
+    return [
+        {
+            "org_size": org_size,
+            "average_rating": round(float(row["average_rating"]), 2) if pd.notna(row["average_rating"]) else 0,
+            "rated_count": int(row["rated_count"]),
+        }
+        for org_size, row in grouped.iterrows()
+    ]
+
+
+def get_organization_performance(df, filters):
+    response = get_default_performance_response()["organization_performance"]
+
+    try:
+        response["summary"].update(fetch_performance_summary(df, filters))
+    except Exception as error:
+        print(f"[performance] summary computation failed: {error}")
+
+    try:
+        response["rating_distribution"] = fetch_rating_distribution(df, filters)
+    except Exception as error:
+        print(f"[performance] rating_distribution computation failed: {error}")
+
+    try:
+        response["top_rated_organizations"] = fetch_top_rated_organizations(df, filters)
+    except Exception as error:
+        print(f"[performance] top_rated_organizations computation failed: {error}")
+
+    try:
+        response["top_collaborator_organizations"] = fetch_top_collaborator_organizations(df, filters)
+    except Exception as error:
+        print(f"[performance] top_collaborator_organizations computation failed: {error}")
+
+    try:
+        response["top_contributor_organizations"] = fetch_top_contributor_organizations(df, filters)
+    except Exception as error:
+        print(f"[performance] top_contributor_organizations computation failed: {error}")
+
+    try:
+        response["ratings_by_organization_type"] = fetch_ratings_by_organization_type(df, filters)
+    except Exception as error:
+        print(f"[performance] ratings_by_organization_type computation failed: {error}")
+
+    try:
+        response["ratings_by_organization_size"] = fetch_ratings_by_organization_size(df, filters)
+    except Exception as error:
+        print(f"[performance] ratings_by_organization_size computation failed: {error}")
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+#
+# These load the mock CSV on each call instead of connecting to AWS/SSM/
+# Postgres. Swapping the data-loading layer back to a real DB connection
+# later (once this is approved and a real DB is wired up) is a small,
+# isolated change contained to load_mock_data().
+# ---------------------------------------------------------------------------
+
+def lambda_handler(event, context=None):
+    filters = parse_event_body(event)
+    dashboard_type = (filters.get("dashboard_type") or "overview").lower()
+
+    response_body = {}
+    if dashboard_type in ("overview", "both"):
+        response_body.update(get_default_overview_response())
+    if dashboard_type in ("performance", "both"):
+        response_body.update(get_default_performance_response())
+    if dashboard_type not in ("overview", "performance", "both"):
+        return build_response(400, {
+            "error": "Invalid dashboard_type. Expected 'overview', 'performance', or 'both'."
+        })
+
+    try:
+        org_df = load_mock_data()
+
+        if dashboard_type in ("overview", "both"):
+            response_body["organization_overview"] = get_organization_overview(org_df, filters)
+
+        if dashboard_type in ("performance", "both"):
+            response_body["organization_performance"] = get_organization_performance(org_df, filters)
+
+        return build_response(200, response_body)
+
+    except Exception as error:
+        print(f"Mock data load failed: {error}")
+        return build_response(500, response_body)
+
+
+def overview_lambda_handler(event, context=None):
+    filters = parse_event_body(event)
+    filters["dashboard_type"] = "overview"
+    return lambda_handler({"body": json.dumps(filters, default=str)}, context)
+
+
+def performance_lambda_handler(event, context=None):
+    filters = parse_event_body(event)
+    filters["dashboard_type"] = "performance"
+    return lambda_handler({"body": json.dumps(filters, default=str)}, context)

--- a/data-analytics/lambda_functions/test_organization_analytics.py
+++ b/data-analytics/lambda_functions/test_organization_analytics.py
@@ -1,0 +1,171 @@
+"""
+Local test suite for organization_analytics.py (mock-data version).
+
+Run directly:
+    python test_organization_analytics.py
+
+What it does:
+  1. Loads the mock CSV data (mock_data/organizations.csv) — no AWS, SSM,
+     or real DB connection involved, per review feedback on issue #228.
+  2. Runs both dashboards through several filter scenarios (unfiltered,
+     each time_filter, a few common-filter combinations, and a "both"
+     dashboard_type call).
+  3. Runs sanity assertions against the computed metrics (e.g. type/size/
+     collaborator/rating breakdowns sum back to the scenario's total).
+  4. Writes a human-readable results file to test_results.md with the
+     full JSON response for every scenario plus a PASS/FAIL summary.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from organization_analytics import (  # noqa: E402
+    load_mock_data,
+    get_organization_overview,
+    get_organization_performance,
+    lambda_handler,
+)
+
+RESULTS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_results.md")
+
+SCENARIOS = [
+    ("Overview - ALL time (unfiltered)", {"dashboard_type": "overview", "time_filter": "ALL", "group_by": "monthly"}),
+    ("Overview - 7D", {"dashboard_type": "overview", "time_filter": "7D", "group_by": "daily"}),
+    ("Overview - 30D", {"dashboard_type": "overview", "time_filter": "30D", "group_by": "daily"}),
+    ("Overview - 1Y, grouped monthly", {"dashboard_type": "overview", "time_filter": "1Y", "group_by": "monthly"}),
+    ("Overview - filtered (Non-Profit)", {
+        "dashboard_type": "overview", "org_type": "Non-Profit", "time_filter": "ALL",
+    }),
+    ("Overview - filtered (is_collaborator=true)", {
+        "dashboard_type": "overview", "is_collaborator": True, "time_filter": "ALL",
+    }),
+    ("Overview - filtered (is_contributor=true)", {
+        "dashboard_type": "overview", "is_contributor": True, "time_filter": "ALL",
+    }),
+    ("Overview - CUSTOM date range", {
+        "dashboard_type": "overview", "time_filter": "CUSTOM",
+        "start_date": "2025-01-01", "end_date": "2025-12-31",
+    }),
+    ("Performance - ALL", {"dashboard_type": "performance", "time_filter": "ALL"}),
+    ("Performance - filtered (org_rating=5)", {"dashboard_type": "performance", "org_rating": 5, "time_filter": "ALL"}),
+    ("Performance - filtered (org_size=Large)", {"dashboard_type": "performance", "org_size": "Large", "time_filter": "ALL"}),
+    ("Both dashboards - ALL", {"dashboard_type": "both", "time_filter": "ALL", "group_by": "monthly"}),
+]
+
+
+def run_scenario(org_df, filters):
+    dashboard_type = filters.get("dashboard_type", "overview")
+    result = {}
+    if dashboard_type in ("overview", "both"):
+        result["organization_overview"] = get_organization_overview(org_df, filters)
+    if dashboard_type in ("performance", "both"):
+        result["organization_performance"] = get_organization_performance(org_df, filters)
+    return result
+
+
+def check_overview_invariants(result, label, failures):
+    overview = result.get("organization_overview")
+    if overview is None:
+        return
+    summary = overview["summary"]
+    total = summary["total_organizations"]
+
+    if summary["non_profit_organizations"] + summary["for_profit_organizations"] != total:
+        failures.append(f"[{label}] org_type breakdown does not sum to total_organizations")
+
+    if summary["collaborator_organizations"] + summary["non_collaborator_organizations"] != total:
+        failures.append(f"[{label}] collaborator breakdown does not sum to total_organizations")
+
+    if summary["contributor_organizations"] + summary["non_contributor_organizations"] != total:
+        failures.append(f"[{label}] contributor breakdown does not sum to total_organizations")
+
+    for key in ("organizations_by_type", "organizations_by_size", "organizations_by_location", "organization_activity_trend"):
+        subtotal = sum(row["count"] for row in overview[key])
+        if subtotal != total:
+            failures.append(f"[{label}] {key} does not sum to total_organizations ({subtotal} != {total})")
+
+
+def check_performance_invariants(result, label, failures):
+    performance = result.get("organization_performance")
+    if performance is None:
+        return
+    summary = performance["summary"]
+
+    if summary["rated_organizations"] + summary["unrated_organizations"] == 0 and summary["average_rating"] != 0:
+        failures.append(f"[{label}] average_rating should be 0 when there are no rated organizations")
+
+    dist_sum = sum(row["count"] for row in performance["rating_distribution"])
+    if dist_sum != summary["rated_organizations"] + summary["unrated_organizations"]:
+        failures.append(f"[{label}] rating_distribution does not sum to rated+unrated organizations")
+
+    for row in performance["top_rated_organizations"]:
+        if row["org_rating"] is None:
+            failures.append(f"[{label}] top_rated_organizations contains an unrated organization")
+
+
+def main():
+    org_df = load_mock_data()
+
+    lines = []
+    lines.append("# Organization Analytics API — Local Test Results (mock data)\n")
+    lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+    lines.append(f"Mock organizations loaded: **{len(org_df)}** rows from `mock_data/organizations.csv`\n")
+    lines.append(
+        "No AWS/SSM/Postgres connection is used anywhere in this test run — "
+        "all data comes from the mock CSV.\n"
+    )
+
+    all_failures = []
+
+    for label, filters in SCENARIOS:
+        result = run_scenario(org_df, filters)
+        check_overview_invariants(result, label, all_failures)
+        check_performance_invariants(result, label, all_failures)
+
+        lines.append(f"## Scenario: {label}\n")
+        lines.append(f"Request filters:\n```json\n{json.dumps(filters, indent=2)}\n```\n")
+        lines.append(f"Response:\n```json\n{json.dumps(result, indent=2, default=str)}\n```\n")
+
+    handler_event = {"body": json.dumps({"dashboard_type": "both", "time_filter": "ALL"})}
+    handler_response = lambda_handler(handler_event, None)
+    if handler_response["statusCode"] != 200:
+        all_failures.append("lambda_handler did not return statusCode 200 for a valid 'both' request")
+    lines.append("## Scenario: lambda_handler(event) end-to-end\n")
+    lines.append(f"Event:\n```json\n{json.dumps(handler_event, indent=2)}\n```\n")
+    lines.append(f"statusCode: {handler_response['statusCode']}\n")
+    lines.append(f"Response body:\n```json\n{json.dumps(json.loads(handler_response['body']), indent=2)}\n```\n")
+
+    invalid_response = lambda_handler({"body": json.dumps({"dashboard_type": "bogus"})}, None)
+    if invalid_response["statusCode"] != 400:
+        all_failures.append("lambda_handler did not return statusCode 400 for an invalid dashboard_type")
+    lines.append("## Scenario: lambda_handler(event) with invalid dashboard_type\n")
+    lines.append(f"statusCode: {invalid_response['statusCode']}\n")
+    lines.append(f"Response body:\n```json\n{json.dumps(json.loads(invalid_response['body']), indent=2)}\n```\n")
+
+    lines.append("## Summary\n")
+    if all_failures:
+        lines.append(f"**{len(all_failures)} check(s) FAILED:**\n")
+        for failure in all_failures:
+            lines.append(f"- ❌ {failure}")
+    else:
+        lines.append(f"✅ All {len(SCENARIOS) + 2} scenarios ran and all invariant checks passed.")
+
+    with open(RESULTS_PATH, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"Wrote results for {len(SCENARIOS) + 2} scenarios to {RESULTS_PATH}")
+    if all_failures:
+        print(f"\n{len(all_failures)} CHECK(S) FAILED:")
+        for failure in all_failures:
+            print(f"  - {failure}")
+        sys.exit(1)
+    else:
+        print("All checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/data-analytics/lambda_functions/test_results.md
+++ b/data-analytics/lambda_functions/test_results.md
@@ -1,0 +1,4206 @@
+# Organization Analytics API — Local Test Results (mock data)
+
+Generated: 2026-08-18 13:31:55
+
+Mock organizations loaded: **40** rows from `mock_data/organizations.csv`
+
+No AWS/SSM/Postgres connection is used anywhere in this test run — all data comes from the mock CSV.
+
+## Scenario: Overview - ALL time (unfiltered)
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "ALL",
+  "group_by": "monthly"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 40,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 19,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 19,
+      "contributor_organizations": 19,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09",
+        "count": 2
+      },
+      {
+        "period": "2023-11",
+        "count": 1
+      },
+      {
+        "period": "2023-12",
+        "count": 2
+      },
+      {
+        "period": "2024-02",
+        "count": 2
+      },
+      {
+        "period": "2024-04",
+        "count": 2
+      },
+      {
+        "period": "2024-06",
+        "count": 1
+      },
+      {
+        "period": "2024-07",
+        "count": 2
+      },
+      {
+        "period": "2024-08",
+        "count": 2
+      },
+      {
+        "period": "2024-09",
+        "count": 3
+      },
+      {
+        "period": "2024-11",
+        "count": 2
+      },
+      {
+        "period": "2024-12",
+        "count": 1
+      },
+      {
+        "period": "2025-01",
+        "count": 3
+      },
+      {
+        "period": "2025-04",
+        "count": 1
+      },
+      {
+        "period": "2025-06",
+        "count": 1
+      },
+      {
+        "period": "2025-08",
+        "count": 4
+      },
+      {
+        "period": "2025-09",
+        "count": 3
+      },
+      {
+        "period": "2025-10",
+        "count": 1
+      },
+      {
+        "period": "2025-11",
+        "count": 3
+      },
+      {
+        "period": "2025-12",
+        "count": 3
+      },
+      {
+        "period": "2026-01",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "count": 19
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 21
+      },
+      {
+        "org_size": "Small",
+        "count": 10
+      },
+      {
+        "org_size": "Medium",
+        "count": 9
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AK",
+        "city": "North Judithbury",
+        "count": 1
+      },
+      {
+        "state": "AL",
+        "city": "Smithberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Ronaldview",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "NJ",
+        "city": "South Williamton",
+        "count": 1
+      },
+      {
+        "state": "NV",
+        "city": "Leehaven",
+        "count": 1
+      },
+      {
+        "state": "OH",
+        "city": "South Jeffrey",
+        "count": 1
+      },
+      {
+        "state": "OK",
+        "city": "Jeremyburgh",
+        "count": 1
+      },
+      {
+        "state": "OR",
+        "city": "Johnberg",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "Mitchellside",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "South Rachelborough",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Hortonberg",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      },
+      {
+        "state": "UT",
+        "city": "New Thomas",
+        "count": 1
+      },
+      {
+        "state": "VA",
+        "city": "Sandrastad",
+        "count": 1
+      },
+      {
+        "state": "VT",
+        "city": "Ortizmouth",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      },
+      {
+        "state": "WI",
+        "city": "Thomasberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Williamview",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Wendyville",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "West Erik",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "East Amanda",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "Robertfort",
+        "count": 1
+      },
+      {
+        "state": "AZ",
+        "city": "Kyleborough",
+        "count": 1
+      },
+      {
+        "state": "CA",
+        "city": "New Susanville",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "North Jamesborough",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "Lake Debbie",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "North Donnaport",
+        "count": 1
+      },
+      {
+        "state": "MO",
+        "city": "Lake Deniseville",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "South Monicamouth",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Burchborough",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Port Andrew",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "New Amyhaven",
+        "count": 1
+      },
+      {
+        "state": "WY",
+        "city": "Kingborough",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 21
+      },
+      {
+        "category": "non_collaborator",
+        "count": 19
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 19
+      },
+      {
+        "category": "non_contributor",
+        "count": 21
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Overview - 7D
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "7D",
+  "group_by": "daily"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 0,
+      "non_profit_organizations": 0,
+      "for_profit_organizations": 0,
+      "collaborator_organizations": 0,
+      "non_collaborator_organizations": 0,
+      "contributor_organizations": 0,
+      "non_contributor_organizations": 0
+    },
+    "organization_activity_trend": [],
+    "organizations_by_type": [],
+    "organizations_by_size": [],
+    "organizations_by_location": [],
+    "collaborator_distribution": [],
+    "contributor_distribution": []
+  }
+}
+```
+
+## Scenario: Overview - 30D
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "30D",
+  "group_by": "daily"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 0,
+      "non_profit_organizations": 0,
+      "for_profit_organizations": 0,
+      "collaborator_organizations": 0,
+      "non_collaborator_organizations": 0,
+      "contributor_organizations": 0,
+      "non_contributor_organizations": 0
+    },
+    "organization_activity_trend": [],
+    "organizations_by_type": [],
+    "organizations_by_size": [],
+    "organizations_by_location": [],
+    "collaborator_distribution": [],
+    "contributor_distribution": []
+  }
+}
+```
+
+## Scenario: Overview - 1Y, grouped monthly
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "1Y",
+  "group_by": "monthly"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 11,
+      "non_profit_organizations": 8,
+      "for_profit_organizations": 3,
+      "collaborator_organizations": 5,
+      "non_collaborator_organizations": 6,
+      "contributor_organizations": 6,
+      "non_contributor_organizations": 5
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2025-09",
+        "count": 3
+      },
+      {
+        "period": "2025-10",
+        "count": 1
+      },
+      {
+        "period": "2025-11",
+        "count": 3
+      },
+      {
+        "period": "2025-12",
+        "count": 3
+      },
+      {
+        "period": "2026-01",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 8
+      },
+      {
+        "org_type": "For-profit",
+        "count": 3
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 7
+      },
+      {
+        "org_size": "Small",
+        "count": 2
+      },
+      {
+        "org_size": "Medium",
+        "count": 2
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MO",
+        "city": "Lake Deniseville",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "OH",
+        "city": "South Jeffrey",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Hortonberg",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 5
+      },
+      {
+        "category": "non_collaborator",
+        "count": 6
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 6
+      },
+      {
+        "category": "non_contributor",
+        "count": 5
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Overview - filtered (Non-Profit)
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "org_type": "Non-Profit",
+  "time_filter": "ALL"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 21,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 0,
+      "collaborator_organizations": 11,
+      "non_collaborator_organizations": 10,
+      "contributor_organizations": 10,
+      "non_contributor_organizations": 11
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09-08",
+        "count": 1
+      },
+      {
+        "period": "2023-11-03",
+        "count": 1
+      },
+      {
+        "period": "2023-12-27",
+        "count": 1
+      },
+      {
+        "period": "2024-04-03",
+        "count": 1
+      },
+      {
+        "period": "2024-06-30",
+        "count": 1
+      },
+      {
+        "period": "2024-09-08",
+        "count": 1
+      },
+      {
+        "period": "2024-09-11",
+        "count": 1
+      },
+      {
+        "period": "2024-11-06",
+        "count": 1
+      },
+      {
+        "period": "2024-12-20",
+        "count": 1
+      },
+      {
+        "period": "2025-01-13",
+        "count": 1
+      },
+      {
+        "period": "2025-06-01",
+        "count": 1
+      },
+      {
+        "period": "2025-08-04",
+        "count": 1
+      },
+      {
+        "period": "2025-08-06",
+        "count": 1
+      },
+      {
+        "period": "2025-09-01",
+        "count": 1
+      },
+      {
+        "period": "2025-09-26",
+        "count": 1
+      },
+      {
+        "period": "2025-10-01",
+        "count": 1
+      },
+      {
+        "period": "2025-11-03",
+        "count": 1
+      },
+      {
+        "period": "2025-11-20",
+        "count": 1
+      },
+      {
+        "period": "2025-12-16",
+        "count": 1
+      },
+      {
+        "period": "2025-12-17",
+        "count": 1
+      },
+      {
+        "period": "2026-01-10",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 21
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 11
+      },
+      {
+        "org_size": "Small",
+        "count": 5
+      },
+      {
+        "org_size": "Medium",
+        "count": 5
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AK",
+        "city": "North Judithbury",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      },
+      {
+        "state": "VT",
+        "city": "Ortizmouth",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Hortonberg",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "South Rachelborough",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "Mitchellside",
+        "count": 1
+      },
+      {
+        "state": "NV",
+        "city": "Leehaven",
+        "count": 1
+      },
+      {
+        "state": "NJ",
+        "city": "South Williamton",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "Robertfort",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Williamview",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Burchborough",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "CA",
+        "city": "New Susanville",
+        "count": 1
+      },
+      {
+        "state": "AZ",
+        "city": "Kyleborough",
+        "count": 1
+      },
+      {
+        "state": "WI",
+        "city": "Thomasberg",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 11
+      },
+      {
+        "category": "non_collaborator",
+        "count": 10
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 10
+      },
+      {
+        "category": "non_contributor",
+        "count": 11
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Overview - filtered (is_collaborator=true)
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "is_collaborator": true,
+  "time_filter": "ALL"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 21,
+      "non_profit_organizations": 11,
+      "for_profit_organizations": 10,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 0,
+      "contributor_organizations": 0,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09-20",
+        "count": 1
+      },
+      {
+        "period": "2023-11-03",
+        "count": 1
+      },
+      {
+        "period": "2024-02-06",
+        "count": 1
+      },
+      {
+        "period": "2024-02-22",
+        "count": 1
+      },
+      {
+        "period": "2024-04-03",
+        "count": 1
+      },
+      {
+        "period": "2024-07-12",
+        "count": 1
+      },
+      {
+        "period": "2024-08-02",
+        "count": 1
+      },
+      {
+        "period": "2024-08-04",
+        "count": 1
+      },
+      {
+        "period": "2024-09-08",
+        "count": 1
+      },
+      {
+        "period": "2024-09-11",
+        "count": 1
+      },
+      {
+        "period": "2024-11-06",
+        "count": 1
+      },
+      {
+        "period": "2024-11-15",
+        "count": 1
+      },
+      {
+        "period": "2024-12-20",
+        "count": 1
+      },
+      {
+        "period": "2025-01-05",
+        "count": 1
+      },
+      {
+        "period": "2025-04-05",
+        "count": 1
+      },
+      {
+        "period": "2025-08-04",
+        "count": 1
+      },
+      {
+        "period": "2025-09-03",
+        "count": 1
+      },
+      {
+        "period": "2025-09-26",
+        "count": 1
+      },
+      {
+        "period": "2025-10-01",
+        "count": 1
+      },
+      {
+        "period": "2025-11-03",
+        "count": 1
+      },
+      {
+        "period": "2025-12-17",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 11
+      },
+      {
+        "org_type": "For-profit",
+        "count": 10
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 11
+      },
+      {
+        "org_size": "Small",
+        "count": 5
+      },
+      {
+        "org_size": "Medium",
+        "count": 5
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AL",
+        "city": "Smithberg",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "VA",
+        "city": "Sandrastad",
+        "count": 1
+      },
+      {
+        "state": "UT",
+        "city": "New Thomas",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "South Rachelborough",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "Mitchellside",
+        "count": 1
+      },
+      {
+        "state": "OR",
+        "city": "Johnberg",
+        "count": 1
+      },
+      {
+        "state": "OK",
+        "city": "Jeremyburgh",
+        "count": 1
+      },
+      {
+        "state": "NV",
+        "city": "Leehaven",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Wendyville",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "Robertfort",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "New Amyhaven",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "Lake Debbie",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "North Jamesborough",
+        "count": 1
+      },
+      {
+        "state": "CA",
+        "city": "New Susanville",
+        "count": 1
+      },
+      {
+        "state": "AZ",
+        "city": "Kyleborough",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 21
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "non_contributor",
+        "count": 21
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Overview - filtered (is_contributor=true)
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "is_contributor": true,
+  "time_filter": "ALL"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 40,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 19,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 19,
+      "contributor_organizations": 19,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09-08",
+        "count": 1
+      },
+      {
+        "period": "2023-09-20",
+        "count": 1
+      },
+      {
+        "period": "2023-11-03",
+        "count": 1
+      },
+      {
+        "period": "2023-12-13",
+        "count": 1
+      },
+      {
+        "period": "2023-12-27",
+        "count": 1
+      },
+      {
+        "period": "2024-02-06",
+        "count": 1
+      },
+      {
+        "period": "2024-02-22",
+        "count": 1
+      },
+      {
+        "period": "2024-04-03",
+        "count": 1
+      },
+      {
+        "period": "2024-04-10",
+        "count": 1
+      },
+      {
+        "period": "2024-06-30",
+        "count": 1
+      },
+      {
+        "period": "2024-07-12",
+        "count": 1
+      },
+      {
+        "period": "2024-07-31",
+        "count": 1
+      },
+      {
+        "period": "2024-08-02",
+        "count": 1
+      },
+      {
+        "period": "2024-08-04",
+        "count": 1
+      },
+      {
+        "period": "2024-09-06",
+        "count": 1
+      },
+      {
+        "period": "2024-09-08",
+        "count": 1
+      },
+      {
+        "period": "2024-09-11",
+        "count": 1
+      },
+      {
+        "period": "2024-11-06",
+        "count": 1
+      },
+      {
+        "period": "2024-11-15",
+        "count": 1
+      },
+      {
+        "period": "2024-12-20",
+        "count": 1
+      },
+      {
+        "period": "2025-01-05",
+        "count": 1
+      },
+      {
+        "period": "2025-01-08",
+        "count": 1
+      },
+      {
+        "period": "2025-01-13",
+        "count": 1
+      },
+      {
+        "period": "2025-04-05",
+        "count": 1
+      },
+      {
+        "period": "2025-06-01",
+        "count": 1
+      },
+      {
+        "period": "2025-08-01",
+        "count": 2
+      },
+      {
+        "period": "2025-08-04",
+        "count": 1
+      },
+      {
+        "period": "2025-08-06",
+        "count": 1
+      },
+      {
+        "period": "2025-09-01",
+        "count": 1
+      },
+      {
+        "period": "2025-09-03",
+        "count": 1
+      },
+      {
+        "period": "2025-09-26",
+        "count": 1
+      },
+      {
+        "period": "2025-10-01",
+        "count": 1
+      },
+      {
+        "period": "2025-11-03",
+        "count": 1
+      },
+      {
+        "period": "2025-11-20",
+        "count": 1
+      },
+      {
+        "period": "2025-11-28",
+        "count": 1
+      },
+      {
+        "period": "2025-12-16",
+        "count": 1
+      },
+      {
+        "period": "2025-12-17",
+        "count": 1
+      },
+      {
+        "period": "2025-12-19",
+        "count": 1
+      },
+      {
+        "period": "2026-01-10",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "count": 19
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 21
+      },
+      {
+        "org_size": "Small",
+        "count": 10
+      },
+      {
+        "org_size": "Medium",
+        "count": 9
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AK",
+        "city": "North Judithbury",
+        "count": 1
+      },
+      {
+        "state": "AL",
+        "city": "Smithberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Ronaldview",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "NJ",
+        "city": "South Williamton",
+        "count": 1
+      },
+      {
+        "state": "NV",
+        "city": "Leehaven",
+        "count": 1
+      },
+      {
+        "state": "OH",
+        "city": "South Jeffrey",
+        "count": 1
+      },
+      {
+        "state": "OK",
+        "city": "Jeremyburgh",
+        "count": 1
+      },
+      {
+        "state": "OR",
+        "city": "Johnberg",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "Mitchellside",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "South Rachelborough",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Hortonberg",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      },
+      {
+        "state": "UT",
+        "city": "New Thomas",
+        "count": 1
+      },
+      {
+        "state": "VA",
+        "city": "Sandrastad",
+        "count": 1
+      },
+      {
+        "state": "VT",
+        "city": "Ortizmouth",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      },
+      {
+        "state": "WI",
+        "city": "Thomasberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Williamview",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Wendyville",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "West Erik",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "East Amanda",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "Robertfort",
+        "count": 1
+      },
+      {
+        "state": "AZ",
+        "city": "Kyleborough",
+        "count": 1
+      },
+      {
+        "state": "CA",
+        "city": "New Susanville",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "North Jamesborough",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "Lake Debbie",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "North Donnaport",
+        "count": 1
+      },
+      {
+        "state": "MO",
+        "city": "Lake Deniseville",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "South Monicamouth",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Burchborough",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Port Andrew",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "New Amyhaven",
+        "count": 1
+      },
+      {
+        "state": "WY",
+        "city": "Kingborough",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 21
+      },
+      {
+        "category": "non_collaborator",
+        "count": 19
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 19
+      },
+      {
+        "category": "non_contributor",
+        "count": 21
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Overview - CUSTOM date range
+
+Request filters:
+```json
+{
+  "dashboard_type": "overview",
+  "time_filter": "CUSTOM",
+  "start_date": "2025-01-01",
+  "end_date": "2025-12-31"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 19,
+      "non_profit_organizations": 11,
+      "for_profit_organizations": 8,
+      "collaborator_organizations": 8,
+      "non_collaborator_organizations": 11,
+      "contributor_organizations": 11,
+      "non_contributor_organizations": 8
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2025-01-05",
+        "count": 1
+      },
+      {
+        "period": "2025-01-08",
+        "count": 1
+      },
+      {
+        "period": "2025-01-13",
+        "count": 1
+      },
+      {
+        "period": "2025-04-05",
+        "count": 1
+      },
+      {
+        "period": "2025-06-01",
+        "count": 1
+      },
+      {
+        "period": "2025-08-01",
+        "count": 2
+      },
+      {
+        "period": "2025-08-04",
+        "count": 1
+      },
+      {
+        "period": "2025-08-06",
+        "count": 1
+      },
+      {
+        "period": "2025-09-01",
+        "count": 1
+      },
+      {
+        "period": "2025-09-03",
+        "count": 1
+      },
+      {
+        "period": "2025-09-26",
+        "count": 1
+      },
+      {
+        "period": "2025-10-01",
+        "count": 1
+      },
+      {
+        "period": "2025-11-03",
+        "count": 1
+      },
+      {
+        "period": "2025-11-20",
+        "count": 1
+      },
+      {
+        "period": "2025-11-28",
+        "count": 1
+      },
+      {
+        "period": "2025-12-16",
+        "count": 1
+      },
+      {
+        "period": "2025-12-17",
+        "count": 1
+      },
+      {
+        "period": "2025-12-19",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 11
+      },
+      {
+        "org_type": "For-profit",
+        "count": 8
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 13
+      },
+      {
+        "org_size": "Small",
+        "count": 4
+      },
+      {
+        "org_size": "Medium",
+        "count": 2
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AK",
+        "city": "North Judithbury",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "UT",
+        "city": "New Thomas",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "OK",
+        "city": "Jeremyburgh",
+        "count": 1
+      },
+      {
+        "state": "OH",
+        "city": "South Jeffrey",
+        "count": 1
+      },
+      {
+        "state": "NJ",
+        "city": "South Williamton",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Williamview",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "East Amanda",
+        "count": 1
+      },
+      {
+        "state": "MO",
+        "city": "Lake Deniseville",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Port Andrew",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "South Monicamouth",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 8
+      },
+      {
+        "category": "non_collaborator",
+        "count": 11
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 11
+      },
+      {
+        "category": "non_contributor",
+        "count": 8
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Performance - ALL
+
+Request filters:
+```json
+{
+  "dashboard_type": "performance",
+  "time_filter": "ALL"
+}
+```
+
+Response:
+```json
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.23,
+      "rated_organizations": 40,
+      "unrated_organizations": 0,
+      "five_star_organizations": 12
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 5
+      },
+      {
+        "rating": 2,
+        "count": 9
+      },
+      {
+        "rating": 3,
+        "count": 10
+      },
+      {
+        "rating": 4,
+        "count": 4
+      },
+      {
+        "rating": 5,
+        "count": 12
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      },
+      {
+        "org_id": "ORG00027",
+        "org_name": "Silverline Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Wendyville",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00020",
+        "org_name": "Lakeside Legal Aid Society",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Barkerfurt",
+        "state_id": "NE"
+      },
+      {
+        "org_id": "ORG00023",
+        "org_name": "Maplewood Veterans Support",
+        "org_type": "For-profit",
+        "org_size": "Medium",
+        "org_rating": 4.0,
+        "city_name": "Smithberg",
+        "state_id": "AL"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "South Williamton",
+        "state_id": "NJ"
+      },
+      {
+        "org_id": "ORG00035",
+        "org_name": "Summit Relief Network",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Ortizmouth",
+        "state_id": "VT"
+      },
+      {
+        "org_id": "ORG00015",
+        "org_name": "Unity Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Port Andrew",
+        "state_id": "KS"
+      },
+      {
+        "org_id": "ORG00006",
+        "org_name": "Harbor Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Medium",
+        "org_rating": 3.0,
+        "city_name": "Lake Deniseville",
+        "state_id": "MO"
+      },
+      {
+        "org_id": "ORG00024",
+        "org_name": "Liberty Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "East Amanda",
+        "state_id": "AR"
+      },
+      {
+        "org_id": "ORG00025",
+        "org_name": "Maplewood Animal Rescue",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "Victoriaport",
+        "state_id": "TX"
+      },
+      {
+        "org_id": "ORG00003",
+        "org_name": "Northgate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 3.0,
+        "city_name": "Thomasberg",
+        "state_id": "WI"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "org_type": "Non-Profit",
+        "average_rating": 3.62,
+        "rated_count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "average_rating": 2.79,
+        "rated_count": 19
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "org_size": "Small",
+        "average_rating": 3.5,
+        "rated_count": 10
+      },
+      {
+        "org_size": "Large",
+        "average_rating": 3.24,
+        "rated_count": 21
+      },
+      {
+        "org_size": "Medium",
+        "average_rating": 2.89,
+        "rated_count": 9
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Performance - filtered (org_rating=5)
+
+Request filters:
+```json
+{
+  "dashboard_type": "performance",
+  "org_rating": 5,
+  "time_filter": "ALL"
+}
+```
+
+Response:
+```json
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 5.0,
+      "rated_organizations": 12,
+      "unrated_organizations": 0,
+      "five_star_organizations": 12
+    },
+    "rating_distribution": [
+      {
+        "rating": 5,
+        "count": 12
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      },
+      {
+        "org_id": "ORG00027",
+        "org_name": "Silverline Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Wendyville",
+        "state_id": "MT"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "South Williamton",
+        "state_id": "NJ"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "org_type": "For-profit",
+        "average_rating": 5.0,
+        "rated_count": 3
+      },
+      {
+        "org_type": "Non-Profit",
+        "average_rating": 5.0,
+        "rated_count": 9
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "org_size": "Large",
+        "average_rating": 5.0,
+        "rated_count": 6
+      },
+      {
+        "org_size": "Medium",
+        "average_rating": 5.0,
+        "rated_count": 1
+      },
+      {
+        "org_size": "Small",
+        "average_rating": 5.0,
+        "rated_count": 5
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Performance - filtered (org_size=Large)
+
+Request filters:
+```json
+{
+  "dashboard_type": "performance",
+  "org_size": "Large",
+  "time_filter": "ALL"
+}
+```
+
+Response:
+```json
+{
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.24,
+      "rated_organizations": 21,
+      "unrated_organizations": 0,
+      "five_star_organizations": 6
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 2
+      },
+      {
+        "rating": 2,
+        "count": 6
+      },
+      {
+        "rating": 3,
+        "count": 4
+      },
+      {
+        "rating": 4,
+        "count": 3
+      },
+      {
+        "rating": 5,
+        "count": 6
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "South Williamton",
+        "state_id": "NJ"
+      },
+      {
+        "org_id": "ORG00020",
+        "org_name": "Lakeside Legal Aid Society",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Barkerfurt",
+        "state_id": "NE"
+      },
+      {
+        "org_id": "ORG00035",
+        "org_name": "Summit Relief Network",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Ortizmouth",
+        "state_id": "VT"
+      },
+      {
+        "org_id": "ORG00015",
+        "org_name": "Unity Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Port Andrew",
+        "state_id": "KS"
+      },
+      {
+        "org_id": "ORG00012",
+        "org_name": "Harbor Animal Rescue",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "New Thomas",
+        "state_id": "UT"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      },
+      {
+        "org_id": "ORG00020",
+        "org_name": "Lakeside Legal Aid Society",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Barkerfurt",
+        "state_id": "NE"
+      },
+      {
+        "org_id": "ORG00012",
+        "org_name": "Harbor Animal Rescue",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "New Thomas",
+        "state_id": "UT"
+      },
+      {
+        "org_id": "ORG00021",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 2.0,
+        "city_name": "Robertfort",
+        "state_id": "AR"
+      },
+      {
+        "org_id": "ORG00017",
+        "org_name": "Liberty Education Fund",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 2.0,
+        "city_name": "East Jenniferfort",
+        "state_id": "TX"
+      },
+      {
+        "org_id": "ORG00016",
+        "org_name": "Meadowbrook Legal Aid Society",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 2.0,
+        "city_name": "West Amandastad",
+        "state_id": "FL"
+      },
+      {
+        "org_id": "ORG00018",
+        "org_name": "Sunrise Community Foundation",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 2.0,
+        "city_name": "Jeremyburgh",
+        "state_id": "OK"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "South Williamton",
+        "state_id": "NJ"
+      },
+      {
+        "org_id": "ORG00035",
+        "org_name": "Summit Relief Network",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Ortizmouth",
+        "state_id": "VT"
+      },
+      {
+        "org_id": "ORG00015",
+        "org_name": "Unity Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Port Andrew",
+        "state_id": "KS"
+      },
+      {
+        "org_id": "ORG00024",
+        "org_name": "Liberty Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "East Amanda",
+        "state_id": "AR"
+      },
+      {
+        "org_id": "ORG00025",
+        "org_name": "Maplewood Animal Rescue",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "Victoriaport",
+        "state_id": "TX"
+      },
+      {
+        "org_id": "ORG00030",
+        "org_name": "Pinecrest Arts Collective",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "Ronaldview",
+        "state_id": "NC"
+      },
+      {
+        "org_id": "ORG00002",
+        "org_name": "Summit Community Foundation",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 2.0,
+        "city_name": "North Donnaport",
+        "state_id": "IN"
+      },
+      {
+        "org_id": "ORG00033",
+        "org_name": "Cedar Valley Health Initiative",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 1.0,
+        "city_name": "South Monicamouth",
+        "state_id": "IN"
+      },
+      {
+        "org_id": "ORG00026",
+        "org_name": "Lakeside Food Bank",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 1.0,
+        "city_name": "Robinfort",
+        "state_id": "NC"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "org_type": "Non-Profit",
+        "average_rating": 3.73,
+        "rated_count": 11
+      },
+      {
+        "org_type": "For-profit",
+        "average_rating": 2.7,
+        "rated_count": 10
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "org_size": "Large",
+        "average_rating": 3.24,
+        "rated_count": 21
+      }
+    ]
+  }
+}
+```
+
+## Scenario: Both dashboards - ALL
+
+Request filters:
+```json
+{
+  "dashboard_type": "both",
+  "time_filter": "ALL",
+  "group_by": "monthly"
+}
+```
+
+Response:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 40,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 19,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 19,
+      "contributor_organizations": 19,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09",
+        "count": 2
+      },
+      {
+        "period": "2023-11",
+        "count": 1
+      },
+      {
+        "period": "2023-12",
+        "count": 2
+      },
+      {
+        "period": "2024-02",
+        "count": 2
+      },
+      {
+        "period": "2024-04",
+        "count": 2
+      },
+      {
+        "period": "2024-06",
+        "count": 1
+      },
+      {
+        "period": "2024-07",
+        "count": 2
+      },
+      {
+        "period": "2024-08",
+        "count": 2
+      },
+      {
+        "period": "2024-09",
+        "count": 3
+      },
+      {
+        "period": "2024-11",
+        "count": 2
+      },
+      {
+        "period": "2024-12",
+        "count": 1
+      },
+      {
+        "period": "2025-01",
+        "count": 3
+      },
+      {
+        "period": "2025-04",
+        "count": 1
+      },
+      {
+        "period": "2025-06",
+        "count": 1
+      },
+      {
+        "period": "2025-08",
+        "count": 4
+      },
+      {
+        "period": "2025-09",
+        "count": 3
+      },
+      {
+        "period": "2025-10",
+        "count": 1
+      },
+      {
+        "period": "2025-11",
+        "count": 3
+      },
+      {
+        "period": "2025-12",
+        "count": 3
+      },
+      {
+        "period": "2026-01",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "count": 19
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 21
+      },
+      {
+        "org_size": "Small",
+        "count": 10
+      },
+      {
+        "org_size": "Medium",
+        "count": 9
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AK",
+        "city": "North Judithbury",
+        "count": 1
+      },
+      {
+        "state": "AL",
+        "city": "Smithberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Ronaldview",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "NJ",
+        "city": "South Williamton",
+        "count": 1
+      },
+      {
+        "state": "NV",
+        "city": "Leehaven",
+        "count": 1
+      },
+      {
+        "state": "OH",
+        "city": "South Jeffrey",
+        "count": 1
+      },
+      {
+        "state": "OK",
+        "city": "Jeremyburgh",
+        "count": 1
+      },
+      {
+        "state": "OR",
+        "city": "Johnberg",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "Mitchellside",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "South Rachelborough",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Hortonberg",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      },
+      {
+        "state": "UT",
+        "city": "New Thomas",
+        "count": 1
+      },
+      {
+        "state": "VA",
+        "city": "Sandrastad",
+        "count": 1
+      },
+      {
+        "state": "VT",
+        "city": "Ortizmouth",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      },
+      {
+        "state": "WI",
+        "city": "Thomasberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Williamview",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Wendyville",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "West Erik",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "East Amanda",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "Robertfort",
+        "count": 1
+      },
+      {
+        "state": "AZ",
+        "city": "Kyleborough",
+        "count": 1
+      },
+      {
+        "state": "CA",
+        "city": "New Susanville",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "North Jamesborough",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "Lake Debbie",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "North Donnaport",
+        "count": 1
+      },
+      {
+        "state": "MO",
+        "city": "Lake Deniseville",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "South Monicamouth",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Burchborough",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Port Andrew",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "New Amyhaven",
+        "count": 1
+      },
+      {
+        "state": "WY",
+        "city": "Kingborough",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 21
+      },
+      {
+        "category": "non_collaborator",
+        "count": 19
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 19
+      },
+      {
+        "category": "non_contributor",
+        "count": 21
+      }
+    ]
+  },
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.23,
+      "rated_organizations": 40,
+      "unrated_organizations": 0,
+      "five_star_organizations": 12
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 5
+      },
+      {
+        "rating": 2,
+        "count": 9
+      },
+      {
+        "rating": 3,
+        "count": 10
+      },
+      {
+        "rating": 4,
+        "count": 4
+      },
+      {
+        "rating": 5,
+        "count": 12
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      },
+      {
+        "org_id": "ORG00027",
+        "org_name": "Silverline Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Wendyville",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00020",
+        "org_name": "Lakeside Legal Aid Society",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Barkerfurt",
+        "state_id": "NE"
+      },
+      {
+        "org_id": "ORG00023",
+        "org_name": "Maplewood Veterans Support",
+        "org_type": "For-profit",
+        "org_size": "Medium",
+        "org_rating": 4.0,
+        "city_name": "Smithberg",
+        "state_id": "AL"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "South Williamton",
+        "state_id": "NJ"
+      },
+      {
+        "org_id": "ORG00035",
+        "org_name": "Summit Relief Network",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Ortizmouth",
+        "state_id": "VT"
+      },
+      {
+        "org_id": "ORG00015",
+        "org_name": "Unity Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Port Andrew",
+        "state_id": "KS"
+      },
+      {
+        "org_id": "ORG00006",
+        "org_name": "Harbor Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Medium",
+        "org_rating": 3.0,
+        "city_name": "Lake Deniseville",
+        "state_id": "MO"
+      },
+      {
+        "org_id": "ORG00024",
+        "org_name": "Liberty Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "East Amanda",
+        "state_id": "AR"
+      },
+      {
+        "org_id": "ORG00025",
+        "org_name": "Maplewood Animal Rescue",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "Victoriaport",
+        "state_id": "TX"
+      },
+      {
+        "org_id": "ORG00003",
+        "org_name": "Northgate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 3.0,
+        "city_name": "Thomasberg",
+        "state_id": "WI"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "org_type": "Non-Profit",
+        "average_rating": 3.62,
+        "rated_count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "average_rating": 2.79,
+        "rated_count": 19
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "org_size": "Small",
+        "average_rating": 3.5,
+        "rated_count": 10
+      },
+      {
+        "org_size": "Large",
+        "average_rating": 3.24,
+        "rated_count": 21
+      },
+      {
+        "org_size": "Medium",
+        "average_rating": 2.89,
+        "rated_count": 9
+      }
+    ]
+  }
+}
+```
+
+## Scenario: lambda_handler(event) end-to-end
+
+Event:
+```json
+{
+  "body": "{\"dashboard_type\": \"both\", \"time_filter\": \"ALL\"}"
+}
+```
+
+statusCode: 200
+
+Response body:
+```json
+{
+  "organization_overview": {
+    "summary": {
+      "total_organizations": 40,
+      "non_profit_organizations": 21,
+      "for_profit_organizations": 19,
+      "collaborator_organizations": 21,
+      "non_collaborator_organizations": 19,
+      "contributor_organizations": 19,
+      "non_contributor_organizations": 21
+    },
+    "organization_activity_trend": [
+      {
+        "period": "2023-09-08",
+        "count": 1
+      },
+      {
+        "period": "2023-09-20",
+        "count": 1
+      },
+      {
+        "period": "2023-11-03",
+        "count": 1
+      },
+      {
+        "period": "2023-12-13",
+        "count": 1
+      },
+      {
+        "period": "2023-12-27",
+        "count": 1
+      },
+      {
+        "period": "2024-02-06",
+        "count": 1
+      },
+      {
+        "period": "2024-02-22",
+        "count": 1
+      },
+      {
+        "period": "2024-04-03",
+        "count": 1
+      },
+      {
+        "period": "2024-04-10",
+        "count": 1
+      },
+      {
+        "period": "2024-06-30",
+        "count": 1
+      },
+      {
+        "period": "2024-07-12",
+        "count": 1
+      },
+      {
+        "period": "2024-07-31",
+        "count": 1
+      },
+      {
+        "period": "2024-08-02",
+        "count": 1
+      },
+      {
+        "period": "2024-08-04",
+        "count": 1
+      },
+      {
+        "period": "2024-09-06",
+        "count": 1
+      },
+      {
+        "period": "2024-09-08",
+        "count": 1
+      },
+      {
+        "period": "2024-09-11",
+        "count": 1
+      },
+      {
+        "period": "2024-11-06",
+        "count": 1
+      },
+      {
+        "period": "2024-11-15",
+        "count": 1
+      },
+      {
+        "period": "2024-12-20",
+        "count": 1
+      },
+      {
+        "period": "2025-01-05",
+        "count": 1
+      },
+      {
+        "period": "2025-01-08",
+        "count": 1
+      },
+      {
+        "period": "2025-01-13",
+        "count": 1
+      },
+      {
+        "period": "2025-04-05",
+        "count": 1
+      },
+      {
+        "period": "2025-06-01",
+        "count": 1
+      },
+      {
+        "period": "2025-08-01",
+        "count": 2
+      },
+      {
+        "period": "2025-08-04",
+        "count": 1
+      },
+      {
+        "period": "2025-08-06",
+        "count": 1
+      },
+      {
+        "period": "2025-09-01",
+        "count": 1
+      },
+      {
+        "period": "2025-09-03",
+        "count": 1
+      },
+      {
+        "period": "2025-09-26",
+        "count": 1
+      },
+      {
+        "period": "2025-10-01",
+        "count": 1
+      },
+      {
+        "period": "2025-11-03",
+        "count": 1
+      },
+      {
+        "period": "2025-11-20",
+        "count": 1
+      },
+      {
+        "period": "2025-11-28",
+        "count": 1
+      },
+      {
+        "period": "2025-12-16",
+        "count": 1
+      },
+      {
+        "period": "2025-12-17",
+        "count": 1
+      },
+      {
+        "period": "2025-12-19",
+        "count": 1
+      },
+      {
+        "period": "2026-01-10",
+        "count": 1
+      }
+    ],
+    "organizations_by_type": [
+      {
+        "org_type": "Non-Profit",
+        "count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "count": 19
+      }
+    ],
+    "organizations_by_size": [
+      {
+        "org_size": "Large",
+        "count": 21
+      },
+      {
+        "org_size": "Small",
+        "count": 10
+      },
+      {
+        "org_size": "Medium",
+        "count": 9
+      }
+    ],
+    "organizations_by_location": [
+      {
+        "state": "AK",
+        "city": "North Judithbury",
+        "count": 1
+      },
+      {
+        "state": "AL",
+        "city": "Smithberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Ronaldview",
+        "count": 1
+      },
+      {
+        "state": "NE",
+        "city": "Barkerfurt",
+        "count": 1
+      },
+      {
+        "state": "NJ",
+        "city": "South Williamton",
+        "count": 1
+      },
+      {
+        "state": "NV",
+        "city": "Leehaven",
+        "count": 1
+      },
+      {
+        "state": "OH",
+        "city": "South Jeffrey",
+        "count": 1
+      },
+      {
+        "state": "OK",
+        "city": "Jeremyburgh",
+        "count": 1
+      },
+      {
+        "state": "OR",
+        "city": "Johnberg",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "Mitchellside",
+        "count": 1
+      },
+      {
+        "state": "RI",
+        "city": "South Rachelborough",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "East Jenniferfort",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Hortonberg",
+        "count": 1
+      },
+      {
+        "state": "TX",
+        "city": "Victoriaport",
+        "count": 1
+      },
+      {
+        "state": "UT",
+        "city": "New Thomas",
+        "count": 1
+      },
+      {
+        "state": "VA",
+        "city": "Sandrastad",
+        "count": 1
+      },
+      {
+        "state": "VT",
+        "city": "Ortizmouth",
+        "count": 1
+      },
+      {
+        "state": "WA",
+        "city": "Stephaniemouth",
+        "count": 1
+      },
+      {
+        "state": "WI",
+        "city": "Thomasberg",
+        "count": 1
+      },
+      {
+        "state": "NC",
+        "city": "Robinfort",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Williamview",
+        "count": 1
+      },
+      {
+        "state": "MT",
+        "city": "Wendyville",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "West Erik",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "East Amanda",
+        "count": 1
+      },
+      {
+        "state": "AR",
+        "city": "Robertfort",
+        "count": 1
+      },
+      {
+        "state": "AZ",
+        "city": "Kyleborough",
+        "count": 1
+      },
+      {
+        "state": "CA",
+        "city": "New Susanville",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "North Jamesborough",
+        "count": 1
+      },
+      {
+        "state": "FL",
+        "city": "West Amandastad",
+        "count": 1
+      },
+      {
+        "state": "IA",
+        "city": "Lake Debbie",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "North Donnaport",
+        "count": 1
+      },
+      {
+        "state": "MO",
+        "city": "Lake Deniseville",
+        "count": 1
+      },
+      {
+        "state": "IN",
+        "city": "South Monicamouth",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Burchborough",
+        "count": 1
+      },
+      {
+        "state": "KS",
+        "city": "Port Andrew",
+        "count": 1
+      },
+      {
+        "state": "ME",
+        "city": "Martinezbury",
+        "count": 1
+      },
+      {
+        "state": "MI",
+        "city": "West Williamport",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "Lake Nancyview",
+        "count": 1
+      },
+      {
+        "state": "MN",
+        "city": "New Amyhaven",
+        "count": 1
+      },
+      {
+        "state": "WY",
+        "city": "Kingborough",
+        "count": 1
+      }
+    ],
+    "collaborator_distribution": [
+      {
+        "category": "collaborator",
+        "count": 21
+      },
+      {
+        "category": "non_collaborator",
+        "count": 19
+      }
+    ],
+    "contributor_distribution": [
+      {
+        "category": "contributor",
+        "count": 19
+      },
+      {
+        "category": "non_contributor",
+        "count": 21
+      }
+    ]
+  },
+  "organization_performance": {
+    "summary": {
+      "average_rating": 3.23,
+      "rated_organizations": 40,
+      "unrated_organizations": 0,
+      "five_star_organizations": 12
+    },
+    "rating_distribution": [
+      {
+        "rating": 1,
+        "count": 5
+      },
+      {
+        "rating": 2,
+        "count": 9
+      },
+      {
+        "rating": 3,
+        "count": 10
+      },
+      {
+        "rating": 4,
+        "count": 4
+      },
+      {
+        "rating": 5,
+        "count": 12
+      }
+    ],
+    "top_rated_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      }
+    ],
+    "top_collaborator_organizations": [
+      {
+        "org_id": "ORG00019",
+        "org_name": "Cedar Valley Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "New Susanville",
+        "state_id": "CA"
+      },
+      {
+        "org_id": "ORG00036",
+        "org_name": "Golden Gate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Kyleborough",
+        "state_id": "AZ"
+      },
+      {
+        "org_id": "ORG00004",
+        "org_name": "Harbor Family Services",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Nancyview",
+        "state_id": "MN"
+      },
+      {
+        "org_id": "ORG00011",
+        "org_name": "Hopewell Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 5.0,
+        "city_name": "South Rachelborough",
+        "state_id": "RI"
+      },
+      {
+        "org_id": "ORG00031",
+        "org_name": "Maplewood Housing Trust",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Sandrastad",
+        "state_id": "VA"
+      },
+      {
+        "org_id": "ORG00022",
+        "org_name": "Meadowbrook Housing Trust",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Leehaven",
+        "state_id": "NV"
+      },
+      {
+        "org_id": "ORG00008",
+        "org_name": "Riverside Environmental Coalition",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "Lake Debbie",
+        "state_id": "IA"
+      },
+      {
+        "org_id": "ORG00027",
+        "org_name": "Silverline Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Wendyville",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00020",
+        "org_name": "Lakeside Legal Aid Society",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Barkerfurt",
+        "state_id": "NE"
+      },
+      {
+        "org_id": "ORG00023",
+        "org_name": "Maplewood Veterans Support",
+        "org_type": "For-profit",
+        "org_size": "Medium",
+        "org_rating": 4.0,
+        "city_name": "Smithberg",
+        "state_id": "AL"
+      }
+    ],
+    "top_contributor_organizations": [
+      {
+        "org_id": "ORG00001",
+        "org_name": "Harbor Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "North Judithbury",
+        "state_id": "AK"
+      },
+      {
+        "org_id": "ORG00009",
+        "org_name": "Lakeside Veterans Support",
+        "org_type": "Non-Profit",
+        "org_size": "Small",
+        "org_rating": 5.0,
+        "city_name": "Williamview",
+        "state_id": "MT"
+      },
+      {
+        "org_id": "ORG00034",
+        "org_name": "Northgate Community Foundation",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "West Williamport",
+        "state_id": "MI"
+      },
+      {
+        "org_id": "ORG00029",
+        "org_name": "Unity Youth Alliance",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 5.0,
+        "city_name": "South Williamton",
+        "state_id": "NJ"
+      },
+      {
+        "org_id": "ORG00035",
+        "org_name": "Summit Relief Network",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Ortizmouth",
+        "state_id": "VT"
+      },
+      {
+        "org_id": "ORG00015",
+        "org_name": "Unity Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 4.0,
+        "city_name": "Port Andrew",
+        "state_id": "KS"
+      },
+      {
+        "org_id": "ORG00006",
+        "org_name": "Harbor Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Medium",
+        "org_rating": 3.0,
+        "city_name": "Lake Deniseville",
+        "state_id": "MO"
+      },
+      {
+        "org_id": "ORG00024",
+        "org_name": "Liberty Senior Care Network",
+        "org_type": "For-profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "East Amanda",
+        "state_id": "AR"
+      },
+      {
+        "org_id": "ORG00025",
+        "org_name": "Maplewood Animal Rescue",
+        "org_type": "Non-Profit",
+        "org_size": "Large",
+        "org_rating": 3.0,
+        "city_name": "Victoriaport",
+        "state_id": "TX"
+      },
+      {
+        "org_id": "ORG00003",
+        "org_name": "Northgate Education Fund",
+        "org_type": "Non-Profit",
+        "org_size": "Medium",
+        "org_rating": 3.0,
+        "city_name": "Thomasberg",
+        "state_id": "WI"
+      }
+    ],
+    "ratings_by_organization_type": [
+      {
+        "org_type": "Non-Profit",
+        "average_rating": 3.62,
+        "rated_count": 21
+      },
+      {
+        "org_type": "For-profit",
+        "average_rating": 2.79,
+        "rated_count": 19
+      }
+    ],
+    "ratings_by_organization_size": [
+      {
+        "org_size": "Small",
+        "average_rating": 3.5,
+        "rated_count": 10
+      },
+      {
+        "org_size": "Large",
+        "average_rating": 3.24,
+        "rated_count": 21
+      },
+      {
+        "org_size": "Medium",
+        "average_rating": 2.89,
+        "rated_count": 9
+      }
+    ]
+  }
+}
+```
+
+## Scenario: lambda_handler(event) with invalid dashboard_type
+
+statusCode: 400
+
+Response body:
+```json
+{
+  "error": "Invalid dashboard_type. Expected 'overview', 'performance', or 'both'."
+}
+```
+
+## Summary
+
+✅ All 14 scenarios ran and all invariant checks passed.


### PR DESCRIPTION
Redo of the Organization Analytics API per review feedback: removes the direct
connection to the real Postgres DB via SSM credentials. This version reads only
from the mock data provided (data-analytics/sql/organizations.csv) and computes
both dashboards (overview + performance) locally with pandas.