### PR TITLE
feat(#273): Steward Dashboard – Review Volunteers Lambda API

### DIFF
--- a/data-analytics/lambda_functions/README_steward_volunteer_review_api.md
+++ b/data-analytics/lambda_functions/README_steward_volunteer_review_api.md
@@ -1,0 +1,60 @@
+# Steward Dashboard – Review Volunteers API (issue #273)
+
+AWS Lambda API that returns the volunteer applications waiting on a steward
+review, for the Steward Dashboard "Review Volunteers" widget.
+
+## Files
+- `steward_volunteer_review_api.py` – Lambda handler
+- `test_steward_volunteer_review_api.py` – local + cursor-based unit tests
+
+## Table mapping
+The issue asks to join the `users` and `volunteers` tables. There is no table
+literally named `volunteers` in the schema (`saayam-for-all/database`); the
+volunteer review queue is backed by **`volunteer_applications`**, whose
+`application_status` enum (`STARTED`, `IN_REVIEW`, `ACCEPTED`, `REJECTED`)
+carries the `IN_REVIEW` state a steward acts on. The API filters on
+`application_status = 'IN_REVIEW'` and joins `users` on `user_id`.
+
+## Request
+```json
+{ "page": 1, "page_size": 5 }
+```
+
+## Response
+```json
+{
+  "statusCode": 200,
+  "body": {
+    "data": [
+      { "user_id": "SID-00-000-000-001", "updated_time": "2026-05-12T07:15:00Z", "volunteer_review": "Review" }
+    ],
+    "pagination": { "current_page": 1, "page_size": 5, "total_records": 20, "total_pages": 4 }
+  }
+}
+```
+`updated_time` = `volunteer_applications.last_updated_at` (ISO-8601 UTC). Rows
+are sorted newest-first. Empty queue returns `200` with `"data": []`. DB errors
+return a safe `500` with an empty payload and no internal details.
+
+## Configuration (no hardcoded creds or Parameter Store paths)
+SSM parameter *paths* come from environment variables; a region is queried only
+when its var is set:
+
+| Env var | Example value |
+| --- | --- |
+| `VIRGINIA_DB_PARAM` | `/dev/saayam/db/Virginia/Analytics/user` |
+| `IRELAND_DB_PARAM` | `/dev/saayam/db/Ireland/Analytics/user` |
+| `AWS_REGION` | `us-east-1` (default) |
+
+Both regions are queried, merged, sorted by `last_updated_at DESC`, then
+paginated so the combined order is correct.
+
+## Testing locally
+```bash
+cd data-analytics/lambda_functions
+python  test_steward_volunteer_review_api.py     # no pytest needed
+pytest  test_steward_volunteer_review_api.py -q  # or via pytest
+```
+The tests mock the DB layer (`connect_region`) with a fake cursor, so no live
+database or AWS access is required. Do not deploy directly to AWS — submit via
+pull request.

--- a/data-analytics/lambda_functions/steward_volunteer_review_api.py
+++ b/data-analytics/lambda_functions/steward_volunteer_review_api.py
@@ -1,0 +1,263 @@
+"""AWS Lambda API for the Steward Dashboard - Review Volunteers (issue #273).
+
+Retrieves the volunteer applications that are waiting on a steward review by
+joining the ``users`` and ``volunteers`` tables. The ``volunteers`` review
+queue is backed by the ``volunteer_applications`` table, whose
+``application_status`` enum carries the ``IN_REVIEW`` state a steward acts on.
+
+Only the fields the Steward Dashboard needs are returned:
+    * user_id           - used by the frontend for the "Review" action
+    * updated_time      - last time the application changed (ISO-8601 UTC)
+    * volunteer_review  - the review action label ("Review")
+
+Results are sorted by the latest updated time, paginated, and returned with
+pagination metadata. Follows the existing lambda coding standards in this
+package (parse_event_body, psycopg2, boto3 SSM config, CORS headers, safe
+error response). Supports the Virginia and Ireland databases and merges them.
+
+Configuration is read from AWS SSM Parameter Store. The parameter *paths* are
+supplied through environment variables so nothing (neither credentials nor
+Parameter Store paths) is hardcoded:
+
+    VIRGINIA_DB_PARAM   e.g. /dev/saayam/db/Virginia/Analytics/user
+    IRELAND_DB_PARAM    e.g. /dev/saayam/db/Ireland/Analytics/user
+    AWS_REGION          e.g. us-east-1 (falls back to us-east-1)
+
+A region is queried only when its parameter path env var is set, so the
+function works with one or both regions configured.
+"""
+
+import json
+import math
+import os
+
+import boto3
+import psycopg2
+
+# --- Schemas / tables per region -------------------------------------------
+SCHEMA_VIRGINIA = "virginia_dev_saayam_rdbms"
+SCHEMA_IRELAND = "ireland_dev_saayam_rdbms"
+
+REAL_TABLE_USERS_VIRGINIA = f"{SCHEMA_VIRGINIA}.users"
+REAL_TABLE_VOLUNTEERS_VIRGINIA = f"{SCHEMA_VIRGINIA}.volunteer_applications"
+
+REAL_TABLE_USERS_IRELAND = f"{SCHEMA_IRELAND}.users"
+REAL_TABLE_VOLUNTEERS_IRELAND = f"{SCHEMA_IRELAND}.volunteer_applications"
+
+# Application status that requires a steward review, and the action label the
+# frontend renders for each row.
+REVIEW_STATUS = "IN_REVIEW"
+REVIEW_ACTION = "Review"
+
+# Pagination defaults / guard rails.
+DEFAULT_PAGE = 1
+DEFAULT_PAGE_SIZE = 5
+MAX_PAGE_SIZE = 100
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+}
+
+
+def parse_event_body(event):
+    """Return the request payload as a dict regardless of invocation style."""
+    if not event:
+        return {}
+
+    body = event.get("body")
+
+    if body is None:
+        return event
+
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+
+    if isinstance(body, dict):
+        return body
+
+    return {}
+
+
+def get_pagination_params(request_body):
+    """Extract and validate ``page`` and ``page_size`` from the payload.
+
+    Falls back to the defaults and clamps to safe bounds so a bad client value
+    can never produce a negative OFFSET or an unbounded page size.
+    """
+    def _as_int(value, default):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    page = _as_int(request_body.get("page", DEFAULT_PAGE), DEFAULT_PAGE)
+    page_size = _as_int(request_body.get("page_size", DEFAULT_PAGE_SIZE), DEFAULT_PAGE_SIZE)
+
+    if page < 1:
+        page = DEFAULT_PAGE
+    if page_size < 1:
+        page_size = DEFAULT_PAGE_SIZE
+    if page_size > MAX_PAGE_SIZE:
+        page_size = MAX_PAGE_SIZE
+
+    return page, page_size
+
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": CORS_HEADERS,
+        "body": json.dumps(body),
+    }
+
+
+def format_updated_time(value):
+    """Format a DB timestamp as ISO-8601 UTC (e.g. 2026-05-12T07:15:00Z)."""
+    if value is None:
+        return None
+    if hasattr(value, "strftime"):
+        return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return str(value)
+
+
+def fetch_review_requests(cursor, users_table, volunteers_table):
+    """Fetch every volunteer application awaiting steward review for one region.
+
+    Uses a parameterized query for the status filter. Returns a list of
+    ``(user_id, updated_datetime)`` tuples ordered newest-first. Pagination is
+    applied after merging regions so the combined order stays correct.
+    """
+    query = f"""
+        SELECT u.user_id, va.last_updated_at
+        FROM {users_table} u
+        JOIN {volunteers_table} va ON u.user_id = va.user_id
+        WHERE va.application_status = %s
+        ORDER BY va.last_updated_at DESC
+    """
+    cursor.execute(query, (REVIEW_STATUS,))
+    return cursor.fetchall()
+
+
+def paginate(records, page, page_size):
+    """Slice merged records and build the pagination metadata block."""
+    total_records = len(records)
+    total_pages = math.ceil(total_records / page_size) if total_records else 0
+
+    start = (page - 1) * page_size
+    end = start + page_size
+    page_records = records[start:end]
+
+    data = [
+        {
+            "user_id": user_id,
+            "updated_time": format_updated_time(updated_time),
+            "volunteer_review": REVIEW_ACTION,
+        }
+        for user_id, updated_time in page_records
+    ]
+
+    pagination = {
+        "current_page": page,
+        "page_size": page_size,
+        "total_records": total_records,
+        "total_pages": total_pages,
+    }
+    return data, pagination
+
+
+def get_db_config(param_name):
+    """Load a psycopg2 connection kwargs dict from an SSM parameter.
+
+    The parameter value is expected to be JSON with HOST / DATABASE NAME /
+    USERNAME / PASSWORD / PORT keys (same shape kpi_api_analytics.py uses).
+    """
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    ssm = boto3.client("ssm", region_name=region)
+
+    response = ssm.get_parameter(Name=param_name, WithDecryption=True)
+    creds = json.loads(response["Parameter"]["Value"])
+
+    return {
+        "host": creds["HOST"],
+        "dbname": creds["DATABASE NAME"],
+        "user": creds["USERNAME"],
+        "password": creds["PASSWORD"],
+        "port": creds["PORT"],
+        "sslmode": "require",
+    }
+
+
+def connect_region(param_env_var):
+    """Connect to a region's DB when its parameter path env var is configured.
+
+    Returns ``None`` (region skipped) when the env var is unset. Raising here
+    is intentional if the var is set but the connection fails, so the handler
+    surfaces a safe error rather than silently dropping a region's queue.
+    """
+    param_name = os.environ.get(param_env_var)
+    if not param_name:
+        return None
+    return psycopg2.connect(**get_db_config(param_name))
+
+
+REGION_TABLES = {
+    "VIRGINIA_DB_PARAM": (REAL_TABLE_USERS_VIRGINIA, REAL_TABLE_VOLUNTEERS_VIRGINIA),
+    "IRELAND_DB_PARAM": (REAL_TABLE_USERS_IRELAND, REAL_TABLE_VOLUNTEERS_IRELAND),
+}
+
+
+def lambda_handler(event, context):
+    request_body = parse_event_body(event)
+    page, page_size = get_pagination_params(request_body)
+
+    connections = []
+    try:
+        merged = []
+        for param_env_var, (users_table, volunteers_table) in REGION_TABLES.items():
+            conn = connect_region(param_env_var)
+            if conn is None:
+                continue
+            connections.append(conn)
+            cursor = conn.cursor()
+            try:
+                merged.extend(fetch_review_requests(cursor, users_table, volunteers_table))
+            finally:
+                cursor.close()
+
+        # Newest first across all regions. sort() is stable so ties keep their
+        # per-region DESC order; None timestamps sort last.
+        merged.sort(key=lambda row: (row[1] is not None, row[1]), reverse=True)
+
+        data, pagination = paginate(merged, page, page_size)
+        return build_response(200, {"data": data, "pagination": pagination})
+
+    except Exception as exc:  # noqa: BLE001 - return a safe response, never leak internals
+        print("ERROR in steward_volunteer_review_api:", str(exc))
+        return build_response(
+            500,
+            {
+                "data": [],
+                "pagination": {
+                    "current_page": page,
+                    "page_size": page_size,
+                    "total_records": 0,
+                    "total_pages": 0,
+                },
+                "error": "Unable to retrieve volunteer review requests.",
+            },
+        )
+    finally:
+        for conn in connections:
+            conn.close()
+
+
+if __name__ == "__main__":
+    # Local smoke run. Without AWS configured this exercises the error path and
+    # returns the safe response; the real coverage lives in the unit tests.
+    print(lambda_handler({"page": 1, "page_size": 5}, None))

