### PR TITLE
Add Steward Dashboard volunteer review Lambda API (#273)

### DIFF
--- a/data-analytics/lambda_functions/steward_volunteer_review_api.py
+++ b/data-analytics/lambda_functions/steward_volunteer_review_api.py
@@ -1,0 +1,239 @@
+"""
+Steward Dashboard - Review Volunteers AWS Lambda API (issue #273)
+
+Retrieves paginated volunteer review requests for the Steward Dashboard by
+joining the `users` and `volunteer_applications` tables. Each row surfaces
+the reviewer-facing fields only: user id, when the application was last
+updated, and the current review action (application status), sorted by the
+most recently updated request first.
+
+Request payload (event body or plain dict when invoked directly):
+    {
+        "page": 1,          # optional, defaults to 1
+        "page_size": 10     # optional, defaults to 10, capped at 100
+    }
+
+Response body:
+    {
+        "data": [
+            {
+                "user_id": "SID-00-000-654-114",
+                "last_updated_at": "2026-02-22T04:23:08",
+                "review_action": "UNDER_REVIEW"
+            },
+            ...
+        ],
+        "pagination": {
+            "page": 1,
+            "page_size": 10,
+            "total_records": 42,
+            "total_pages": 5
+        }
+    }
+"""
+import json
+import math
+import os
+
+import boto3
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+SCHEMA_NAME = os.environ.get("DB_SCHEMA", "virginia_dev_saayam_rdbms")
+DB_SSM_PARAM = os.environ.get("DB_SSM_PARAM", "/dev/saayam/db/Virginia/Analytics/user")
+
+DEFAULT_PAGE = 1
+DEFAULT_PAGE_SIZE = 10
+MAX_PAGE_SIZE = 100
+
+
+def parse_event_body(event):
+    """
+    Normalizes the incoming Lambda event so the handler reads parameters
+    the same way whether it was invoked through API Gateway (JSON-encoded
+    string body) or invoked directly with a plain dict (e.g. from tests).
+    """
+    if not event:
+        return {}
+
+    body = event.get("body")
+
+    if body is None:
+        return event
+
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+
+    if isinstance(body, dict):
+        return body
+
+    return {}
+
+
+def get_pagination_params(request_body):
+    """
+    Reads and sanitizes the page / page_size parameters. Falls back to
+    sane defaults and clamps out-of-range values instead of raising, so a
+    bad client value degrades gracefully rather than failing the request.
+    """
+    try:
+        page = int(request_body.get("page", DEFAULT_PAGE))
+    except (TypeError, ValueError):
+        page = DEFAULT_PAGE
+
+    try:
+        page_size = int(request_body.get("page_size", DEFAULT_PAGE_SIZE))
+    except (TypeError, ValueError):
+        page_size = DEFAULT_PAGE_SIZE
+
+    if page < 1:
+        page = DEFAULT_PAGE
+
+    if page_size < 1:
+        page_size = DEFAULT_PAGE_SIZE
+    elif page_size > MAX_PAGE_SIZE:
+        page_size = MAX_PAGE_SIZE
+
+    return page, page_size
+
+
+def get_db_connection():
+    """
+    Builds a Postgres connection using credentials pulled from AWS
+    Parameter Store at invocation time. No credentials are hardcoded;
+    the parameter name itself can be overridden via the DB_SSM_PARAM
+    environment variable if a deployment needs a different path.
+    """
+    ssm = boto3.client("ssm", region_name="us-east-1")
+
+    response = ssm.get_parameter(
+        Name=DB_SSM_PARAM,
+        WithDecryption=True
+    )
+
+    creds = json.loads(response["Parameter"]["Value"])
+    return psycopg2.connect(
+        host=creds["HOST"],
+        database=creds["DATABASE NAME"],
+        user=creds["USERNAME"],
+        password=creds["PASSWORD"],
+        port=creds["PORT"],
+        sslmode="require"
+    )
+
+
+def get_total_review_count(cursor):
+    """
+    Returns the total number of volunteer review requests (users that
+    have a volunteer application on file), used to compute pagination
+    metadata (total_records / total_pages).
+    """
+    query = f"""
+        SELECT COUNT(*) AS total
+        FROM {SCHEMA_NAME}.users u
+        JOIN {SCHEMA_NAME}.volunteer_applications va
+            ON u.user_id = va.user_id
+    """
+    cursor.execute(query)
+    row = cursor.fetchone()
+    return int(row["total"]) if row and row["total"] is not None else 0
+
+
+def get_volunteer_reviews(cursor, page, page_size):
+    """
+    Fetches one page of volunteer review requests, joining users and
+    volunteer_applications by user_id, sorted by the most recently
+    updated application first. Uses parameterized LIMIT/OFFSET so page
+    and page_size are never interpolated directly into the SQL string.
+    """
+    offset = (page - 1) * page_size
+
+    query = f"""
+        SELECT
+            u.user_id AS user_id,
+            va.last_updated_at AS last_updated_at,
+            va.application_status AS review_action
+        FROM {SCHEMA_NAME}.users u
+        JOIN {SCHEMA_NAME}.volunteer_applications va
+            ON u.user_id = va.user_id
+        ORDER BY va.last_updated_at DESC
+        LIMIT %s OFFSET %s
+    """
+    cursor.execute(query, (page_size, offset))
+    rows = cursor.fetchall()
+
+    return [
+        {
+            "user_id": row["user_id"],
+            "last_updated_at": row["last_updated_at"].isoformat() if row["last_updated_at"] else None,
+            "review_action": row["review_action"]
+        }
+        for row in rows
+    ]
+
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "Content-Type,Authorization",
+            "Access-Control-Allow-Methods": "GET,POST,OPTIONS"
+        },
+        "body": json.dumps(body, default=str)
+    }
+
+
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+
+    request_body = parse_event_body(event)
+    page, page_size = get_pagination_params(request_body)
+
+    safe_response = {
+        "data": [],
+        "pagination": {
+            "page": page,
+            "page_size": page_size,
+            "total_records": 0,
+            "total_pages": 0
+        }
+    }
+
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+
+        total_records = get_total_review_count(cursor)
+        total_pages = math.ceil(total_records / page_size) if total_records > 0 else 0
+        data = get_volunteer_reviews(cursor, page, page_size) if total_records > 0 else []
+
+        response_body = {
+            "data": data,
+            "pagination": {
+                "page": page,
+                "page_size": page_size,
+                "total_records": total_records,
+                "total_pages": total_pages
+            }
+        }
+
+        return build_response(200, response_body)
+
+    except Exception as e:
+        print("ERROR:", str(e))
+        return build_response(500, safe_response)
+
+    finally:
+        if cursor: cursor.close()
+        if conn: conn.close()
+
+
+if __name__ == "__main__":
+    test_event = {"page": 1, "page_size": 10}
+    print(json.dumps(lambda_handler(test_event, None), indent=2))

