### PR TITLE
add Organization Analytics API for the Organization Dashboard #228

### DIFF
--- a/data-analytics/.gitignore
+++ b/data-analytics/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/data-analytics/docs/organization_analytics_api.md
+++ b/data-analytics/docs/organization_analytics_api.md
@@ -1,0 +1,212 @@
+# Organization Analytics API
+
+Single endpoint backing all three tabs of the Organization Dashboard (issue #228).
+
+```http
+POST /analytics/organizations
+```
+
+Handler: `data-analytics/lambda_functions/organization_analytics.py`
+Tests: `data-analytics/lambda_functions/test_organization_analytics.py`
+
+Source tables: `virginia_dev_saayam_rdbms.organizations`, `virginia_dev_saayam_rdbms.state`
+
+---
+
+## Local setup
+
+The handler connects to a **local PostgreSQL** instance through environment
+variables. AWS Parameter Store is not used anywhere in this module.
+
+| Variable | Default |
+| --- | --- |
+| `DB_HOST` | `localhost` |
+| `DB_PORT` | `5432` |
+| `DB_NAME` | `saayam` |
+| `DB_USER` | `postgres` |
+| `DB_PASSWORD` | *(empty)* |
+| `DB_SSLMODE` | `prefer` |
+| `DB_SCHEMA` | `virginia_dev_saayam_rdbms` |
+
+Create the tables and load the sample data:
+
+```bash
+createdb saayam_local
+psql -d saayam_local -f data-analytics/sql/organization_analytics_local_setup.sql
+psql -d saayam_local -c "\copy virginia_dev_saayam_rdbms.state FROM 'data-analytics/sql/state.csv' WITH (FORMAT csv, HEADER true, NULL '')"
+psql -d saayam_local -c "\copy virginia_dev_saayam_rdbms.organizations FROM 'data-analytics/sql/organizations.csv' WITH (FORMAT csv, HEADER true, NULL '')"
+```
+
+Then run the handler against the sample payloads:
+
+```bash
+DB_NAME=saayam_local DB_USER=postgres DB_PASSWORD=postgres \
+  python data-analytics/lambda_functions/organization_analytics.py
+```
+
+---
+
+## Request
+
+Same common filter structure as the Request, Volunteer, Beneficiary and KPI dashboards.
+
+```json
+{
+  "time_filter": "30D",
+  "start_date": null,
+  "end_date": null,
+  "group_by": "daily",
+  "region": "ALL",
+  "organization_type": "ALL"
+}
+```
+
+| Field | Values | Default |
+| --- | --- | --- |
+| `time_filter` | `7D`, `30D`, `1Y`, `ALL`, `CUSTOM` | `ALL` |
+| `start_date` / `end_date` | `YYYY-MM-DD`, both required when `time_filter` is `CUSTOM` | `null` |
+| `group_by` | `daily`, `weekly`, `monthly`, `yearly` | `monthly` |
+| `region` | state name or state code, or `ALL` | `ALL` |
+| `organization_type` | `for_profit`, `non_profit`, or `ALL` | `ALL` |
+
+All values are case-insensitive, and `Non-Profit` is accepted as `non_profit`.
+Date windows are applied to `organizations.created_at`. `CUSTOM` is inclusive of
+both endpoints.
+
+Both a plain payload and an API Gateway event (`{"body": "<json string>"}`) are accepted.
+
+### Validation
+
+A rejected filter returns **HTTP 400** with the full empty response shape plus an
+`error` field, and never opens a database connection:
+
+```json
+{ "error": "Invalid time_filter '90D'. Supported values: 7D, 30D, 1Y, ALL, CUSTOM." }
+```
+
+---
+
+## Response
+
+```json
+{
+  "summary": {
+    "total_organizations": 40,
+    "total_collaborators": 21,
+    "total_contributors": 19,
+    "average_org_rating": 3.2
+  },
+  "growth_trend": [
+    { "period": "2025", "total_organizations": 39, "total_collaborators": 21 },
+    { "period": "2026", "total_organizations": 40, "total_collaborators": 21 }
+  ],
+  "organizations_by_location": [
+    {
+      "state_id": "TX",
+      "state_name": "Texas",
+      "organization_count": 3,
+      "percentage": 7.5,
+      "cities": [
+        { "city_name": "East Jenniferfort", "organization_count": 1 },
+        { "city_name": "Hortonberg", "organization_count": 1 },
+        { "city_name": "Victoriaport", "organization_count": 1 }
+      ]
+    }
+  ],
+  "organizations_by_size": [
+    { "org_size": "small", "organization_count": 10 },
+    { "org_size": "medium", "organization_count": 9 },
+    { "org_size": "large", "organization_count": 21 }
+  ],
+  "collaborator_vs_contributor": [
+    { "type": "collaborator", "organization_count": 21, "percentage": 52.5 },
+    { "type": "contributor", "organization_count": 19, "percentage": 47.5 }
+  ],
+  "rating_distribution": [
+    { "rating": 1, "organization_count": 5 },
+    { "rating": 2, "organization_count": 9 },
+    { "rating": 3, "organization_count": 10 },
+    { "rating": 4, "organization_count": 4 },
+    { "rating": 5, "organization_count": 12 }
+  ],
+  "organization_type_distribution": [
+    { "period": "2025", "for_profit": 19, "non_profit": 20, "total": 39 },
+    { "period": "2026", "for_profit": 19, "non_profit": 21, "total": 40 }
+  ],
+  "filters_applied": { "...": "the normalised filters that produced this response" }
+}
+```
+
+### Which tab reads what
+
+| Tab | Section |
+| --- | --- |
+| *(header)* | `summary` |
+| 1 – Growth & Location | `growth_trend`, `organizations_by_location` |
+| 2 – Size & Contribution | `organizations_by_size`, `collaborator_vs_contributor` |
+| 3 – Ratings & Type | `rating_distribution`, `organization_type_distribution` |
+
+---
+
+## Behaviour notes
+
+**Trends are cumulative.** `growth_trend` and `organization_type_distribution`
+report running totals per period, so "Total Organizations" grows over the window
+rather than resetting each period. This keeps the two charts reconcilable: the
+last period of `organization_type_distribution.total` equals
+`growth_trend.total_organizations` and `summary.total_organizations`.
+
+**`organizations_by_location` nests cities inside states.** The state fields match
+the shape in the issue; the `cities` array is added underneath so one section can
+serve both the state and city breakdowns without a second round trip. States are
+ordered by descending count, and `percentage` is the state's share of all
+organizations in the window.
+
+**Fixed-scale widgets always return their full scale.** `organizations_by_size`
+always returns `small`/`medium`/`large` (zero-filled, with any unexpected stored
+value appended after them) and `rating_distribution` always returns ratings 1–5.
+The dashboard therefore never has to fill gaps itself.
+
+**`percentage` in `collaborator_vs_contributor`** is each type's share of the two
+combined, not of all organizations — an organization can in principle be both.
+
+**Stored values are normalised in SQL.** The sample data holds `Non-Profit` /
+`For-profit` and `Small` / `Medium` / `Large`; these are lowercased and
+hyphen-normalised inside the query, so grouping and filtering are case-insensitive.
+
+**The schema is probed before querying.** Two things the issue flags as unstable
+are detected at request time via `information_schema` and degraded rather than
+allowed to fail:
+
+- `is_contributor` may not exist yet in dev. When absent, contributor counts
+  return `0` and every other metric is unaffected.
+- The state lookup is named `states` in the issue but `state` in the sample data
+  and the existing analytics APIs. Either is used, and if neither exists the state
+  code is returned in place of the state name.
+
+**NULL handling.** Organizations with a `NULL` `org_rating` are excluded from
+`rating_distribution` and from the average; if every rating is NULL the average
+returns `0.0`. NULL cities and states are reported as `Unknown`.
+
+**One failing widget does not fail the dashboard.** Each section runs in its own
+try/except (same pattern as `kpi_api_analytics.py`); a broken query yields that
+section's empty value while the rest of the response returns normally with HTTP 200.
+Only a connection failure returns HTTP 500, and it still returns the full empty shape.
+
+**All filter values are bound parameters.** No user-supplied value is ever
+interpolated into SQL — including the `DATE_TRUNC` unit and `TO_CHAR` format,
+which are bound rather than formatted in.
+
+---
+
+## Tests
+
+```bash
+python -m unittest discover -s data-analytics/lambda_functions -p "test_organization_analytics.py"
+```
+
+62 tests, no database and no third-party runner required — they drive a mock
+cursor that records the generated SQL. Coverage: valid filters, invalid filters,
+custom ranges, empty result sets, query exceptions, connection failure, NULL
+handling, missing `is_contributor`, missing state lookup, parameterised SQL and
+an injection attempt, response structure, and the environment-driven DB config.

--- a/data-analytics/lambda_functions/organization_analytics.py
+++ b/data-analytics/lambda_functions/organization_analytics.py
@@ -1,0 +1,695 @@
+"""
+Organization Analytics API for the Organization Dashboard.
+
+Endpoint: POST /analytics/organizations
+
+Returns every widget of the three-tab Organization Dashboard from a single call:
+
+    summary                          -> the four common KPI cards
+    growth_trend                     -> Tab 1, organizations + collaborators over time
+    organizations_by_location        -> Tab 1, state (with nested city) breakdown
+    organizations_by_size            -> Tab 2, small / medium / large
+    collaborator_vs_contributor      -> Tab 2, count + percentage split
+    rating_distribution              -> Tab 3, 1..5 stars
+    organization_type_distribution   -> Tab 3, for_profit vs non_profit over time
+
+Source tables: <schema>.organizations, <schema>.states
+
+Database access is a plain local PostgreSQL connection configured through
+environment variables. AWS Parameter Store is deliberately NOT used here.
+
+    DB_HOST      (default: localhost)
+    DB_PORT      (default: 5432)
+    DB_NAME      (default: saayam)
+    DB_USER      (default: postgres)
+    DB_PASSWORD  (default: empty)
+    DB_SSLMODE   (default: prefer)
+    DB_SCHEMA    (default: virginia_dev_saayam_rdbms)
+"""
+
+import json
+import os
+import re
+from datetime import datetime
+
+try:
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+except ImportError:  # driver is not needed for the mock-cursor unit tests
+    psycopg2 = None
+    RealDictCursor = None
+
+
+DEFAULT_SCHEMA = "virginia_dev_saayam_rdbms"
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+SCHEMA_NAME = os.getenv("DB_SCHEMA", DEFAULT_SCHEMA).strip()
+if not _IDENTIFIER_PATTERN.match(SCHEMA_NAME):
+    raise ValueError(f"DB_SCHEMA is not a valid PostgreSQL identifier: {SCHEMA_NAME!r}")
+
+ORGANIZATIONS_TABLE = f"{SCHEMA_NAME}.organizations"
+# The issue names this lookup `states`, the existing analytics APIs and the sample
+# data use `state`. Whichever one the connected database has is used.
+STATE_LOOKUP_CANDIDATES = ("states", "state")
+
+# Common dashboard filters, shared with the Request / Volunteer / Beneficiary / KPI APIs.
+VALID_TIME_FILTERS = ("7D", "30D", "1Y", "ALL", "CUSTOM")
+TIME_FILTER_INTERVALS = {
+    "7D": "7 days",
+    "30D": "30 days",
+    "1Y": "1 year",
+}
+
+# group_by -> (DATE_TRUNC unit, TO_CHAR format)
+GROUP_BY_SETTINGS = {
+    "daily": ("day", "YYYY-MM-DD"),
+    "weekly": ("week", 'IYYY-"W"IW'),
+    "monthly": ("month", "YYYY-MM"),
+    "yearly": ("year", "YYYY"),
+}
+
+VALID_ORGANIZATION_TYPES = ("ALL", "for_profit", "non_profit")
+ORGANIZATION_SIZES = ("small", "medium", "large")
+RATING_SCALE = (1, 2, 3, 4, 5)
+
+DATE_FORMAT = "%Y-%m-%d"
+
+# The sample data stores these as "Non-Profit" / "For-profit" / "Small", so both
+# columns are normalised inside SQL before they are compared or grouped.
+ORG_TYPE_EXPRESSION = "REPLACE(LOWER(TRIM(o.org_type)), '-', '_')"
+ORG_SIZE_EXPRESSION = "LOWER(TRIM(o.org_size))"
+
+RESPONSE_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+}
+
+
+class FilterValidationError(ValueError):
+    """Raised when the incoming dashboard filters are not usable."""
+
+
+def get_default_response():
+    """Empty but structurally complete payload, used for errors and as the base result."""
+    return {
+        "summary": {
+            "total_organizations": 0,
+            "total_collaborators": 0,
+            "total_contributors": 0,
+            "average_org_rating": 0.0,
+        },
+        "growth_trend": [],
+        "organizations_by_location": [],
+        "organizations_by_size": [],
+        "collaborator_vs_contributor": [],
+        "rating_distribution": [],
+        "organization_type_distribution": [],
+    }
+
+
+def build_response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": RESPONSE_HEADERS,
+        "body": json.dumps(body, default=str),
+    }
+
+
+def parse_event_body(event):
+    """Accept both a raw API Gateway event and a plain dict payload."""
+    if not event:
+        return {}
+
+    body = event.get("body")
+
+    if body is None:
+        return event
+
+    if isinstance(body, str):
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            raise FilterValidationError("Request body is not valid JSON.")
+
+    if isinstance(body, dict):
+        return body
+
+    return {}
+
+
+def _parse_date(value, field_name):
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise FilterValidationError(
+            f"'{field_name}' is required when time_filter is CUSTOM."
+        )
+
+    if isinstance(value, datetime):
+        return value.strftime(DATE_FORMAT)
+
+    try:
+        return datetime.strptime(str(value).strip(), DATE_FORMAT).strftime(DATE_FORMAT)
+    except ValueError:
+        raise FilterValidationError(
+            f"'{field_name}' must be a date in YYYY-MM-DD format, got {value!r}."
+        )
+
+
+def parse_filters(request_body):
+    """Validate the common dashboard filters and return them in a normalised form."""
+    request_body = request_body or {}
+
+    time_filter = str(request_body.get("time_filter") or "ALL").strip().upper()
+    if time_filter not in VALID_TIME_FILTERS:
+        raise FilterValidationError(
+            f"Invalid time_filter {time_filter!r}. Supported values: {', '.join(VALID_TIME_FILTERS)}."
+        )
+
+    group_by = str(request_body.get("group_by") or "monthly").strip().lower()
+    if group_by not in GROUP_BY_SETTINGS:
+        raise FilterValidationError(
+            f"Invalid group_by {group_by!r}. Supported values: {', '.join(GROUP_BY_SETTINGS)}."
+        )
+
+    start_date = None
+    end_date = None
+    if time_filter == "CUSTOM":
+        start_date = _parse_date(request_body.get("start_date"), "start_date")
+        end_date = _parse_date(request_body.get("end_date"), "end_date")
+        if start_date > end_date:
+            raise FilterValidationError(
+                "'start_date' must be on or before 'end_date' for a CUSTOM range."
+            )
+
+    region = str(request_body.get("region") or "ALL").strip()
+    if not region:
+        region = "ALL"
+
+    raw_org_type = str(request_body.get("organization_type") or "ALL").strip()
+    organization_type = (
+        "ALL"
+        if raw_org_type.upper() == "ALL"
+        else raw_org_type.lower().replace("-", "_")
+    )
+    if organization_type not in VALID_ORGANIZATION_TYPES:
+        raise FilterValidationError(
+            f"Invalid organization_type {raw_org_type!r}. "
+            f"Supported values: {', '.join(VALID_ORGANIZATION_TYPES)}."
+        )
+
+    return {
+        "time_filter": time_filter,
+        "start_date": start_date,
+        "end_date": end_date,
+        "group_by": group_by,
+        "region": region,
+        "organization_type": organization_type,
+    }
+
+
+def relation_exists(cursor, table_name, column_name=None):
+    """Check information_schema for a table, or for a column inside that table."""
+    try:
+        if column_name is None:
+            cursor.execute(
+                """
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = %s AND table_name = %s
+                LIMIT 1;
+                """,
+                (SCHEMA_NAME, table_name),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = %s AND table_name = %s AND column_name = %s
+                LIMIT 1;
+                """,
+                (SCHEMA_NAME, table_name, column_name),
+            )
+        return cursor.fetchone() is not None
+    except Exception as error:
+        # Fall back to the narrower behaviour rather than failing the whole request.
+        print(f"Schema introspection failed for {table_name}.{column_name}: {error}")
+        return False
+
+
+def build_schema_context(cursor):
+    """
+    Adapt the SQL to whatever the connected database actually has.
+
+    `is_contributor` is a recent column and may be missing in dev, and the state
+    lookup table may be named `states` or `state`, so neither is allowed to break
+    the request.
+    """
+    state_table = next(
+        (name for name in STATE_LOOKUP_CANDIDATES if relation_exists(cursor, name)),
+        None,
+    )
+    has_states = state_table is not None
+    has_contributor = relation_exists(cursor, "organizations", "is_contributor")
+
+    from_clause = f"FROM {ORGANIZATIONS_TABLE} o"
+    if has_states:
+        from_clause += (
+            f" LEFT JOIN {SCHEMA_NAME}.{state_table} s ON o.state_id = s.state_id"
+        )
+
+    state_id_expression = "COALESCE(NULLIF(TRIM(o.state_id::text), ''), 'Unknown')"
+    if has_states:
+        state_name_expression = (
+            "COALESCE(NULLIF(TRIM(s.state_name), ''), "
+            "NULLIF(TRIM(o.state_id::text), ''), 'Unknown')"
+        )
+    else:
+        state_name_expression = state_id_expression
+
+    return {
+        "has_states": has_states,
+        "state_table": state_table,
+        "has_contributor": has_contributor,
+        "from_clause": from_clause,
+        "state_id_expression": state_id_expression,
+        "state_name_expression": state_name_expression,
+        # COUNT(*) FILTER (WHERE FALSE) is valid SQL and yields 0.
+        "contributor_expression": "o.is_contributor IS TRUE" if has_contributor else "FALSE",
+    }
+
+
+def build_where_clause(filters, context, extra_conditions=None):
+    """
+    Build the shared WHERE clause for every widget.
+
+    Returns (sql, params) with every user supplied value passed as a bound parameter.
+    """
+    conditions = ["o.created_at IS NOT NULL"]
+    params = []
+
+    time_filter = filters["time_filter"]
+    if time_filter == "CUSTOM":
+        conditions.append("o.created_at >= %s::date")
+        conditions.append("o.created_at < (%s::date + INTERVAL '1 day')")
+        params.append(filters["start_date"])
+        params.append(filters["end_date"])
+    elif time_filter in TIME_FILTER_INTERVALS:
+        conditions.append("o.created_at >= CURRENT_DATE - %s::interval")
+        params.append(TIME_FILTER_INTERVALS[time_filter])
+
+    region = filters["region"]
+    if region.upper() != "ALL":
+        if context["has_states"]:
+            conditions.append(
+                "(UPPER(TRIM(COALESCE(s.state_name, ''))) = UPPER(%s)"
+                " OR UPPER(TRIM(COALESCE(o.state_id::text, ''))) = UPPER(%s))"
+            )
+            params.append(region)
+            params.append(region)
+        else:
+            conditions.append("UPPER(TRIM(COALESCE(o.state_id::text, ''))) = UPPER(%s)")
+            params.append(region)
+
+    organization_type = filters["organization_type"]
+    if organization_type != "ALL":
+        conditions.append(f"{ORG_TYPE_EXPRESSION} = %s")
+        params.append(organization_type)
+
+    for condition in extra_conditions or []:
+        conditions.append(condition)
+
+    return "WHERE " + " AND ".join(conditions), params
+
+
+def _to_int(value):
+    return int(value) if value is not None else 0
+
+
+def _percentage(count, total):
+    return round(count * 100.0 / total, 1) if total else 0.0
+
+
+def fetch_summary(cursor, filters, context):
+    """The four common KPI cards."""
+    where_clause, params = build_where_clause(filters, context)
+
+    query = f"""
+        SELECT
+            COUNT(*) AS total_organizations,
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS total_collaborators,
+            COUNT(*) FILTER (WHERE {context['contributor_expression']}) AS total_contributors,
+            ROUND(AVG(o.org_rating)::numeric, 1) AS average_org_rating
+        {context['from_clause']}
+        {where_clause};
+    """
+
+    cursor.execute(query, params)
+    row = cursor.fetchone() or {}
+
+    average_rating = row.get("average_org_rating")
+    return {
+        "total_organizations": _to_int(row.get("total_organizations")),
+        "total_collaborators": _to_int(row.get("total_collaborators")),
+        "total_contributors": _to_int(row.get("total_contributors")),
+        "average_org_rating": float(average_rating) if average_rating is not None else 0.0,
+    }
+
+
+def fetch_growth_trend(cursor, filters, context):
+    """Running totals of organizations and collaborators, grouped by the selected period."""
+    trunc_unit, date_format = GROUP_BY_SETTINGS[filters["group_by"]]
+    where_clause, where_params = build_where_clause(filters, context)
+
+    query = f"""
+        SELECT
+            period,
+            SUM(new_organizations) OVER (ORDER BY period) AS total_organizations,
+            SUM(new_collaborators) OVER (ORDER BY period) AS total_collaborators
+        FROM (
+            SELECT
+                TO_CHAR(DATE_TRUNC(%s, o.created_at), %s) AS period,
+                COUNT(*) AS new_organizations,
+                COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS new_collaborators
+            {context['from_clause']}
+            {where_clause}
+            GROUP BY 1
+        ) grouped
+        ORDER BY period ASC;
+    """
+
+    cursor.execute(query, [trunc_unit, date_format] + where_params)
+
+    return [
+        {
+            "period": row["period"],
+            "total_organizations": _to_int(row["total_organizations"]),
+            "total_collaborators": _to_int(row["total_collaborators"]),
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def fetch_organizations_by_location(cursor, filters, context):
+    """
+    State level counts with the matching city breakdown nested underneath.
+
+    Percentages are relative to the total number of organizations in the window.
+    """
+    where_clause, params = build_where_clause(filters, context)
+
+    query = f"""
+        SELECT
+            {context['state_id_expression']} AS state_id,
+            {context['state_name_expression']} AS state_name,
+            COALESCE(NULLIF(TRIM(o.city_name), ''), 'Unknown') AS city_name,
+            COUNT(*) AS organization_count
+        {context['from_clause']}
+        {where_clause}
+        GROUP BY 1, 2, 3
+        ORDER BY 1, 3;
+    """
+
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+
+    states = {}
+    total = 0
+    for row in rows:
+        count = _to_int(row["organization_count"])
+        total += count
+
+        state = states.setdefault(
+            row["state_id"],
+            {
+                "state_id": row["state_id"],
+                "state_name": row["state_name"],
+                "organization_count": 0,
+                "percentage": 0.0,
+                "cities": [],
+            },
+        )
+        state["organization_count"] += count
+        state["cities"].append(
+            {"city_name": row["city_name"], "organization_count": count}
+        )
+
+    location = sorted(
+        states.values(),
+        key=lambda state: (-state["organization_count"], state["state_id"]),
+    )
+    for state in location:
+        state["percentage"] = _percentage(state["organization_count"], total)
+        state["cities"].sort(
+            key=lambda city: (-city["organization_count"], city["city_name"])
+        )
+
+    return location
+
+
+def fetch_organizations_by_size(cursor, filters, context):
+    """Small / medium / large distribution, always returning all three buckets."""
+    where_clause, params = build_where_clause(filters, context)
+
+    query = f"""
+        SELECT
+            COALESCE(NULLIF({ORG_SIZE_EXPRESSION}, ''), 'unknown') AS org_size,
+            COUNT(*) AS organization_count
+        {context['from_clause']}
+        {where_clause}
+        GROUP BY 1;
+    """
+
+    cursor.execute(query, params)
+    counts = {row["org_size"]: _to_int(row["organization_count"]) for row in cursor.fetchall()}
+
+    distribution = [
+        {"org_size": size, "organization_count": counts.pop(size, 0)}
+        for size in ORGANIZATION_SIZES
+    ]
+    # Anything the database holds outside the three supported values is still reported.
+    distribution.extend(
+        {"org_size": size, "organization_count": counts[size]}
+        for size in sorted(counts)
+    )
+    return distribution
+
+
+def fetch_collaborator_vs_contributor(cursor, filters, context):
+    """Collaborator and contributor counts with their share of the two combined."""
+    where_clause, params = build_where_clause(filters, context)
+
+    query = f"""
+        SELECT
+            COUNT(*) FILTER (WHERE o.is_collaborator IS TRUE) AS collaborator_count,
+            COUNT(*) FILTER (WHERE {context['contributor_expression']}) AS contributor_count
+        {context['from_clause']}
+        {where_clause};
+    """
+
+    cursor.execute(query, params)
+    row = cursor.fetchone() or {}
+
+    collaborators = _to_int(row.get("collaborator_count"))
+    contributors = _to_int(row.get("contributor_count"))
+    total = collaborators + contributors
+
+    return [
+        {
+            "type": "collaborator",
+            "organization_count": collaborators,
+            "percentage": _percentage(collaborators, total),
+        },
+        {
+            "type": "contributor",
+            "organization_count": contributors,
+            "percentage": _percentage(contributors, total),
+        },
+    ]
+
+
+def fetch_rating_distribution(cursor, filters, context):
+    """1..5 star distribution. Organizations with a NULL rating are skipped, not failed on."""
+    where_clause, params = build_where_clause(
+        filters,
+        context,
+        extra_conditions=["o.org_rating IS NOT NULL", "o.org_rating BETWEEN 1 AND 5"],
+    )
+
+    query = f"""
+        SELECT
+            o.org_rating::int AS rating,
+            COUNT(*) AS organization_count
+        {context['from_clause']}
+        {where_clause}
+        GROUP BY 1
+        ORDER BY 1;
+    """
+
+    cursor.execute(query, params)
+    counts = {_to_int(row["rating"]): _to_int(row["organization_count"]) for row in cursor.fetchall()}
+
+    return [
+        {"rating": rating, "organization_count": counts.get(rating, 0)}
+        for rating in RATING_SCALE
+    ]
+
+
+def fetch_organization_type_distribution(cursor, filters, context):
+    """For-profit vs non-profit running totals per period, for the stacked bar chart."""
+    trunc_unit, date_format = GROUP_BY_SETTINGS[filters["group_by"]]
+    where_clause, where_params = build_where_clause(filters, context)
+
+    query = f"""
+        SELECT
+            period,
+            SUM(new_for_profit) OVER (ORDER BY period) AS for_profit,
+            SUM(new_non_profit) OVER (ORDER BY period) AS non_profit
+        FROM (
+            SELECT
+                TO_CHAR(DATE_TRUNC(%s, o.created_at), %s) AS period,
+                COUNT(*) FILTER (WHERE {ORG_TYPE_EXPRESSION} = 'for_profit') AS new_for_profit,
+                COUNT(*) FILTER (WHERE {ORG_TYPE_EXPRESSION} = 'non_profit') AS new_non_profit
+            {context['from_clause']}
+            {where_clause}
+            GROUP BY 1
+        ) grouped
+        ORDER BY period ASC;
+    """
+
+    cursor.execute(query, [trunc_unit, date_format] + where_params)
+
+    distribution = []
+    for row in cursor.fetchall():
+        for_profit = _to_int(row["for_profit"])
+        non_profit = _to_int(row["non_profit"])
+        distribution.append(
+            {
+                "period": row["period"],
+                "for_profit": for_profit,
+                "non_profit": non_profit,
+                "total": for_profit + non_profit,
+            }
+        )
+    return distribution
+
+
+# section key -> (fetch function, value used when that single query fails)
+DASHBOARD_SECTIONS = (
+    ("summary", fetch_summary, None),
+    ("growth_trend", fetch_growth_trend, []),
+    ("organizations_by_location", fetch_organizations_by_location, []),
+    ("organizations_by_size", fetch_organizations_by_size, []),
+    ("collaborator_vs_contributor", fetch_collaborator_vs_contributor, []),
+    ("rating_distribution", fetch_rating_distribution, []),
+    ("organization_type_distribution", fetch_organization_type_distribution, []),
+)
+
+
+def get_db_config():
+    """Local PostgreSQL connection settings. AWS Parameter Store is not used."""
+    return {
+        "host": os.getenv("DB_HOST", "localhost"),
+        "port": int(os.getenv("DB_PORT", "5432")),
+        "dbname": os.getenv("DB_NAME", "saayam"),
+        "user": os.getenv("DB_USER", "postgres"),
+        "password": os.getenv("DB_PASSWORD", ""),
+        "sslmode": os.getenv("DB_SSLMODE", "prefer"),
+    }
+
+
+def get_db_connection():
+    if psycopg2 is None:
+        raise RuntimeError("psycopg2 is not installed; cannot open a database connection.")
+    return psycopg2.connect(**get_db_config())
+
+
+def lambda_handler(event, context):
+    conn = None
+    cursor = None
+    response_body = get_default_response()
+
+    try:
+        filters = parse_filters(parse_event_body(event))
+    except FilterValidationError as error:
+        print(f"Invalid dashboard filters: {error}")
+        response_body["error"] = str(error)
+        return build_response(400, response_body)
+
+    response_body["filters_applied"] = filters
+
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        schema_context = build_schema_context(cursor)
+
+        for section, fetch, empty_value in DASHBOARD_SECTIONS:
+            try:
+                response_body[section] = fetch(cursor, filters, schema_context)
+            except Exception as error:
+                # One failing widget must not take the whole dashboard down.
+                print(f"Query for '{section}' failed: {error}")
+                if empty_value is not None:
+                    response_body[section] = empty_value
+
+        return build_response(200, response_body)
+
+    except Exception as error:
+        print(f"DB connection failed: {error}")
+        return build_response(500, response_body)
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+
+if __name__ == "__main__":
+    sample_payloads = {
+        "Standard test (30D, daily)": {
+            "time_filter": "30D",
+            "start_date": None,
+            "end_date": None,
+            "group_by": "daily",
+            "region": "ALL",
+            "organization_type": "ALL",
+        },
+        "Last 12 months (1Y, monthly)": {
+            "time_filter": "1Y",
+            "start_date": None,
+            "end_date": None,
+            "group_by": "monthly",
+            "region": "ALL",
+            "organization_type": "ALL",
+        },
+        "Filter by region": {
+            "time_filter": "1Y",
+            "start_date": None,
+            "end_date": None,
+            "group_by": "monthly",
+            "region": "California",
+            "organization_type": "ALL",
+        },
+        "Filter by organization type": {
+            "time_filter": "1Y",
+            "start_date": None,
+            "end_date": None,
+            "group_by": "monthly",
+            "region": "ALL",
+            "organization_type": "non_profit",
+        },
+        "Custom date range": {
+            "time_filter": "CUSTOM",
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "group_by": "monthly",
+            "region": "ALL",
+            "organization_type": "ALL",
+        },
+    }
+
+    for name, payload in sample_payloads.items():
+        print(f"\n===== {name} =====")
+        print(json.dumps(lambda_handler(payload, None), indent=2))

--- a/data-analytics/lambda_functions/test_organization_analytics.py
+++ b/data-analytics/lambda_functions/test_organization_analytics.py
@@ -1,0 +1,856 @@
+"""
+Unit tests for the Organization Analytics API.
+
+These run entirely against a mock cursor, so no PostgreSQL instance, no AWS
+access and no third party test runner are required:
+
+    py -m unittest data-analytics/lambda_functions/test_organization_analytics.py
+    py data-analytics/lambda_functions/test_organization_analytics.py
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import organization_analytics as oa
+
+
+# ---------------------------------------------------------------------------
+# Mock database plumbing
+# ---------------------------------------------------------------------------
+
+class QueryError(Exception):
+    """Stands in for a psycopg2 error raised while running a query."""
+
+
+def classify_query(query):
+    """Map a generated SQL statement back to the dashboard section that built it."""
+    if "information_schema.tables" in query:
+        return "table_exists"
+    if "information_schema.columns" in query:
+        return "column_exists"
+    if "new_for_profit" in query:
+        return "organization_type_distribution"
+    if "new_organizations" in query:
+        return "growth_trend"
+    if "average_org_rating" in query:
+        return "summary"
+    if "AS city_name" in query:
+        return "organizations_by_location"
+    if "AS org_size" in query:
+        return "organizations_by_size"
+    if "collaborator_count" in query:
+        return "collaborator_vs_contributor"
+    if "AS rating" in query:
+        return "rating_distribution"
+    return "unknown"
+
+
+class MockCursor:
+    """Records every statement it is given and replays canned rows back."""
+
+    def __init__(self, rows=None, state_table="states", has_contributor=True, failing_sections=()):
+        self.rows = rows or {}
+        # Name of the state lookup the fake database has, or None if it has neither.
+        self.state_table = state_table
+        self.has_contributor = has_contributor
+        self.failing_sections = set(failing_sections)
+        self.executed = []
+        self.closed = False
+        self._result = []
+
+    def execute(self, query, params=None):
+        section = classify_query(query)
+        self.executed.append((section, query, list(params or [])))
+
+        if section in self.failing_sections:
+            raise QueryError(f"simulated failure in {section}")
+
+        if section == "table_exists":
+            probed_table = params[1] if params and len(params) > 1 else None
+            self._result = [{"?column?": 1}] if probed_table == self.state_table else []
+        elif section == "column_exists":
+            self._result = [{"?column?": 1}] if self.has_contributor else []
+        else:
+            self._result = self.rows.get(section, [])
+
+    def fetchall(self):
+        return self._result
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def close(self):
+        self.closed = True
+
+    # helpers used by the assertions
+    def query_for(self, section):
+        for recorded_section, query, _params in self.executed:
+            if recorded_section == section:
+                return query
+        raise AssertionError(f"no query was executed for section {section!r}")
+
+    def params_for(self, section):
+        for recorded_section, _query, params in self.executed:
+            if recorded_section == section:
+                return params
+        raise AssertionError(f"no query was executed for section {section!r}")
+
+    def sections(self):
+        return [section for section, _query, _params in self.executed]
+
+
+class MockConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self, *args, **kwargs):
+        return self._cursor
+
+    def close(self):
+        self.closed = True
+
+
+DEFAULT_ROWS = {
+    "summary": [
+        {
+            "total_organizations": 126,
+            "total_collaborators": 42,
+            "total_contributors": 84,
+            "average_org_rating": 4.2,
+        }
+    ],
+    "growth_trend": [
+        {"period": "2026-01", "total_organizations": 100, "total_collaborators": 34},
+        {"period": "2026-02", "total_organizations": 108, "total_collaborators": 36},
+    ],
+    "organizations_by_location": [
+        {"state_id": "CA", "state_name": "California", "city_name": "San Jose", "organization_count": 20},
+        {"state_id": "CA", "state_name": "California", "city_name": "Fresno", "organization_count": 12},
+        {"state_id": "TX", "state_name": "Texas", "city_name": "Austin", "organization_count": 24},
+    ],
+    "organizations_by_size": [
+        {"org_size": "small", "organization_count": 50},
+        {"org_size": "medium", "organization_count": 45},
+        {"org_size": "large", "organization_count": 31},
+    ],
+    "collaborator_vs_contributor": [{"collaborator_count": 42, "contributor_count": 84}],
+    "rating_distribution": [
+        {"rating": 1, "organization_count": 1},
+        {"rating": 3, "organization_count": 12},
+        {"rating": 4, "organization_count": 46},
+        {"rating": 5, "organization_count": 64},
+    ],
+    "organization_type_distribution": [
+        {"period": "2026-01", "for_profit": 41, "non_profit": 68},
+        {"period": "2026-02", "for_profit": 43, "non_profit": 68},
+    ],
+}
+
+BASE_PAYLOAD = {
+    "time_filter": "30D",
+    "start_date": None,
+    "end_date": None,
+    "group_by": "daily",
+    "region": "ALL",
+    "organization_type": "ALL",
+}
+
+
+def run_handler(payload, cursor):
+    """Invoke lambda_handler with the database swapped out for the mock cursor."""
+    connection = MockConnection(cursor)
+    with mock.patch.object(oa, "get_db_connection", return_value=connection):
+        response = oa.lambda_handler(payload, None)
+    return response, json.loads(response["body"]), connection
+
+
+def context_for(cursor):
+    return oa.build_schema_context(cursor)
+
+
+DEFAULT_CONTEXT = {
+    "has_states": True,
+    "state_table": "states",
+    "has_contributor": True,
+    "from_clause": (
+        f"FROM {oa.ORGANIZATIONS_TABLE} o "
+        f"LEFT JOIN {oa.SCHEMA_NAME}.states s ON o.state_id = s.state_id"
+    ),
+    "state_id_expression": "COALESCE(NULLIF(TRIM(o.state_id::text), ''), 'Unknown')",
+    "state_name_expression": "COALESCE(NULLIF(TRIM(s.state_name), ''), NULLIF(TRIM(o.state_id::text), ''), 'Unknown')",
+    "contributor_expression": "o.is_contributor IS TRUE",
+}
+
+
+# ---------------------------------------------------------------------------
+# Filter validation
+# ---------------------------------------------------------------------------
+
+class TestFilterValidation(unittest.TestCase):
+
+    def test_defaults_are_applied_for_an_empty_payload(self):
+        filters = oa.parse_filters({})
+        self.assertEqual(filters["time_filter"], "ALL")
+        self.assertEqual(filters["group_by"], "monthly")
+        self.assertEqual(filters["region"], "ALL")
+        self.assertEqual(filters["organization_type"], "ALL")
+        self.assertIsNone(filters["start_date"])
+        self.assertIsNone(filters["end_date"])
+
+    def test_all_supported_time_filters_are_accepted(self):
+        for time_filter in ("7D", "30D", "1Y", "ALL"):
+            with self.subTest(time_filter=time_filter):
+                self.assertEqual(
+                    oa.parse_filters({"time_filter": time_filter})["time_filter"],
+                    time_filter,
+                )
+
+    def test_all_supported_group_by_values_are_accepted(self):
+        for group_by in ("daily", "weekly", "monthly", "yearly"):
+            with self.subTest(group_by=group_by):
+                self.assertEqual(
+                    oa.parse_filters({"group_by": group_by})["group_by"], group_by
+                )
+
+    def test_filter_values_are_case_insensitive(self):
+        filters = oa.parse_filters(
+            {
+                "time_filter": "custom",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "group_by": "MONTHLY",
+                "organization_type": "Non-Profit",
+            }
+        )
+        self.assertEqual(filters["time_filter"], "CUSTOM")
+        self.assertEqual(filters["group_by"], "monthly")
+        self.assertEqual(filters["organization_type"], "non_profit")
+
+    def test_invalid_time_filter_is_rejected(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters({"time_filter": "90D"})
+
+    def test_invalid_group_by_is_rejected(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters({"group_by": "hourly"})
+
+    def test_invalid_organization_type_is_rejected(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters({"organization_type": "charity"})
+
+    def test_custom_requires_both_dates(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters({"time_filter": "CUSTOM", "start_date": "2026-01-01"})
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters({"time_filter": "CUSTOM", "end_date": "2026-06-30"})
+
+    def test_custom_rejects_a_malformed_date(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters(
+                {"time_filter": "CUSTOM", "start_date": "01-01-2026", "end_date": "2026-06-30"}
+            )
+
+    def test_custom_rejects_an_inverted_range(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_filters(
+                {"time_filter": "CUSTOM", "start_date": "2026-06-30", "end_date": "2026-01-01"}
+            )
+
+    def test_custom_accepts_a_valid_range(self):
+        filters = oa.parse_filters(
+            {"time_filter": "CUSTOM", "start_date": "2026-01-01", "end_date": "2026-06-30"}
+        )
+        self.assertEqual(filters["start_date"], "2026-01-01")
+        self.assertEqual(filters["end_date"], "2026-06-30")
+
+
+class TestEventParsing(unittest.TestCase):
+
+    def test_plain_dict_payload_is_returned_as_is(self):
+        self.assertEqual(oa.parse_event_body(BASE_PAYLOAD), BASE_PAYLOAD)
+
+    def test_api_gateway_string_body_is_decoded(self):
+        event = {"body": json.dumps(BASE_PAYLOAD)}
+        self.assertEqual(oa.parse_event_body(event), BASE_PAYLOAD)
+
+    def test_api_gateway_dict_body_is_decoded(self):
+        self.assertEqual(oa.parse_event_body({"body": BASE_PAYLOAD}), BASE_PAYLOAD)
+
+    def test_empty_event_yields_empty_filters(self):
+        self.assertEqual(oa.parse_event_body({}), {})
+        self.assertEqual(oa.parse_event_body(None), {})
+
+    def test_malformed_json_body_is_rejected(self):
+        with self.assertRaises(oa.FilterValidationError):
+            oa.parse_event_body({"body": "{not json"})
+
+
+# ---------------------------------------------------------------------------
+# WHERE clause construction / parameterised SQL
+# ---------------------------------------------------------------------------
+
+class TestWhereClause(unittest.TestCase):
+
+    def build(self, payload, context=None):
+        return oa.build_where_clause(
+            oa.parse_filters(payload), context or DEFAULT_CONTEXT
+        )
+
+    def test_all_time_filter_adds_no_date_condition(self):
+        sql, params = self.build({"time_filter": "ALL"})
+        self.assertNotIn("INTERVAL", sql)
+        self.assertEqual(params, [])
+
+    def test_relative_time_filters_bind_the_interval(self):
+        for time_filter, interval in (("7D", "7 days"), ("30D", "30 days"), ("1Y", "1 year")):
+            with self.subTest(time_filter=time_filter):
+                sql, params = self.build({"time_filter": time_filter})
+                self.assertIn("CURRENT_DATE - %s::interval", sql)
+                self.assertEqual(params, [interval])
+
+    def test_custom_range_binds_both_dates(self):
+        sql, params = self.build(
+            {"time_filter": "CUSTOM", "start_date": "2026-01-01", "end_date": "2026-06-30"}
+        )
+        self.assertIn("o.created_at >= %s::date", sql)
+        self.assertEqual(params, ["2026-01-01", "2026-06-30"])
+
+    def test_region_filter_is_bound_not_interpolated(self):
+        sql, params = self.build({"region": "California"})
+        self.assertNotIn("California", sql)
+        self.assertEqual(params, ["California", "California"])
+
+    def test_region_filter_falls_back_to_state_id_without_the_states_table(self):
+        context = dict(DEFAULT_CONTEXT, has_states=False)
+        sql, params = self.build({"region": "CA"}, context)
+        self.assertNotIn("s.state_name", sql)
+        self.assertEqual(params, ["CA"])
+
+    def test_organization_type_filter_is_bound_not_interpolated(self):
+        sql, params = self.build({"organization_type": "non_profit"})
+        self.assertNotIn("'non_profit'", sql)
+        self.assertEqual(params, ["non_profit"])
+
+    def test_all_region_and_type_add_no_conditions(self):
+        sql, params = self.build({"region": "ALL", "organization_type": "ALL"})
+        self.assertEqual(sql, "WHERE o.created_at IS NOT NULL")
+        self.assertEqual(params, [])
+
+    def test_filters_combine_in_a_single_clause(self):
+        sql, params = self.build(
+            {
+                "time_filter": "CUSTOM",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "region": "Texas",
+                "organization_type": "for_profit",
+            }
+        )
+        self.assertEqual(sql.count("WHERE o.created_at IS NOT NULL"), 1)
+        self.assertEqual(
+            params, ["2026-01-01", "2026-06-30", "Texas", "Texas", "for_profit"]
+        )
+
+    def test_extra_conditions_are_appended(self):
+        sql, _params = oa.build_where_clause(
+            oa.parse_filters({}), DEFAULT_CONTEXT, extra_conditions=["o.org_rating IS NOT NULL"]
+        )
+        self.assertIn("AND o.org_rating IS NOT NULL", sql)
+
+
+# ---------------------------------------------------------------------------
+# Schema adaptation
+# ---------------------------------------------------------------------------
+
+class TestSchemaContext(unittest.TestCase):
+
+    def test_full_schema_joins_states_and_uses_is_contributor(self):
+        context = context_for(MockCursor())
+        self.assertTrue(context["has_states"])
+        self.assertTrue(context["has_contributor"])
+        self.assertIn("LEFT JOIN", context["from_clause"])
+        self.assertEqual(context["contributor_expression"], "o.is_contributor IS TRUE")
+
+    def test_plural_states_lookup_is_preferred(self):
+        context = context_for(MockCursor(state_table="states"))
+        self.assertEqual(context["state_table"], "states")
+        self.assertIn(f"{oa.SCHEMA_NAME}.states s", context["from_clause"])
+
+    def test_singular_state_lookup_is_used_when_states_is_absent(self):
+        context = context_for(MockCursor(state_table="state"))
+        self.assertTrue(context["has_states"])
+        self.assertEqual(context["state_table"], "state")
+        self.assertIn(f"{oa.SCHEMA_NAME}.state s", context["from_clause"])
+        self.assertNotIn(f"{oa.SCHEMA_NAME}.states s", context["from_clause"])
+
+    def test_missing_is_contributor_column_degrades_to_zero(self):
+        context = context_for(MockCursor(has_contributor=False))
+        self.assertFalse(context["has_contributor"])
+        self.assertEqual(context["contributor_expression"], "FALSE")
+
+    def test_missing_states_table_drops_the_join(self):
+        context = context_for(MockCursor(state_table=None))
+        self.assertFalse(context["has_states"])
+        self.assertIsNone(context["state_table"])
+        self.assertNotIn("LEFT JOIN", context["from_clause"])
+        self.assertEqual(
+            context["state_name_expression"], context["state_id_expression"]
+        )
+
+    def test_introspection_failure_degrades_safely(self):
+        context = context_for(
+            MockCursor(failing_sections=("table_exists", "column_exists"))
+        )
+        self.assertFalse(context["has_states"])
+        self.assertFalse(context["has_contributor"])
+
+
+# ---------------------------------------------------------------------------
+# Individual widget queries
+# ---------------------------------------------------------------------------
+
+class TestWidgetQueries(unittest.TestCase):
+
+    def setUp(self):
+        self.cursor = MockCursor(rows=DEFAULT_ROWS)
+        self.filters = oa.parse_filters(BASE_PAYLOAD)
+        self.context = DEFAULT_CONTEXT
+
+    def test_summary_returns_the_four_kpi_cards(self):
+        summary = oa.fetch_summary(self.cursor, self.filters, self.context)
+        self.assertEqual(
+            summary,
+            {
+                "total_organizations": 126,
+                "total_collaborators": 42,
+                "total_contributors": 84,
+                "average_org_rating": 4.2,
+            },
+        )
+
+    def test_summary_handles_a_null_average_rating(self):
+        cursor = MockCursor(
+            rows={
+                "summary": [
+                    {
+                        "total_organizations": 3,
+                        "total_collaborators": 0,
+                        "total_contributors": 0,
+                        "average_org_rating": None,
+                    }
+                ]
+            }
+        )
+        summary = oa.fetch_summary(cursor, self.filters, self.context)
+        self.assertEqual(summary["average_org_rating"], 0.0)
+        self.assertEqual(summary["total_organizations"], 3)
+
+    def test_growth_trend_returns_organizations_and_collaborators(self):
+        trend = oa.fetch_growth_trend(self.cursor, self.filters, self.context)
+        self.assertEqual(
+            trend,
+            [
+                {"period": "2026-01", "total_organizations": 100, "total_collaborators": 34},
+                {"period": "2026-02", "total_organizations": 108, "total_collaborators": 36},
+            ],
+        )
+
+    def test_growth_trend_binds_the_grouping_period(self):
+        for group_by, expected in (
+            ("daily", ["day", "YYYY-MM-DD"]),
+            ("weekly", ["week", 'IYYY-"W"IW']),
+            ("monthly", ["month", "YYYY-MM"]),
+            ("yearly", ["year", "YYYY"]),
+        ):
+            with self.subTest(group_by=group_by):
+                cursor = MockCursor(rows=DEFAULT_ROWS)
+                filters = oa.parse_filters(dict(BASE_PAYLOAD, group_by=group_by))
+                oa.fetch_growth_trend(cursor, filters, self.context)
+                query = cursor.query_for("growth_trend")
+                self.assertIn("TO_CHAR(DATE_TRUNC(%s, o.created_at), %s)", query)
+                self.assertEqual(cursor.params_for("growth_trend")[:2], expected)
+
+    def test_location_nests_cities_and_computes_percentages(self):
+        location = oa.fetch_organizations_by_location(
+            self.cursor, self.filters, self.context
+        )
+        self.assertEqual([state["state_id"] for state in location], ["CA", "TX"])
+
+        california = location[0]
+        self.assertEqual(california["state_name"], "California")
+        self.assertEqual(california["organization_count"], 32)
+        self.assertEqual(california["percentage"], 57.1)  # 32 of 56
+        self.assertEqual(
+            california["cities"],
+            [
+                {"city_name": "San Jose", "organization_count": 20},
+                {"city_name": "Fresno", "organization_count": 12},
+            ],
+        )
+
+        texas = location[1]
+        self.assertEqual(texas["organization_count"], 24)
+        self.assertEqual(texas["percentage"], 42.9)
+
+    def test_size_always_returns_the_three_supported_buckets(self):
+        cursor = MockCursor(rows={"organizations_by_size": [{"org_size": "small", "organization_count": 7}]})
+        sizes = oa.fetch_organizations_by_size(cursor, self.filters, self.context)
+        self.assertEqual(
+            sizes,
+            [
+                {"org_size": "small", "organization_count": 7},
+                {"org_size": "medium", "organization_count": 0},
+                {"org_size": "large", "organization_count": 0},
+            ],
+        )
+
+    def test_size_reports_unexpected_values_after_the_known_ones(self):
+        cursor = MockCursor(
+            rows={
+                "organizations_by_size": [
+                    {"org_size": "large", "organization_count": 4},
+                    {"org_size": "unknown", "organization_count": 2},
+                ]
+            }
+        )
+        sizes = oa.fetch_organizations_by_size(cursor, self.filters, self.context)
+        self.assertEqual([entry["org_size"] for entry in sizes], ["small", "medium", "large", "unknown"])
+        self.assertEqual(sizes[-1]["organization_count"], 2)
+
+    def test_collaborator_vs_contributor_percentages(self):
+        split = oa.fetch_collaborator_vs_contributor(
+            self.cursor, self.filters, self.context
+        )
+        self.assertEqual(
+            split,
+            [
+                {"type": "collaborator", "organization_count": 42, "percentage": 33.3},
+                {"type": "contributor", "organization_count": 84, "percentage": 66.7},
+            ],
+        )
+
+    def test_collaborator_vs_contributor_handles_a_zero_total(self):
+        cursor = MockCursor(
+            rows={"collaborator_vs_contributor": [{"collaborator_count": 0, "contributor_count": 0}]}
+        )
+        split = oa.fetch_collaborator_vs_contributor(cursor, self.filters, self.context)
+        self.assertEqual([entry["percentage"] for entry in split], [0.0, 0.0])
+
+    def test_rating_distribution_is_zero_filled_from_one_to_five(self):
+        ratings = oa.fetch_rating_distribution(self.cursor, self.filters, self.context)
+        self.assertEqual([entry["rating"] for entry in ratings], [1, 2, 3, 4, 5])
+        self.assertEqual(
+            [entry["organization_count"] for entry in ratings], [1, 0, 12, 46, 64]
+        )
+
+    def test_rating_distribution_excludes_null_ratings_in_sql(self):
+        oa.fetch_rating_distribution(self.cursor, self.filters, self.context)
+        query = self.cursor.query_for("rating_distribution")
+        self.assertIn("o.org_rating IS NOT NULL", query)
+        self.assertIn("o.org_rating BETWEEN 1 AND 5", query)
+
+    def test_type_distribution_totals_each_period(self):
+        distribution = oa.fetch_organization_type_distribution(
+            self.cursor, self.filters, self.context
+        )
+        self.assertEqual(
+            distribution,
+            [
+                {"period": "2026-01", "for_profit": 41, "non_profit": 68, "total": 109},
+                {"period": "2026-02", "for_profit": 43, "non_profit": 68, "total": 111},
+            ],
+        )
+
+    def test_type_distribution_normalises_the_stored_org_type(self):
+        oa.fetch_organization_type_distribution(self.cursor, self.filters, self.context)
+        query = self.cursor.query_for("organization_type_distribution")
+        self.assertIn("REPLACE(LOWER(TRIM(o.org_type)), '-', '_')", query)
+
+
+class TestEmptyResultSets(unittest.TestCase):
+    """Every widget must degrade to a well formed, empty shaped payload."""
+
+    def setUp(self):
+        self.cursor = MockCursor(rows={})
+        self.filters = oa.parse_filters(BASE_PAYLOAD)
+        self.context = DEFAULT_CONTEXT
+
+    def test_summary_is_zeroed(self):
+        self.assertEqual(
+            oa.fetch_summary(self.cursor, self.filters, self.context),
+            {
+                "total_organizations": 0,
+                "total_collaborators": 0,
+                "total_contributors": 0,
+                "average_org_rating": 0.0,
+            },
+        )
+
+    def test_trend_and_location_are_empty_lists(self):
+        self.assertEqual(oa.fetch_growth_trend(self.cursor, self.filters, self.context), [])
+        self.assertEqual(
+            oa.fetch_organizations_by_location(self.cursor, self.filters, self.context), []
+        )
+        self.assertEqual(
+            oa.fetch_organization_type_distribution(self.cursor, self.filters, self.context), []
+        )
+
+    def test_fixed_scale_widgets_keep_their_buckets(self):
+        sizes = oa.fetch_organizations_by_size(self.cursor, self.filters, self.context)
+        self.assertEqual([entry["organization_count"] for entry in sizes], [0, 0, 0])
+
+        ratings = oa.fetch_rating_distribution(self.cursor, self.filters, self.context)
+        self.assertEqual(len(ratings), 5)
+        self.assertTrue(all(entry["organization_count"] == 0 for entry in ratings))
+
+        split = oa.fetch_collaborator_vs_contributor(self.cursor, self.filters, self.context)
+        self.assertEqual([entry["organization_count"] for entry in split], [0, 0])
+
+
+# ---------------------------------------------------------------------------
+# Handler behaviour
+# ---------------------------------------------------------------------------
+
+class TestLambdaHandler(unittest.TestCase):
+
+    def test_happy_path_returns_every_dashboard_section(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        response, body, connection = run_handler(BASE_PAYLOAD, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["headers"]["Content-Type"], "application/json")
+        for section in (
+            "summary",
+            "growth_trend",
+            "organizations_by_location",
+            "organizations_by_size",
+            "collaborator_vs_contributor",
+            "rating_distribution",
+            "organization_type_distribution",
+        ):
+            self.assertIn(section, body)
+
+        self.assertEqual(body["summary"]["total_organizations"], 126)
+        self.assertEqual(body["summary"]["average_org_rating"], 4.2)
+        self.assertEqual(len(body["growth_trend"]), 2)
+        self.assertEqual(len(body["rating_distribution"]), 5)
+        self.assertTrue(cursor.closed)
+        self.assertTrue(connection.closed)
+
+    def test_applied_filters_are_echoed_back(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        payload = dict(BASE_PAYLOAD, region="California", organization_type="non_profit")
+        _response, body, _connection = run_handler(payload, cursor)
+
+        self.assertEqual(body["filters_applied"]["region"], "California")
+        self.assertEqual(body["filters_applied"]["organization_type"], "non_profit")
+
+    def test_custom_range_reaches_every_widget_query(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        payload = {
+            "time_filter": "CUSTOM",
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "group_by": "monthly",
+            "region": "ALL",
+            "organization_type": "ALL",
+        }
+        response, _body, _connection = run_handler(payload, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        for section, _fetch, _empty in oa.DASHBOARD_SECTIONS:
+            with self.subTest(section=section):
+                self.assertIn("2026-01-01", cursor.params_for(section))
+                self.assertIn("2026-06-30", cursor.params_for(section))
+
+    def test_api_gateway_event_shape_is_supported(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        event = {"body": json.dumps(BASE_PAYLOAD)}
+        response, body, _connection = run_handler(event, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(body["summary"]["total_organizations"], 126)
+
+    def test_invalid_filter_returns_400_with_the_default_structure(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        response, body, _connection = run_handler(dict(BASE_PAYLOAD, time_filter="90D"), cursor)
+
+        self.assertEqual(response["statusCode"], 400)
+        self.assertIn("Invalid time_filter", body["error"])
+        self.assertEqual(body["summary"]["total_organizations"], 0)
+        self.assertEqual(body["growth_trend"], [])
+        # The database must never be touched for a rejected request.
+        self.assertEqual(cursor.executed, [])
+
+    def test_custom_without_dates_returns_400(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        response, body, _connection = run_handler(
+            dict(BASE_PAYLOAD, time_filter="CUSTOM"), cursor
+        )
+        self.assertEqual(response["statusCode"], 400)
+        self.assertIn("start_date", body["error"])
+
+    def test_a_single_failing_widget_does_not_break_the_dashboard(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS, failing_sections=("rating_distribution",))
+        response, body, _connection = run_handler(BASE_PAYLOAD, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(body["rating_distribution"], [])
+        self.assertEqual(body["summary"]["total_organizations"], 126)
+        self.assertEqual(len(body["growth_trend"]), 2)
+
+    def test_a_failing_summary_query_keeps_the_default_kpi_card_values(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS, failing_sections=("summary",))
+        response, body, _connection = run_handler(BASE_PAYLOAD, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(body["summary"], oa.get_default_response()["summary"])
+        self.assertEqual(len(body["organizations_by_location"]), 2)
+
+    def test_every_widget_failing_still_returns_200_and_the_full_shape(self):
+        all_sections = [section for section, _fetch, _empty in oa.DASHBOARD_SECTIONS]
+        cursor = MockCursor(rows=DEFAULT_ROWS, failing_sections=all_sections)
+        response, body, _connection = run_handler(BASE_PAYLOAD, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        default = oa.get_default_response()
+        for section in all_sections:
+            with self.subTest(section=section):
+                self.assertEqual(body[section], default[section])
+
+    def test_connection_failure_returns_500_with_the_default_structure(self):
+        with mock.patch.object(
+            oa, "get_db_connection", side_effect=Exception("could not connect to server")
+        ):
+            response = oa.lambda_handler(BASE_PAYLOAD, None)
+
+        body = json.loads(response["body"])
+        self.assertEqual(response["statusCode"], 500)
+        default = oa.get_default_response()
+        self.assertEqual(body["summary"], default["summary"])
+        self.assertEqual(body["growth_trend"], [])
+        self.assertEqual(body["organization_type_distribution"], [])
+
+    def test_missing_is_contributor_column_yields_zero_contributors(self):
+        rows = dict(
+            DEFAULT_ROWS,
+            summary=[
+                {
+                    "total_organizations": 126,
+                    "total_collaborators": 42,
+                    "total_contributors": 0,
+                    "average_org_rating": 4.2,
+                }
+            ],
+            collaborator_vs_contributor=[{"collaborator_count": 42, "contributor_count": 0}],
+        )
+        cursor = MockCursor(rows=rows, has_contributor=False)
+        response, body, _connection = run_handler(BASE_PAYLOAD, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(body["summary"]["total_contributors"], 0)
+        self.assertIn("COUNT(*) FILTER (WHERE FALSE)", cursor.query_for("summary"))
+
+    def test_missing_states_table_still_returns_locations(self):
+        rows = dict(
+            DEFAULT_ROWS,
+            organizations_by_location=[
+                {"state_id": "CA", "state_name": "CA", "city_name": "San Jose", "organization_count": 5}
+            ],
+        )
+        cursor = MockCursor(rows=rows, state_table=None)
+        response, body, _connection = run_handler(BASE_PAYLOAD, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(body["organizations_by_location"][0]["state_name"], "CA")
+        self.assertNotIn("LEFT JOIN", cursor.query_for("organizations_by_location"))
+
+    def test_response_body_is_json_serialisable(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        response, _body, _connection = run_handler(BASE_PAYLOAD, cursor)
+        self.assertIsInstance(response["body"], str)
+        json.loads(response["body"])
+
+
+class TestParameterisedSql(unittest.TestCase):
+    """No user supplied value may ever be inlined into a statement."""
+
+    def test_no_filter_value_appears_literally_in_any_query(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        payload = {
+            "time_filter": "CUSTOM",
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "group_by": "monthly",
+            "region": "California",
+            "organization_type": "non_profit",
+        }
+        run_handler(payload, cursor)
+
+        for section, query, params in cursor.executed:
+            with self.subTest(section=section):
+                self.assertNotIn("2026-01-01", query)
+                self.assertNotIn("2026-06-30", query)
+                self.assertNotIn("California", query)
+
+                if section in ("table_exists", "column_exists"):
+                    continue
+
+                # The type distribution query legitimately contains 'for_profit' /
+                # 'non_profit' as fixed bucket labels, so the filter value itself is
+                # checked by confirming it was bound rather than inlined.
+                self.assertIn(f"{oa.ORG_TYPE_EXPRESSION} = %s", query)
+                self.assertIn("non_profit", params)
+
+    def test_a_sql_injection_attempt_is_bound_as_a_value(self):
+        cursor = MockCursor(rows=DEFAULT_ROWS)
+        payload = dict(BASE_PAYLOAD, region="CA'; DROP TABLE organizations;--")
+        response, _body, _connection = run_handler(payload, cursor)
+
+        self.assertEqual(response["statusCode"], 200)
+        for section, query, params in cursor.executed:
+            with self.subTest(section=section):
+                self.assertNotIn("DROP TABLE", query)
+                if section not in ("table_exists", "column_exists"):
+                    self.assertIn("CA'; DROP TABLE organizations;--", params)
+
+
+class TestDatabaseConfig(unittest.TestCase):
+
+    def test_config_comes_from_environment_variables(self):
+        env = {
+            "DB_HOST": "127.0.0.1",
+            "DB_PORT": "5433",
+            "DB_NAME": "saayam_local",
+            "DB_USER": "analytics",
+            "DB_PASSWORD": "secret",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            config = oa.get_db_config()
+
+        self.assertEqual(config["host"], "127.0.0.1")
+        self.assertEqual(config["port"], 5433)
+        self.assertEqual(config["dbname"], "saayam_local")
+        self.assertEqual(config["user"], "analytics")
+        self.assertEqual(config["password"], "secret")
+
+    def test_module_does_not_reference_aws_parameter_store(self):
+        source_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "organization_analytics.py"
+        )
+        with open(source_path, "r", encoding="utf-8") as handle:
+            source = handle.read()
+
+        self.assertNotIn("boto3", source)
+        self.assertNotIn("get_parameter", source)
+        self.assertNotIn("/dev/saayam/db/", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/data-analytics/sql/organization_analytics_local_setup.sql
+++ b/data-analytics/sql/organization_analytics_local_setup.sql
@@ -1,0 +1,46 @@
+-- Local PostgreSQL setup for the Organization Analytics API (issue #228).
+--
+-- Creates the schema plus the two source tables the API reads, so the endpoint
+-- can be exercised locally without any AWS access. Load the sample data with:
+--
+--   psql -U postgres -d saayam_local -f organization_analytics_local_setup.sql
+--   \copy virginia_dev_saayam_rdbms.state FROM 'state.csv' WITH (FORMAT csv, HEADER true, NULL '')
+--   \copy virginia_dev_saayam_rdbms.organizations FROM 'organizations.csv' WITH (FORMAT csv, HEADER true, NULL '')
+
+CREATE SCHEMA IF NOT EXISTS virginia_dev_saayam_rdbms;
+
+DROP TABLE IF EXISTS virginia_dev_saayam_rdbms.organizations;
+DROP TABLE IF EXISTS virginia_dev_saayam_rdbms.state;
+
+-- Mirrors data-analytics/sql/state.csv
+CREATE TABLE virginia_dev_saayam_rdbms.state (
+    state_id          VARCHAR(10) PRIMARY KEY,
+    country_id        INTEGER,
+    state_name        VARCHAR(100),
+    state_code        VARCHAR(20),
+    last_update_date  TIMESTAMP
+);
+
+-- Mirrors data-analytics/sql/organizations.csv
+CREATE TABLE virginia_dev_saayam_rdbms.organizations (
+    org_id           VARCHAR(20) PRIMARY KEY,
+    org_name         VARCHAR(255),
+    street           VARCHAR(255),
+    city_name        VARCHAR(100),
+    state_id         VARCHAR(10),
+    zip_code         VARCHAR(20),
+    mission          TEXT,
+    web_url          VARCHAR(255),
+    phone            VARCHAR(50),
+    email            VARCHAR(255),
+    org_type         VARCHAR(50),
+    org_size         VARCHAR(50),
+    org_rating       INTEGER,
+    is_collaborator  BOOLEAN,
+    is_contributor   BOOLEAN,
+    created_at       TIMESTAMP,
+    last_updated_at  TIMESTAMP
+);
+
+CREATE INDEX idx_organizations_created_at ON virginia_dev_saayam_rdbms.organizations (created_at);
+CREATE INDEX idx_organizations_state_id ON virginia_dev_saayam_rdbms.organizations (state_id);


### PR DESCRIPTION
Adds POST /analytics/organizations, a single endpoint that returns every widget of the three-tab Organization Dashboard:

- summary: the four common KPI cards
- growth_trend: organizations + collaborators over time (Tab 1)
- organizations_by_location: state counts with nested city breakdown (Tab 1)
- organizations_by_size: small / medium / large (Tab 2)
- collaborator_vs_contributor: counts and percentages (Tab 2)
- rating_distribution: 1-5 stars (Tab 3)
- organization_type_distribution: for_profit vs non_profit over time (Tab 3)

Reuses the common dashboard filter structure (7D/30D/1Y/ALL/CUSTOM, group_by daily/weekly/monthly/yearly, region, organization_type) and the per-section try/except response pattern from kpi_api_analytics.py.

Connects to a local PostgreSQL through environment variables; AWS Parameter Store is not referenced anywhere in the module. All filter values are bound parameters, including the DATE_TRUNC unit and TO_CHAR format.

The schema is probed at request time so the two unstable pieces the issue flags degrade instead of failing: a missing is_contributor column yields zero contributors, and the state lookup resolves as either `states` or `state` (falling back to the state code when neither exists).

Adds 64 mock-cursor unit tests covering valid and invalid filters, custom date ranges, empty result sets, query and connection exceptions, NULL handling, parameterised SQL, and the response structure. Also adds a local setup script for the sample CSVs and API documentation with sample payloads.