--- a/data-analytics/lambda_functions/test_steward_volunteer_review_api.py
+++ b/data-analytics/lambda_functions/test_steward_volunteer_review_api.py
@@ -1,0 +1,243 @@
+"""Local + cursor-based unit tests for steward_volunteer_review_api (issue #273).
+
+The users/volunteers tables aren't reachable in CI, so these mock the DB layer
+(connect_region) with a fake cursor that returns canned IN_REVIEW rows. Runs
+two ways:
+
+    pytest data-analytics/lambda_functions/test_steward_volunteer_review_api.py
+    python  data-analytics/lambda_functions/test_steward_volunteer_review_api.py
+
+The plain-python entrypoint lets contributors verify locally without pytest.
+"""
+
+import json
+from datetime import datetime
+
+import steward_volunteer_review_api as api
+
+
+class FakeCursor:
+    """Minimal psycopg2-cursor stand-in that records queries/params."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.queries = []
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        self.closed = True
+
+
+def _dt(text):
+    return datetime.strptime(text, "%Y-%m-%d %H:%M:%S")
+
+
+# 20 IN_REVIEW rows so pagination math matches the issue example (page_size 5 -> 4 pages).
+SAMPLE_ROWS = [
+    (f"SID-00-000-000-{i:03d}", _dt(f"2026-05-{(i % 28) + 1:02d} 07:15:00"))
+    for i in range(1, 21)
+]
+
+
+def _single_region(monkeypatch, rows):
+    """Wire connect_region so only Virginia returns `rows`; Ireland is skipped."""
+    cursor = FakeCursor(rows)
+    conn = FakeConnection(cursor)
+
+    def fake_connect(param_env_var):
+        return conn if param_env_var == "VIRGINIA_DB_PARAM" else None
+
+    monkeypatch.setattr(api, "connect_region", fake_connect)
+    return conn, cursor
+
+
+# --- pagination param handling ---------------------------------------------
+
+def test_pagination_defaults():
+    assert api.get_pagination_params({}) == (api.DEFAULT_PAGE, api.DEFAULT_PAGE_SIZE)
+
+
+def test_pagination_clamps_bad_values():
+    assert api.get_pagination_params({"page": 0, "page_size": -3}) == (1, 5)
+    assert api.get_pagination_params({"page": "x", "page_size": "y"}) == (1, 5)
+    assert api.get_pagination_params({"page_size": 9999})[1] == api.MAX_PAGE_SIZE
+
+
+# --- happy path -------------------------------------------------------------
+
+def test_returns_first_page_sorted_desc(monkeypatch):
+    _single_region(monkeypatch, SAMPLE_ROWS)
+
+    resp = api.lambda_handler({"page": 1, "page_size": 5}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+
+    assert body["pagination"] == {
+        "current_page": 1,
+        "page_size": 5,
+        "total_records": 20,
+        "total_pages": 4,
+    }
+    assert len(body["data"]) == 5
+
+    # descending updated_time
+    times = [row["updated_time"] for row in body["data"]]
+    assert times == sorted(times, reverse=True)
+
+    first = body["data"][0]
+    assert set(first.keys()) == {"user_id", "updated_time", "volunteer_review"}
+    assert first["volunteer_review"] == "Review"
+    assert first["updated_time"].endswith("Z")
+
+
+def test_query_is_parameterized_and_filters_review_status(monkeypatch):
+    _, cursor = _single_region(monkeypatch, SAMPLE_ROWS)
+    api.lambda_handler({"page": 1, "page_size": 5}, None)
+
+    query, params = cursor.queries[0]
+    assert params == (api.REVIEW_STATUS,)          # value passed out-of-band, not interpolated
+    assert "application_status = %s" in query
+    assert "ORDER BY va.last_updated_at DESC" in query
+
+
+def test_second_page_offsets_correctly(monkeypatch):
+    _single_region(monkeypatch, SAMPLE_ROWS)
+    page1 = json.loads(api.lambda_handler({"page": 1, "page_size": 5}, None)["body"])["data"]
+    page2 = json.loads(api.lambda_handler({"page": 2, "page_size": 5}, None)["body"])["data"]
+
+    ids1 = {r["user_id"] for r in page1}
+    ids2 = {r["user_id"] for r in page2}
+    assert ids1.isdisjoint(ids2)
+
+
+def test_connections_are_closed(monkeypatch):
+    conn, _ = _single_region(monkeypatch, SAMPLE_ROWS)
+    api.lambda_handler({"page": 1, "page_size": 5}, None)
+    assert conn.closed is True
+
+
+# --- merging two regions ----------------------------------------------------
+
+def test_merges_and_sorts_across_regions(monkeypatch):
+    va_rows = [("SID-VA-1", _dt("2026-05-10 10:00:00"))]
+    ie_rows = [("SID-IE-1", _dt("2026-05-12 10:00:00"))]
+
+    def fake_connect(param_env_var):
+        if param_env_var == "VIRGINIA_DB_PARAM":
+            return FakeConnection(FakeCursor(va_rows))
+        if param_env_var == "IRELAND_DB_PARAM":
+            return FakeConnection(FakeCursor(ie_rows))
+        return None
+
+    monkeypatch.setattr(api, "connect_region", fake_connect)
+
+    body = json.loads(api.lambda_handler({"page": 1, "page_size": 5}, None)["body"])
+    assert body["pagination"]["total_records"] == 2
+    # Ireland row is newer, so it comes first after the cross-region sort.
+    assert body["data"][0]["user_id"] == "SID-IE-1"
+    assert body["data"][1]["user_id"] == "SID-VA-1"
+
+
+# --- empty + error paths ----------------------------------------------------
+
+def test_empty_results_return_ok_with_empty_array(monkeypatch):
+    _single_region(monkeypatch, [])
+    resp = api.lambda_handler({"page": 1, "page_size": 5}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["data"] == []
+    assert body["pagination"] == {
+        "current_page": 1,
+        "page_size": 5,
+        "total_records": 0,
+        "total_pages": 0,
+    }
+
+
+def test_db_error_returns_safe_response(monkeypatch):
+    def boom(param_env_var):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(api, "connect_region", boom)
+    resp = api.lambda_handler({"page": 1, "page_size": 5}, None)
+    assert resp["statusCode"] == 500
+    body = json.loads(resp["body"])
+    assert body["data"] == []
+    assert body["pagination"]["total_records"] == 0
+    assert "error" in body
+
+
+def test_string_body_is_parsed(monkeypatch):
+    _single_region(monkeypatch, SAMPLE_ROWS)
+    event = {"body": json.dumps({"page": 1, "page_size": 5})}
+    resp = api.lambda_handler(event, None)
+    assert resp["statusCode"] == 200
+    assert len(json.loads(resp["body"])["data"]) == 5
+
+
+# --- plain-python runner (no pytest) ----------------------------------------
+
+class _MonkeyPatch:
+    """Tiny monkeypatch shim so the tests run without pytest installed."""
+
+    def __init__(self):
+        self._undo = []
+
+    def setattr(self, target, name, value):
+        old = getattr(target, name)
+        self._undo.append((target, name, old))
+        setattr(target, name, value)
+
+    def undo(self):
+        for target, name, old in reversed(self._undo):
+            setattr(target, name, old)
+        self._undo.clear()
+
+
+def _run_local():
+    passed = 0
+    failed = 0
+    for name, func in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(func):
+            continue
+        mp = _MonkeyPatch()
+        try:
+            if func.__code__.co_argcount:
+                func(mp)
+            else:
+                func()
+            print(f"PASS {name}")
+            passed += 1
+        except AssertionError as exc:
+            print(f"FAIL {name}: {exc}")
+            failed += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR {name}: {exc}")
+            failed += 1
+        finally:
+            mp.undo()
+    print(f"\n{passed} passed, {failed} failed")
+    return failed
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(1 if _run_local() else 0)


### PR DESCRIPTION
Closes #273

AWS Lambda API returning volunteer applications awaiting steward review.

**Files** (`data-analytics/lambda_functions/`)
- `steward_volunteer_review_api.py` — handler
- `test_steward_volunteer_review_api.py` — 10 unit tests (pytest + plain python)
- `README_steward_volunteer_review_api.md` — notes

**Table mapping:** no table literally named `volunteers` in schema. Review queue backed by `volunteer_applications` (`application_status` enum has `IN_REVIEW`). Filter `application_status = 'IN_REVIEW'`, join `users` on `user_id`.

**Behavior:** returns `user_id`, `updated_time` (ISO-8601 UTC), `volunteer_review: "Review"`; sorted `last_updated_at DESC` across Virginia+Ireland; pagination; empty→200+`[]`; DB error→safe 500; parameterized SQL; SSM paths from env vars (nothing hardcoded).

**Tested locally**, not deployed. 10/10 tests pass.