### PR TITLE
#228: Align organization analytics with finalized dashboard requirements

### DIFF
--- a/data-analytics/docs/organization-analytics-api.md
+++ b/data-analytics/docs/organization-analytics-api.md
@@ -1,0 +1,115 @@
+# Organization Analytics API
+
+`POST /analytics/organizations` returns all three Organization Dashboard tabs in one response.
+
+## Local configuration
+
+The Lambda reads PostgreSQL connection settings from `DATABASE_URL` or from `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, and `DB_PASSWORD`. It does not read AWS Parameter Store.
+
+The ticket's state lookup table is `virginia_dev_saayam_rdbms.states`. For an older local Saayam schema that still uses the singular table name, set:
+
+```bash
+export SAAYAM_STATE_TABLE=state
+```
+
+The handler checks `information_schema.columns` for `organizations.is_contributor`. Until that migration is present, contributor counts safely return `0` while all other metrics continue to work.
+
+## Sample request
+
+```json
+{
+  "time_filter": "1Y",
+  "start_date": null,
+  "end_date": null,
+  "group_by": "monthly",
+  "region": "California",
+  "organization_type": "ALL"
+}
+```
+
+Other local/PR test payloads:
+
+```json
+{"time_filter":"30D","start_date":null,"end_date":null,"group_by":"daily","region":"ALL","organization_type":"ALL"}
+```
+
+```json
+{"time_filter":"1Y","start_date":null,"end_date":null,"group_by":"monthly","region":"ALL","organization_type":"ALL"}
+```
+
+```json
+{"time_filter":"1Y","start_date":null,"end_date":null,"group_by":"monthly","region":"ALL","organization_type":"non_profit"}
+```
+
+```json
+{"time_filter":"CUSTOM","start_date":"2026-01-01","end_date":"2026-06-30","group_by":"monthly","region":"ALL","organization_type":"ALL"}
+```
+
+Supported values:
+
+- `time_filter`: `7D`, `30D`, `1Y`, `ALL`, `CUSTOM`
+- `group_by`: `daily`, `weekly`, `monthly`, `yearly`
+- `organization_type`: `ALL`, `for_profit`, `non_profit`
+- `region`: `ALL`, a state name, or a state ID
+
+`CUSTOM` requires both dates in `YYYY-MM-DD` format. The full `end_date` is included.
+
+## Sample successful response body
+
+```json
+{
+  "summary": {
+    "total_organizations": 126,
+    "total_collaborators": 42,
+    "total_contributors": 84,
+    "average_org_rating": 4.2
+  },
+  "growth_trend": [
+    {
+      "period": "2026-01",
+      "total_organizations": 100,
+      "total_collaborators": 34
+    }
+  ],
+  "organizations_by_location": [
+    {
+      "state_id": "CA",
+      "state_name": "California",
+      "organization_count": 32,
+      "percentage": 25.4,
+      "cities": [
+        {"city_name": "Los Angeles", "organization_count": 12}
+      ]
+    }
+  ],
+  "organizations_by_size": [
+    {"org_size": "small", "organization_count": 50},
+    {"org_size": "medium", "organization_count": 45},
+    {"org_size": "large", "organization_count": 31}
+  ],
+  "collaborator_vs_contributor": [
+    {"type": "collaborator", "organization_count": 42, "percentage": 33.3},
+    {"type": "contributor", "organization_count": 84, "percentage": 66.7}
+  ],
+  "rating_distribution": [
+    {"rating": 1, "organization_count": 1},
+    {"rating": 2, "organization_count": 3},
+    {"rating": 3, "organization_count": 12},
+    {"rating": 4, "organization_count": 46},
+    {"rating": 5, "organization_count": 64}
+  ],
+  "organization_type_distribution": [
+    {"period": "2026-01", "for_profit": 41, "non_profit": 68, "total": 109}
+  ]
+}
+```
+
+API Gateway serializes this object in the response's `body` field. Invalid filters return HTTP `400`; a connection failure returns HTTP `500` with the stable empty dashboard structure.
+
+## Local unit tests
+
+```bash
+python -m unittest discover -s data-analytics/tests -p "test_*.py" -v
+```
+
+The tests mock the PostgreSQL connection and cursor. They cover the documented filters, invalid input, custom date ranges, empty results, a missing `is_contributor` migration, query rollback/fallback behavior, connection failures, response shape, and resource cleanup.

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,668 @@
+"""Organization-level analytics for the Saayam application dashboard.
+
+The handler accepts either an API Gateway event or a direct dictionary payload.
+Database credentials come only from local/runtime environment variables; this
+module intentionally does not use AWS Systems Manager Parameter Store.
+"""
+
+import json
+import logging
+import os
+import re
+from datetime import date, timedelta
+from decimal import Decimal
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+DEFAULT_SCHEMA = "virginia_dev_saayam_rdbms"
+VALID_TIME_FILTERS = {"7D", "30D", "1Y", "ALL", "CUSTOM"}
+GROUPINGS = {
+    "daily": ("day", "YYYY-MM-DD"),
+    "weekly": ("week", 'IYYY-"W"IW'),
+    "monthly": ("month", "YYYY-MM"),
+    "yearly": ("year", "YYYY"),
+}
+VALID_ORGANIZATION_TYPES = {"for_profit", "non_profit"}
+VALID_STATE_TABLES = {"state", "states"}
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+}
+
+
+class RequestValidationError(ValueError):
+    """Raised when request filters do not satisfy the API contract."""
+
+
+def build_response(status_code, body):
+    """Build an API Gateway-compatible JSON response."""
+    return {
+        "statusCode": status_code,
+        "headers": CORS_HEADERS,
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def _json_default(value):
+    """Serialize PostgreSQL numeric/date values returned by mocked or live cursors."""
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def get_default_response():
+    """Return the stable response shape used for empty data and failures."""
+    return {
+        "summary": {
+            "total_organizations": 0,
+            "total_collaborators": 0,
+            "total_contributors": 0,
+            "average_org_rating": 0.0,
+        },
+        "growth_trend": [],
+        "organizations_by_location": [],
+        "organizations_by_size": [],
+        "collaborator_vs_contributor": [],
+        "rating_distribution": [],
+        "organization_type_distribution": [],
+    }
+
+
+def parse_event_body(event):
+    """Normalize API Gateway and direct invocation events to a payload dictionary."""
+    if event is None:
+        return {}
+    if not isinstance(event, dict):
+        raise RequestValidationError("Request must be a JSON object")
+
+    body = event.get("body")
+    if body is None:
+        return event
+    if isinstance(body, dict):
+        return body
+    if isinstance(body, str):
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RequestValidationError(
+                "Request body must contain valid JSON"
+            ) from exc
+        if isinstance(parsed, dict):
+            return parsed
+    raise RequestValidationError("Request body must be a JSON object")
+
+
+def _parse_date(value, field_name):
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise RequestValidationError(
+            f"{field_name} must use YYYY-MM-DD format"
+        ) from exc
+
+
+def _normalize_org_type(value):
+    return str(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def validate_filters(payload):
+    """Validate and normalize the dashboard's shared filters."""
+    time_filter = str(payload.get("time_filter", "30D")).strip().upper()
+    if time_filter not in VALID_TIME_FILTERS:
+        raise RequestValidationError("time_filter must be 7D, 30D, 1Y, ALL, or CUSTOM")
+
+    group_by = str(payload.get("group_by", "daily")).strip().lower()
+    if group_by not in GROUPINGS:
+        raise RequestValidationError(
+            "group_by must be daily, weekly, monthly, or yearly"
+        )
+
+    start_date = _parse_date(payload.get("start_date"), "start_date")
+    end_date = _parse_date(payload.get("end_date"), "end_date")
+    if time_filter == "CUSTOM" and (start_date is None or end_date is None):
+        raise RequestValidationError(
+            "CUSTOM time_filter requires both start_date and end_date"
+        )
+    if start_date and end_date and start_date > end_date:
+        raise RequestValidationError("start_date cannot be after end_date")
+
+    raw_region = payload.get("region", "ALL")
+    region = "ALL" if raw_region is None else str(raw_region).strip()
+    if not region:
+        raise RequestValidationError("region cannot be empty")
+
+    raw_org_type = payload.get("organization_type", "ALL")
+    organization_type = (
+        "all" if raw_org_type is None else _normalize_org_type(raw_org_type)
+    )
+    if organization_type == "all":
+        organization_type = "ALL"
+    if organization_type != "ALL" and organization_type not in VALID_ORGANIZATION_TYPES:
+        raise RequestValidationError(
+            "organization_type must be ALL, for_profit, or non_profit"
+        )
+
+    return {
+        "time_filter": time_filter,
+        "start_date": start_date,
+        "end_date": end_date,
+        "group_by": group_by,
+        "region": region,
+        "organization_type": organization_type,
+    }
+
+
+def _validated_identifier(value, label):
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
+        raise ValueError(f"{label} must be a valid PostgreSQL identifier")
+    return value
+
+
+def get_database_layout():
+    """Return validated table identifiers used in query interpolation.
+
+    The current ticket names ``states``. Older Saayam schemas use ``state``;
+    local testing against those schemas can set ``SAAYAM_STATE_TABLE=state``.
+    """
+    schema = _validated_identifier(
+        os.environ.get("DB_SCHEMA", DEFAULT_SCHEMA), "DB_SCHEMA"
+    )
+    state_table = os.environ.get("SAAYAM_STATE_TABLE", "states")
+    if state_table not in VALID_STATE_TABLES:
+        raise ValueError("SAAYAM_STATE_TABLE must be 'state' or 'states'")
+    return schema, state_table
+
+
+def get_db_connection():
+    """Create a local/runtime PostgreSQL connection without AWS Parameter Store."""
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url:
+        return psycopg2.connect(database_url)
+
+    return psycopg2.connect(
+        host=os.environ.get("DB_HOST", os.environ.get("PGHOST", "localhost")),
+        dbname=os.environ.get("DB_NAME", os.environ.get("PGDATABASE", "saayam")),
+        user=os.environ.get("DB_USER", os.environ.get("PGUSER", "postgres")),
+        password=os.environ.get("DB_PASSWORD", os.environ.get("PGPASSWORD", "")),
+        port=int(os.environ.get("DB_PORT", os.environ.get("PGPORT", "5432"))),
+        connect_timeout=int(os.environ.get("DB_CONNECT_TIMEOUT", "10")),
+    )
+
+
+def contributor_column_exists(cursor, schema):
+    """Check whether the latest ``is_contributor`` migration is available."""
+    cursor.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = %s
+              AND table_name = 'organizations'
+              AND column_name = 'is_contributor'
+        ) AS exists
+        """,
+        (schema,),
+    )
+    row = cursor.fetchone()
+    return bool(row and row["exists"])
+
+
+def _from_clause(schema, state_table):
+    return (
+        f"FROM {schema}.organizations o "
+        f"LEFT JOIN {schema}.{state_table} s ON o.state_id = s.state_id"
+    )
+
+
+def _time_conditions(filters):
+    """Return window condition, baseline condition, and named parameters."""
+    time_filter = filters["time_filter"]
+    if time_filter == "7D":
+        boundary = "CURRENT_DATE - INTERVAL '7 days'"
+        return f"o.created_at >= {boundary}", f"o.created_at < {boundary}", {}
+    if time_filter == "30D":
+        boundary = "CURRENT_DATE - INTERVAL '30 days'"
+        return f"o.created_at >= {boundary}", f"o.created_at < {boundary}", {}
+    if time_filter == "1Y":
+        boundary = "CURRENT_DATE - INTERVAL '1 year'"
+        return f"o.created_at >= {boundary}", f"o.created_at < {boundary}", {}
+    if time_filter == "CUSTOM":
+        return (
+            "o.created_at >= %(start_date)s AND o.created_at < %(end_exclusive)s",
+            "o.created_at < %(start_date)s",
+            {
+                "start_date": filters["start_date"],
+                "end_exclusive": filters["end_date"] + timedelta(days=1),
+            },
+        )
+    return "", "FALSE", {}
+
+
+def _non_date_conditions(filters):
+    conditions = []
+    params = {}
+
+    if filters["region"].upper() != "ALL":
+        conditions.append(
+            "(LOWER(COALESCE(s.state_name, '')) = LOWER(%(region)s) "
+            "OR LOWER(COALESCE(s.state_id::text, '')) = LOWER(%(region)s))"
+        )
+        params["region"] = filters["region"]
+
+    if filters["organization_type"] != "ALL":
+        conditions.append(
+            "LOWER(REGEXP_REPLACE(TRIM(o.org_type::text), '[- ]+', '_', 'g')) "
+            "= %(organization_type)s"
+        )
+        params["organization_type"] = filters["organization_type"]
+
+    return conditions, params
+
+
+def build_where_clause(filters, include_time=True, extra_conditions=None):
+    """Build the common parameterized SQL filter used by every metric."""
+    conditions, params = _non_date_conditions(filters)
+    if include_time:
+        time_condition, _, time_params = _time_conditions(filters)
+        if time_condition:
+            conditions.insert(0, time_condition)
+        params.update(time_params)
+    if extra_conditions:
+        conditions.extend(extra_conditions)
+    return (f"WHERE {' AND '.join(conditions)}" if conditions else ""), params
+
+
+def _where_from_conditions(conditions):
+    return f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+
+def get_summary(cursor, schema, state_table, filters, has_contributor):
+    where_sql, params = build_where_clause(filters)
+    contributor_sql = (
+        "COUNT(*) FILTER (WHERE o.is_contributor IS TRUE)"
+        if has_contributor
+        else "0::bigint"
+    )
+    cursor.execute(
+        f"""
+        SELECT COUNT(*) AS total_organizations,
+               COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS total_collaborators,
+               {contributor_sql} AS total_contributors,
+               ROUND(AVG(o.org_rating)::numeric, 2) AS average_org_rating
+        {_from_clause(schema, state_table)}
+        {where_sql}
+        """,
+        params,
+    )
+    row = cursor.fetchone() or {}
+    rating = row.get("average_org_rating")
+    return {
+        "total_organizations": int(row.get("total_organizations") or 0),
+        "total_collaborators": int(row.get("total_collaborators") or 0),
+        "total_contributors": int(row.get("total_contributors") or 0),
+        "average_org_rating": float(rating) if rating is not None else 0.0,
+    }
+
+
+def get_growth_trend(cursor, schema, state_table, filters):
+    trunc_unit, date_format = GROUPINGS[filters["group_by"]]
+    non_date_conditions, params = _non_date_conditions(filters)
+    window_condition, baseline_condition, time_params = _time_conditions(filters)
+    params.update(time_params)
+    window_conditions = list(non_date_conditions)
+    if window_condition:
+        window_conditions.insert(0, window_condition)
+    baseline_conditions = list(non_date_conditions) + [baseline_condition]
+
+    cursor.execute(
+        f"""
+        WITH baseline AS (
+            SELECT COUNT(*) AS organizations,
+                   COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborators
+            {_from_clause(schema, state_table)}
+            {_where_from_conditions(baseline_conditions)}
+        ), period_counts AS (
+            SELECT DATE_TRUNC('{trunc_unit}', o.created_at) AS period_start,
+                   TO_CHAR(DATE_TRUNC('{trunc_unit}', o.created_at), '{date_format}') AS period,
+                   COUNT(*) AS organizations,
+                   COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborators
+            {_from_clause(schema, state_table)}
+            {_where_from_conditions(window_conditions)}
+            GROUP BY 1, 2
+        )
+        SELECT pc.period,
+               b.organizations + SUM(pc.organizations) OVER (ORDER BY pc.period_start)
+                   AS total_organizations,
+               b.collaborators + SUM(pc.collaborators) OVER (ORDER BY pc.period_start)
+                   AS total_collaborators
+        FROM period_counts pc CROSS JOIN baseline b
+        ORDER BY pc.period_start
+        """,
+        params,
+    )
+    return [
+        {
+            "period": row["period"],
+            "total_organizations": int(row["total_organizations"]),
+            "total_collaborators": int(row["total_collaborators"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def get_organizations_by_location(cursor, schema, state_table, filters):
+    where_sql, params = build_where_clause(filters)
+    from_sql = _from_clause(schema, state_table)
+    state_id_sql = "COALESCE(s.state_id::text, o.state_id::text, 'UNKNOWN')"
+
+    cursor.execute(
+        f"""
+        SELECT {state_id_sql} AS state_id,
+               COALESCE(s.state_name, 'Unknown') AS state_name,
+               COUNT(*) AS organization_count,
+               ROUND(
+                   (100.0 * COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0))::numeric,
+                   1
+               ) AS percentage
+        {from_sql}
+        {where_sql}
+        GROUP BY 1, 2
+        ORDER BY organization_count DESC, state_name
+        """,
+        params,
+    )
+    states = cursor.fetchall()
+
+    cursor.execute(
+        f"""
+        SELECT {state_id_sql} AS state_id,
+               COALESCE(NULLIF(TRIM(o.city_name), ''), 'Unknown') AS city_name,
+               COUNT(*) AS organization_count
+        {from_sql}
+        {where_sql}
+        GROUP BY 1, 2
+        ORDER BY organization_count DESC, city_name
+        """,
+        params,
+    )
+    cities_by_state = {}
+    for row in cursor.fetchall():
+        cities_by_state.setdefault(row["state_id"], []).append(
+            {
+                "city_name": row["city_name"],
+                "organization_count": int(row["organization_count"]),
+            }
+        )
+
+    return [
+        {
+            "state_id": row["state_id"],
+            "state_name": row["state_name"],
+            "organization_count": int(row["organization_count"]),
+            "percentage": float(row["percentage"] or 0),
+            "cities": cities_by_state.get(row["state_id"], []),
+        }
+        for row in states
+    ]
+
+
+def get_organizations_by_size(cursor, schema, state_table, filters):
+    where_sql, params = build_where_clause(filters)
+    cursor.execute(
+        f"""
+        WITH filtered AS (
+            SELECT LOWER(TRIM(o.org_size::text)) AS org_size
+            {_from_clause(schema, state_table)}
+            {where_sql}
+        ), sizes(org_size, sort_order) AS (
+            VALUES ('small', 1), ('medium', 2), ('large', 3)
+        )
+        SELECT sizes.org_size, COUNT(filtered.org_size) AS organization_count
+        FROM sizes
+        LEFT JOIN filtered ON filtered.org_size = sizes.org_size
+        GROUP BY sizes.org_size, sizes.sort_order
+        ORDER BY sizes.sort_order
+        """,
+        params,
+    )
+    return [
+        {
+            "org_size": row["org_size"],
+            "organization_count": int(row["organization_count"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def get_collaborator_vs_contributor(
+    cursor, schema, state_table, filters, has_contributor
+):
+    where_sql, params = build_where_clause(filters)
+    contributor_sql = (
+        "COUNT(*) FILTER (WHERE o.is_contributor IS TRUE)"
+        if has_contributor
+        else "0::bigint"
+    )
+    cursor.execute(
+        f"""
+        SELECT COUNT(*) AS total,
+               COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborators,
+               {contributor_sql} AS contributors
+        {_from_clause(schema, state_table)}
+        {where_sql}
+        """,
+        params,
+    )
+    row = cursor.fetchone() or {}
+    total = int(row.get("total") or 0)
+    collaborators = int(row.get("collaborators") or 0)
+    contributors = int(row.get("contributors") or 0)
+
+    def percentage(count):
+        return round(count * 100.0 / total, 1) if total else 0.0
+
+    return [
+        {
+            "type": "collaborator",
+            "organization_count": collaborators,
+            "percentage": percentage(collaborators),
+        },
+        {
+            "type": "contributor",
+            "organization_count": contributors,
+            "percentage": percentage(contributors),
+        },
+    ]
+
+
+def get_rating_distribution(cursor, schema, state_table, filters):
+    where_sql, params = build_where_clause(filters)
+    cursor.execute(
+        f"""
+        WITH filtered AS (
+            SELECT o.org_rating
+            {_from_clause(schema, state_table)}
+            {where_sql}
+        ), ratings(rating) AS (
+            VALUES (1), (2), (3), (4), (5)
+        )
+        SELECT ratings.rating, COUNT(filtered.org_rating) AS organization_count
+        FROM ratings
+        LEFT JOIN filtered ON filtered.org_rating = ratings.rating
+        GROUP BY ratings.rating
+        ORDER BY ratings.rating
+        """,
+        params,
+    )
+    return [
+        {
+            "rating": int(row["rating"]),
+            "organization_count": int(row["organization_count"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def get_organization_type_distribution(cursor, schema, state_table, filters):
+    trunc_unit, date_format = GROUPINGS[filters["group_by"]]
+    non_date_conditions, params = _non_date_conditions(filters)
+    window_condition, baseline_condition, time_params = _time_conditions(filters)
+    params.update(time_params)
+    window_conditions = list(non_date_conditions)
+    if window_condition:
+        window_conditions.insert(0, window_condition)
+    baseline_conditions = list(non_date_conditions) + [baseline_condition]
+    normalized_type = "LOWER(REGEXP_REPLACE(TRIM(o.org_type::text), '[- ]+', '_', 'g'))"
+
+    cursor.execute(
+        f"""
+        WITH baseline AS (
+            SELECT COUNT(*) FILTER (WHERE {normalized_type} = 'for_profit') AS for_profit,
+                   COUNT(*) FILTER (WHERE {normalized_type} = 'non_profit') AS non_profit
+            {_from_clause(schema, state_table)}
+            {_where_from_conditions(baseline_conditions)}
+        ), period_counts AS (
+            SELECT DATE_TRUNC('{trunc_unit}', o.created_at) AS period_start,
+                   TO_CHAR(DATE_TRUNC('{trunc_unit}', o.created_at), '{date_format}') AS period,
+                   COUNT(*) FILTER (WHERE {normalized_type} = 'for_profit') AS for_profit,
+                   COUNT(*) FILTER (WHERE {normalized_type} = 'non_profit') AS non_profit
+            {_from_clause(schema, state_table)}
+            {_where_from_conditions(window_conditions)}
+            GROUP BY 1, 2
+        )
+        SELECT pc.period,
+               b.for_profit + SUM(pc.for_profit) OVER (ORDER BY pc.period_start) AS for_profit,
+               b.non_profit + SUM(pc.non_profit) OVER (ORDER BY pc.period_start) AS non_profit,
+               b.for_profit + b.non_profit
+                   + SUM(pc.for_profit + pc.non_profit) OVER (ORDER BY pc.period_start) AS total
+        FROM period_counts pc CROSS JOIN baseline b
+        ORDER BY pc.period_start
+        """,
+        params,
+    )
+    return [
+        {
+            "period": row["period"],
+            "for_profit": int(row["for_profit"]),
+            "non_profit": int(row["non_profit"]),
+            "total": int(row["total"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def _run_metric(name, default, connection, function):
+    """Run one metric and restore the transaction after a query failure."""
+    try:
+        return function()
+    except Exception:
+        LOGGER.exception("Organization analytics query failed: %s", name)
+        try:
+            connection.rollback()
+        except Exception:
+            LOGGER.exception("Database rollback failed after %s", name)
+        return default
+
+
+def lambda_handler(event, context):
+    """Return all organization dashboard tabs from a single request."""
+    del context
+    response_body = get_default_response()
+
+    try:
+        payload = parse_event_body(event)
+        filters = validate_filters(payload)
+        schema, state_table = get_database_layout()
+    except (RequestValidationError, ValueError) as exc:
+        return build_response(400, {"error": str(exc), **response_body})
+
+    connection = None
+    cursor = None
+    try:
+        connection = get_db_connection()
+        cursor = connection.cursor(cursor_factory=RealDictCursor)
+
+        has_contributor = _run_metric(
+            "contributor_column_check",
+            False,
+            connection,
+            lambda: contributor_column_exists(cursor, schema),
+        )
+
+        response_body["summary"] = _run_metric(
+            "summary",
+            response_body["summary"],
+            connection,
+            lambda: get_summary(cursor, schema, state_table, filters, has_contributor),
+        )
+        response_body["growth_trend"] = _run_metric(
+            "growth_trend",
+            [],
+            connection,
+            lambda: get_growth_trend(cursor, schema, state_table, filters),
+        )
+        response_body["organizations_by_location"] = _run_metric(
+            "organizations_by_location",
+            [],
+            connection,
+            lambda: get_organizations_by_location(cursor, schema, state_table, filters),
+        )
+        response_body["organizations_by_size"] = _run_metric(
+            "organizations_by_size",
+            [],
+            connection,
+            lambda: get_organizations_by_size(cursor, schema, state_table, filters),
+        )
+        response_body["collaborator_vs_contributor"] = _run_metric(
+            "collaborator_vs_contributor",
+            [],
+            connection,
+            lambda: get_collaborator_vs_contributor(
+                cursor, schema, state_table, filters, has_contributor
+            ),
+        )
+        response_body["rating_distribution"] = _run_metric(
+            "rating_distribution",
+            [],
+            connection,
+            lambda: get_rating_distribution(cursor, schema, state_table, filters),
+        )
+        response_body["organization_type_distribution"] = _run_metric(
+            "organization_type_distribution",
+            [],
+            connection,
+            lambda: get_organization_type_distribution(
+                cursor, schema, state_table, filters
+            ),
+        )
+
+        return build_response(200, response_body)
+    except Exception:
+        LOGGER.exception("Organization analytics database connection failed")
+        return build_response(500, response_body)
+    finally:
+        if cursor is not None:
+            try:
+                cursor.close()
+            except Exception:
+                LOGGER.exception("Failed to close organization analytics cursor")
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception:
+                LOGGER.exception("Failed to close organization analytics connection")
+
+
+if __name__ == "__main__":
+    print(json.dumps(lambda_handler({}, None), indent=2))

--- a/data-analytics/requirements.txt
+++ b/data-analytics/requirements.txt
@@ -1,0 +1,1 @@
+psycopg2-binary==2.9.9

--- a/data-analytics/tests/test_organization_analytics.py
+++ b/data-analytics/tests/test_organization_analytics.py
@@ -1,0 +1,323 @@
+"""Cursor-based unit tests for the Organization Analytics Lambda."""
+
+import json
+import os
+import sys
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+LAMBDA_DIRECTORY = Path(__file__).resolve().parents[1] / "lambda_functions"
+sys.path.insert(0, str(LAMBDA_DIRECTORY))
+
+import organization_analytics as analytics
+
+EXPECTED_RESPONSE_KEYS = {
+    "summary",
+    "growth_trend",
+    "organizations_by_location",
+    "organizations_by_size",
+    "collaborator_vs_contributor",
+    "rating_distribution",
+    "organization_type_distribution",
+}
+
+
+def make_connection(cursor):
+    connection = MagicMock()
+    connection.cursor.return_value = cursor
+    return connection
+
+
+def happy_cursor():
+    cursor = MagicMock()
+    cursor.fetchone.side_effect = [
+        {"exists": True},
+        {
+            "total_organizations": 126,
+            "total_collaborators": 42,
+            "total_contributors": 84,
+            "average_org_rating": 4.2,
+        },
+        {"total": 126, "collaborators": 42, "contributors": 84},
+    ]
+    cursor.fetchall.side_effect = [
+        [
+            {
+                "period": "2026-01",
+                "total_organizations": 100,
+                "total_collaborators": 34,
+            }
+        ],
+        [
+            {
+                "state_id": "CA",
+                "state_name": "California",
+                "organization_count": 32,
+                "percentage": 25.4,
+            }
+        ],
+        [{"state_id": "CA", "city_name": "Los Angeles", "organization_count": 12}],
+        [
+            {"org_size": "small", "organization_count": 50},
+            {"org_size": "medium", "organization_count": 45},
+            {"org_size": "large", "organization_count": 31},
+        ],
+        [
+            {"rating": 1, "organization_count": 1},
+            {"rating": 2, "organization_count": 3},
+            {"rating": 3, "organization_count": 12},
+            {"rating": 4, "organization_count": 46},
+            {"rating": 5, "organization_count": 64},
+        ],
+        [
+            {
+                "period": "2026-01",
+                "for_profit": 41,
+                "non_profit": 68,
+                "total": 109,
+            }
+        ],
+    ]
+    return cursor
+
+
+class TestRequestValidation(unittest.TestCase):
+    def test_accepts_all_documented_payloads(self):
+        payloads = [
+            {"time_filter": "30D", "group_by": "daily"},
+            {"time_filter": "1Y", "group_by": "monthly"},
+            {"time_filter": "1Y", "region": "California"},
+            {"time_filter": "1Y", "organization_type": "non_profit"},
+            {
+                "time_filter": "CUSTOM",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "group_by": "monthly",
+            },
+            {"time_filter": "ALL", "organization_type": "ALL"},
+        ]
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                result = analytics.validate_filters(payload)
+                self.assertIn(result["time_filter"], analytics.VALID_TIME_FILTERS)
+
+    def test_normalizes_organization_type_variants(self):
+        self.assertEqual(
+            analytics.validate_filters({"organization_type": "Non-Profit"})[
+                "organization_type"
+            ],
+            "non_profit",
+        )
+        self.assertEqual(
+            analytics.validate_filters({"organization_type": "all"})[
+                "organization_type"
+            ],
+            "ALL",
+        )
+
+    def test_custom_requires_both_dates(self):
+        with self.assertRaisesRegex(
+            analytics.RequestValidationError, "both start_date"
+        ):
+            analytics.validate_filters(
+                {"time_filter": "CUSTOM", "start_date": "2026-01-01"}
+            )
+
+    def test_rejects_invalid_filters_and_dates(self):
+        invalid_payloads = [
+            {"time_filter": "90D"},
+            {"group_by": "quarterly"},
+            {"organization_type": "government"},
+            {"time_filter": "CUSTOM", "start_date": "bad", "end_date": "2026-01-02"},
+            {
+                "time_filter": "CUSTOM",
+                "start_date": "2026-02-01",
+                "end_date": "2026-01-01",
+            },
+        ]
+        for payload in invalid_payloads:
+            with (
+                self.subTest(payload=payload),
+                self.assertRaises(analytics.RequestValidationError),
+            ):
+                analytics.validate_filters(payload)
+
+    def test_malformed_api_gateway_body_returns_400(self):
+        result = analytics.lambda_handler({"body": "{"}, None)
+        self.assertEqual(result["statusCode"], 400)
+        self.assertIn("valid JSON", json.loads(result["body"])["error"])
+
+
+class TestSqlFilters(unittest.TestCase):
+    def test_custom_range_includes_entire_end_date(self):
+        filters = analytics.validate_filters(
+            {
+                "time_filter": "CUSTOM",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+            }
+        )
+        where_sql, params = analytics.build_where_clause(filters)
+        self.assertIn("o.created_at >= %(start_date)s", where_sql)
+        self.assertIn("o.created_at < %(end_exclusive)s", where_sql)
+        self.assertEqual(params["start_date"], date(2026, 1, 1))
+        self.assertEqual(params["end_exclusive"], date(2026, 7, 1))
+
+    def test_values_are_parameters_not_interpolated(self):
+        region = "California' OR 1=1 --"
+        filters = analytics.validate_filters(
+            {
+                "region": region,
+                "organization_type": "for-profit",
+            }
+        )
+        where_sql, params = analytics.build_where_clause(filters)
+        self.assertNotIn(region, where_sql)
+        self.assertEqual(params["region"], region)
+        self.assertEqual(params["organization_type"], "for_profit")
+
+    def test_state_table_defaults_to_ticket_name_and_supports_legacy_name(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(analytics.get_database_layout()[1], "states")
+        with patch.dict(os.environ, {"SAAYAM_STATE_TABLE": "state"}, clear=True):
+            self.assertEqual(analytics.get_database_layout()[1], "state")
+
+
+class TestLambdaHandler(unittest.TestCase):
+    @patch("organization_analytics.get_db_connection")
+    def test_standard_request_returns_complete_dashboard(self, get_connection):
+        cursor = happy_cursor()
+        connection = make_connection(cursor)
+        get_connection.return_value = connection
+
+        result = analytics.lambda_handler(
+            {
+                "body": json.dumps(
+                    {
+                        "time_filter": "30D",
+                        "start_date": None,
+                        "end_date": None,
+                        "group_by": "daily",
+                        "region": "ALL",
+                        "organization_type": "ALL",
+                    }
+                )
+            },
+            None,
+        )
+
+        self.assertEqual(result["statusCode"], 200)
+        body = json.loads(result["body"])
+        self.assertEqual(set(body), EXPECTED_RESPONSE_KEYS)
+        self.assertEqual(body["summary"]["total_organizations"], 126)
+        self.assertEqual(body["summary"]["average_org_rating"], 4.2)
+        self.assertEqual(
+            body["organizations_by_location"][0]["cities"][0]["city_name"],
+            "Los Angeles",
+        )
+        self.assertEqual(
+            [item["rating"] for item in body["rating_distribution"]], [1, 2, 3, 4, 5]
+        )
+        cursor.close.assert_called_once()
+        connection.close.assert_called_once()
+
+    @patch("organization_analytics.get_db_connection")
+    def test_empty_result_set_is_safe(self, get_connection):
+        cursor = MagicMock()
+        cursor.fetchone.side_effect = [
+            {"exists": True},
+            {
+                "total_organizations": 0,
+                "total_collaborators": 0,
+                "total_contributors": 0,
+                "average_org_rating": None,
+            },
+            {"total": 0, "collaborators": 0, "contributors": 0},
+        ]
+        cursor.fetchall.side_effect = [
+            [],
+            [],
+            [],
+            [
+                {"org_size": "small", "organization_count": 0},
+                {"org_size": "medium", "organization_count": 0},
+                {"org_size": "large", "organization_count": 0},
+            ],
+            [{"rating": value, "organization_count": 0} for value in range(1, 6)],
+            [],
+        ]
+        get_connection.return_value = make_connection(cursor)
+
+        result = analytics.lambda_handler({"time_filter": "7D"}, None)
+        body = json.loads(result["body"])
+
+        self.assertEqual(result["statusCode"], 200)
+        self.assertEqual(body["summary"]["total_organizations"], 0)
+        self.assertEqual(body["summary"]["average_org_rating"], 0.0)
+        self.assertEqual(body["growth_trend"], [])
+        self.assertEqual(body["organizations_by_location"], [])
+        self.assertEqual(body["collaborator_vs_contributor"][0]["percentage"], 0.0)
+        self.assertEqual(len(body["rating_distribution"]), 5)
+
+    @patch("organization_analytics.get_db_connection")
+    def test_missing_contributor_column_returns_zero_without_bad_queries(
+        self, get_connection
+    ):
+        cursor = happy_cursor()
+        cursor.fetchone.side_effect = [
+            {"exists": False},
+            {
+                "total_organizations": 126,
+                "total_collaborators": 42,
+                "total_contributors": 0,
+                "average_org_rating": 4.2,
+            },
+            {"total": 126, "collaborators": 42, "contributors": 0},
+        ]
+        get_connection.return_value = make_connection(cursor)
+
+        result = analytics.lambda_handler({}, None)
+        body = json.loads(result["body"])
+
+        self.assertEqual(result["statusCode"], 200)
+        self.assertEqual(body["summary"]["total_contributors"], 0)
+        metric_queries = [call.args[0] for call in cursor.execute.call_args_list[1:]]
+        self.assertTrue(
+            all("o.is_contributor" not in query for query in metric_queries)
+        )
+
+    @patch("organization_analytics.get_db_connection")
+    def test_one_query_exception_uses_default_and_rolls_back(self, get_connection):
+        cursor = happy_cursor()
+        cursor.execute.side_effect = [None, RuntimeError("query failed")] + [None] * 7
+        cursor.fetchone.side_effect = [
+            {"exists": True},
+            {"total": 126, "collaborators": 42, "contributors": 84},
+        ]
+        connection = make_connection(cursor)
+        get_connection.return_value = connection
+
+        with patch.object(analytics.LOGGER, "exception"):
+            result = analytics.lambda_handler({}, None)
+        body = json.loads(result["body"])
+
+        self.assertEqual(result["statusCode"], 200)
+        self.assertEqual(body["summary"], analytics.get_default_response()["summary"])
+        self.assertEqual(body["growth_trend"][0]["total_organizations"], 100)
+        connection.rollback.assert_called_once()
+
+    @patch("organization_analytics.get_db_connection")
+    def test_connection_exception_returns_500_defaults(self, get_connection):
+        get_connection.side_effect = RuntimeError("database unavailable")
+        with patch.object(analytics.LOGGER, "exception"):
+            result = analytics.lambda_handler({}, None)
+        body = json.loads(result["body"])
+        self.assertEqual(result["statusCode"], 500)
+        self.assertEqual(set(body), EXPECTED_RESPONSE_KEYS)
+        self.assertEqual(body["summary"]["total_organizations"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This follow-up aligns the Organization Analytics API with the finalized Organization Dashboard requirements.

Related to #228. Follow-up to #272.

## Changes

* Added a single response structure for all three Organization Dashboard tabs.
* Added four KPI cards:

  * Total Organizations
  * Total Collaborators
  * Total Contributors
  * Average Organization Rating
* Added organization and collaborator growth trends.
* Added state and city organization distribution.
* Added Small, Medium, and Large organization-size distributions.
* Added collaborator vs contributor counts and percentages.
* Added rating distribution from 1 through 5.
* Added For-Profit vs Non-Profit organization trends.
* Added support for `7D`, `30D`, `1Y`, `ALL`, and `CUSTOM` date filters.
* Added region, organization-type, and grouping filters.
* Added parameterized PostgreSQL queries.
* Added safe handling for NULL values and empty results.
* Added compatibility for databases where `is_contributor` is not yet available.
* Added cursor/mock database unit tests.
* Added API documentation with sample request and response payloads.

## Test Results

### Cursor/Mock Unit Tests

```text
Ran 13 tests
OK
```

### Local PostgreSQL Smoke Test

```text
LOCAL POSTGRESQL TEST PASSED
CUSTOM DATE TEST PASSED
```

The tests cover:

* Valid filters
* Invalid filters
* Custom date ranges
* Empty result sets
* Missing `is_contributor`
* Query exceptions and transaction rollback
* Database connection exceptions
* Response structure
* Cursor and connection cleanup

## Sample Request

```json
{
  "time_filter": "1Y",
  "start_date": null,
  "end_date": null,
  "group_by": "monthly",
  "region": "California",
  "organization_type": "ALL"
}
```

## Sample Response

```json
{
  "summary": {
    "total_organizations": 126,
    "total_collaborators": 42,
    "total_contributors": 84,
    "average_org_rating": 4.2
  },
  "growth_trend": [
    {
      "period": "2026-01",
      "total_organizations": 100,
      "total_collaborators": 34
    }
  ],
  "organizations_by_location": [
    {
      "state_id": "CA",
      "state_name": "California",
      "organization_count": 32,
      "percentage": 25.4,
      "cities": [
        {
          "city_name": "Los Angeles",
          "organization_count": 12
        }
      ]
    }
  ],
  "organizations_by_size": [
    {
      "org_size": "small",
      "organization_count": 50
    },
    {
      "org_size": "medium",
      "organization_count": 45
    },
    {
      "org_size": "large",
      "organization_count": 31
    }
  ],
  "collaborator_vs_contributor": [
    {
      "type": "collaborator",
      "organization_count": 42,
      "percentage": 33.3
    },
    {
      "type": "contributor",
      "organization_count": 84,
      "percentage": 66.7
    }
  ],
  "rating_distribution": [
    {
      "rating": 1,
      "organization_count": 1
    },
    {
      "rating": 2,
      "organization_count": 3
    },
    {
      "rating": 3,
      "organization_count": 12
    },
    {
      "rating": 4,
      "organization_count": 46
    },
    {
      "rating": 5,
      "organization_count": 64
    }
  ],
  "organization_type_distribution": [
    {
      "period": "2026-01",
      "for_profit": 41,
      "non_profit": 68,
      "total": 109
    }
  ]
}
```