--- a/data-analytics/lambda_functions/tests/test_steward_volunteer_review_api.py
+++ b/data-analytics/lambda_functions/tests/test_steward_volunteer_review_api.py
@@ -1,0 +1,230 @@
+"""
+Unit tests for steward_volunteer_review_api.py (issue #273).
+
+The users / volunteer_applications tables aren't reachable in CI, so these
+mock the DB layer (get_db_connection) with a fake cursor/connection, the
+same pattern used elsewhere in this repo for lambda + DB tests. Run with:
+
+    pytest data-analytics/lambda_functions/tests/test_steward_volunteer_review_api.py
+"""
+import datetime
+import json
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import steward_volunteer_review_api as api
+
+
+class FakeCursor:
+    """
+    Minimal stand-in for a psycopg2 RealDictCursor. Records every query
+    and its params so tests can assert the SQL stayed parameterized, and
+    serves canned results for fetchone/fetchall in call order.
+    """
+
+    def __init__(self, fetchone_results=None, fetchall_results=None):
+        self._fetchone_results = list(fetchone_results or [])
+        self._fetchall_results = list(fetchall_results or [])
+        self.queries = []
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+
+    def fetchone(self):
+        return self._fetchone_results.pop(0) if self._fetchone_results else None
+
+    def fetchall(self):
+        return self._fetchall_results.pop(0) if self._fetchall_results else []
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, cursor_factory=None):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def make_row(user_id, last_updated_at, review_action):
+    return {
+        "user_id": user_id,
+        "last_updated_at": last_updated_at,
+        "review_action": review_action,
+    }
+
+
+# --- parse_event_body -------------------------------------------------
+
+def test_parse_event_body_handles_api_gateway_json_string():
+    event = {"body": json.dumps({"page": 2, "page_size": 5})}
+    assert api.parse_event_body(event) == {"page": 2, "page_size": 5}
+
+
+def test_parse_event_body_handles_direct_invocation_dict():
+    event = {"page": 3, "page_size": 20}
+    assert api.parse_event_body(event) == event
+
+
+def test_parse_event_body_handles_malformed_json():
+    event = {"body": "{not valid json"}
+    assert api.parse_event_body(event) == {}
+
+
+def test_parse_event_body_handles_empty_event():
+    assert api.parse_event_body({}) == {}
+    assert api.parse_event_body(None) == {}
+
+
+# --- get_pagination_params --------------------------------------------
+
+def test_pagination_defaults_when_missing():
+    page, page_size = api.get_pagination_params({})
+    assert (page, page_size) == (api.DEFAULT_PAGE, api.DEFAULT_PAGE_SIZE)
+
+
+def test_pagination_uses_provided_values():
+    page, page_size = api.get_pagination_params({"page": 3, "page_size": 25})
+    assert (page, page_size) == (3, 25)
+
+
+def test_pagination_rejects_non_positive_page():
+    page, _ = api.get_pagination_params({"page": 0})
+    assert page == api.DEFAULT_PAGE
+    page, _ = api.get_pagination_params({"page": -5})
+    assert page == api.DEFAULT_PAGE
+
+
+def test_pagination_clamps_page_size_to_max():
+    _, page_size = api.get_pagination_params({"page_size": 9999})
+    assert page_size == api.MAX_PAGE_SIZE
+
+
+def test_pagination_falls_back_on_non_numeric_values():
+    page, page_size = api.get_pagination_params({"page": "abc", "page_size": "xyz"})
+    assert (page, page_size) == (api.DEFAULT_PAGE, api.DEFAULT_PAGE_SIZE)
+
+
+# --- get_total_review_count / get_volunteer_reviews --------------------
+
+def test_get_total_review_count_returns_zero_when_no_rows():
+    cursor = FakeCursor(fetchone_results=[{"total": 0}])
+    assert api.get_total_review_count(cursor) == 0
+
+
+def test_get_total_review_count_returns_int_count():
+    cursor = FakeCursor(fetchone_results=[{"total": 42}])
+    assert api.get_total_review_count(cursor) == 42
+
+
+def test_get_volunteer_reviews_uses_parameterized_limit_offset():
+    now = datetime.datetime(2026, 2, 22, 4, 23, 8)
+    cursor = FakeCursor(fetchall_results=[[make_row("SID-1", now, "UNDER_REVIEW")]])
+
+    result = api.get_volunteer_reviews(cursor, page=2, page_size=10)
+
+    query, params = cursor.queries[0]
+    assert params == (10, 10)  # page_size, offset for page 2
+    assert "LIMIT %s OFFSET %s" in query
+    assert "JOIN" in query and "volunteer_applications" in query
+    assert result == [
+        {"user_id": "SID-1", "last_updated_at": "2026-02-22T04:23:08", "review_action": "UNDER_REVIEW"}
+    ]
+
+
+def test_get_volunteer_reviews_handles_null_timestamp():
+    cursor = FakeCursor(fetchall_results=[[make_row("SID-2", None, "SUBMITTED")]])
+    result = api.get_volunteer_reviews(cursor, page=1, page_size=10)
+    assert result[0]["last_updated_at"] is None
+
+
+def test_get_volunteer_reviews_returns_empty_list_when_no_rows():
+    cursor = FakeCursor(fetchall_results=[[]])
+    result = api.get_volunteer_reviews(cursor, page=1, page_size=10)
+    assert result == []
+
+
+# --- lambda_handler (end to end with a fake DB layer) -------------------
+
+@patch.object(api, "get_db_connection")
+def test_lambda_handler_returns_paginated_data(mock_get_conn):
+    now = datetime.datetime(2026, 2, 22, 4, 23, 8)
+    cursor = FakeCursor(
+        fetchone_results=[{"total": 1}],
+        fetchall_results=[[make_row("SID-1", now, "APPROVED")]],
+    )
+    mock_get_conn.return_value = FakeConnection(cursor)
+
+    response = api.lambda_handler({"page": 1, "page_size": 10}, None)
+    body = json.loads(response["body"])
+
+    assert response["statusCode"] == 200
+    assert body["data"] == [
+        {"user_id": "SID-1", "last_updated_at": "2026-02-22T04:23:08", "review_action": "APPROVED"}
+    ]
+    assert body["pagination"] == {
+        "page": 1, "page_size": 10, "total_records": 1, "total_pages": 1
+    }
+
+
+@patch.object(api, "get_db_connection")
+def test_lambda_handler_returns_empty_array_when_no_records(mock_get_conn):
+    cursor = FakeCursor(fetchone_results=[{"total": 0}])
+    mock_get_conn.return_value = FakeConnection(cursor)
+
+    response = api.lambda_handler({}, None)
+    body = json.loads(response["body"])
+
+    assert response["statusCode"] == 200
+    assert body["data"] == []
+    assert body["pagination"]["total_records"] == 0
+    assert body["pagination"]["total_pages"] == 0
+
+
+@patch.object(api, "get_db_connection")
+def test_lambda_handler_computes_total_pages_correctly(mock_get_conn):
+    cursor = FakeCursor(
+        fetchone_results=[{"total": 25}],
+        fetchall_results=[[]],
+    )
+    mock_get_conn.return_value = FakeConnection(cursor)
+
+    response = api.lambda_handler({"page": 1, "page_size": 10}, None)
+    body = json.loads(response["body"])
+
+    assert body["pagination"]["total_pages"] == 3  # ceil(25 / 10)
+
+
+@patch.object(api, "get_db_connection")
+def test_lambda_handler_returns_500_and_safe_response_on_db_error(mock_get_conn):
+    mock_get_conn.side_effect = Exception("connection refused")
+
+    response = api.lambda_handler({"page": 1, "page_size": 10}, None)
+    body = json.loads(response["body"])
+
+    assert response["statusCode"] == 500
+    assert body["data"] == []
+    assert body["pagination"]["total_records"] == 0
+
+
+@patch.object(api, "get_db_connection")
+def test_lambda_handler_closes_cursor_and_connection(mock_get_conn):
+    cursor = FakeCursor(fetchone_results=[{"total": 0}])
+    conn = FakeConnection(cursor)
+    mock_get_conn.return_value = conn
+
+    closed = {"cursor": False, "conn": False}
+    cursor.close = lambda: closed.__setitem__("cursor", True)
+    conn.close = lambda: closed.__setitem__("conn", True)
+
+    api.lambda_handler({}, None)
+
+    assert closed == {"cursor": True, "conn": True}


### PR DESCRIPTION
## Summary

Adds the AWS Lambda API for the Steward Dashboard's "Review Volunteers" view (closes #273).

`steward_volunteer_review_api.py` retrieves paginated volunteer review requests by joining
`users` and `volunteer_applications` on `user_id`, returning `user_id`, `last_updated_at`,
and `review_action`, sorted by most recently updated first.

## Notes

- Parameterized SQL (`LIMIT %s OFFSET %s`), no hardcoded credentials (pulled from Parameter
  Store at invocation).
- Returns `"data": []` gracefully when there are no records.
- Follows existing conventions in `data-analytics/lambda_functions/` (`RealDictCursor`,
  `build_response`, CORS headers).

## Testing

Added `tests/test_steward_volunteer_review_api.py` — 19 unit tests with a mocked cursor,
covering pagination, empty results, error handling, and query shape. All passed